### PR TITLE
feat: fund wallets using Faucet contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,12 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
 # dependencies
 **/node_modules
 /.pnp

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "packages/demo/contracts/lib/forge-std"]
+	path = packages/demo/contracts/lib/forge-std
+	url = https://github.com/foundry-rs/forge-std

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,19 @@
 [tools]
 node = "20.11"
 
+# Foundry dependencies
+# Foundry is a special case because it supplies multiple binaries at the same
+# GitHub release, so we need to use the aliasing trick to get mise to not error
+# The git ref here should be on the `stable` branch.
+forge = "nightly-0dd4d3153764f4706c2c9857675e42dec64155a7"
+cast = "nightly-0dd4d3153764f4706c2c9857675e42dec64155a7"
+anvil = "nightly-0dd4d3153764f4706c2c9857675e42dec64155a7"
+
+[alias]
+forge = "ubi:foundry-rs/foundry[exe=forge]"
+cast = "ubi:foundry-rs/foundry[exe=cast]"
+anvil = "ubi:foundry-rs/foundry[exe=anvil]"
+
 [hooks]
 # Enabling corepack will install `pnpm`
 postinstall = "npx corepack enable"

--- a/mprocs.yml
+++ b/mprocs.yml
@@ -1,0 +1,16 @@
+procs:
+  supersim:
+    cwd: .
+    shell: pnpm dev:supersim
+  supersim-chain-901:
+    cwd: supersim-logs
+    shell: pnpm wait-port http://:8420/ready && tail -f anvil-130.log
+  frontend:
+    cwd: packages/demo/frontend
+    shell: pnpm dev
+  backend:
+    cwd: packages/demo/backend
+    shell: pnpm dev
+  deploy-contracts:
+    cwd: packages/demo/contracts
+    shell: pnpm wait-port http://:8420/ready && pnpm deploy:fund:faucet

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
   "scripts": {
     "build": "pnpm -r build",
     "clean": "pnpm -r clean",
+    "dev": "mprocs --config mprocs.yml",
+    "dev:supersim": "pnpm supersim fork --chains unichain --logs.directory supersim-logs",
     "lint": "pnpm -r lint",
     "lint:fix": "pnpm -r lint:fix",
     "test": "pnpm -r test",
@@ -36,10 +38,13 @@
     "eslint-plugin-react-refresh": "^0.4.5",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "globals": "^15.0.0",
+    "mprocs": "^0.7.2",
     "nx": "^21.3.2",
     "prettier": "^3.0.0",
     "resolve-tspaths": "^0.8.18",
-    "tsx": "^4.0.0"
+    "supersim": "^0.1.0-alpha.58",
+    "tsx": "^4.0.0",
+    "wait-port": "^1.1.0"
   },
   "engines": {
     "node": ">=18"

--- a/packages/demo/backend/package.json
+++ b/packages/demo/backend/package.json
@@ -36,11 +36,13 @@
   "dependencies": {
     "@eth-optimism/utils-app": "^0.0.6",
     "@eth-optimism/verbs-sdk": "workspace:*",
+    "@eth-optimism/viem": "^0.4.13",
     "@hono/node-server": "^1.14.0",
     "commander": "^13.1.0",
     "dotenv": "^16.4.5",
     "envalid": "^8.1.0",
     "hono": "^4.5.0",
+    "viem": "^2.24.1",
     "zod": "^4.0.5"
   },
   "devDependencies": {

--- a/packages/demo/backend/src/abis/faucet.ts
+++ b/packages/demo/backend/src/abis/faucet.ts
@@ -1,0 +1,97 @@
+export const faucetAbi = [
+  {
+    type: 'constructor',
+    inputs: [{ name: '_admin', type: 'address', internalType: 'address' }],
+    stateMutability: 'nonpayable',
+  },
+  { type: 'receive', stateMutability: 'payable' },
+  {
+    type: 'function',
+    name: 'ADMIN',
+    inputs: [],
+    outputs: [{ name: '', type: 'address', internalType: 'address' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'dripERC20',
+    inputs: [
+      { name: '_recipient', type: 'address', internalType: 'address' },
+      { name: '_amount', type: 'uint256', internalType: 'uint256' },
+      { name: '_token', type: 'address', internalType: 'address' },
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'dripETH',
+    inputs: [
+      { name: '_recipient', type: 'address', internalType: 'address' },
+      { name: '_amount', type: 'uint256', internalType: 'uint256' },
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'updateAdmin',
+    inputs: [{ name: '_admin', type: 'address', internalType: 'address' }],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'withdraw',
+    inputs: [
+      { name: '_recipient', type: 'address', internalType: 'address payable' },
+      { name: '_amount', type: 'uint256', internalType: 'uint256' },
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'event',
+    name: 'DripERC20',
+    inputs: [
+      {
+        name: 'amount',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
+      {
+        name: 'recipient',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
+      {
+        name: 'token',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: 'event',
+    name: 'DripETH',
+    inputs: [
+      {
+        name: 'amount',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
+      {
+        name: 'recipient',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
+    ],
+    anonymous: false,
+  },
+] as const

--- a/packages/demo/backend/src/config/env.ts
+++ b/packages/demo/backend/src/config/env.ts
@@ -4,6 +4,14 @@ import { cleanEnv, port, str } from 'envalid'
 
 export const env = cleanEnv(process.env, {
   PORT: port({ default: 3000 }),
-  PRIVY_APP_ID: str(),
-  PRIVY_APP_SECRET: str(),
+  PRIVY_APP_ID: str({ devDefault: 'dummy' }),
+  PRIVY_APP_SECRET: str({ devDefault: 'dummy' }),
+  RPC_URL: str({ default: 'http://127.0.0.1:9545' }),
+  FAUCET_ADMIN_PRIVATE_KEY: str({
+    default:
+      '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
+  }),
+  FAUCET_ADDRESS: str({
+    default: '0xA8b0621be8F2feadEaFb3d2ff477daCf38bFC2a8',
+  }),
 })

--- a/packages/demo/backend/src/config/verbs.ts
+++ b/packages/demo/backend/src/config/verbs.ts
@@ -3,6 +3,7 @@ import {
   type VerbsConfig,
   type VerbsInterface,
 } from '@eth-optimism/verbs-sdk'
+import { unichain } from 'viem/chains'
 
 import { env } from './env.js'
 
@@ -18,8 +19,12 @@ export function createVerbsConfig(): VerbsConfig {
     lend: {
       type: 'morpho',
     },
-    chainId: 130, // Unichain
-    rpcUrl: 'https://mainnet.unichain.org/',
+    chains: [
+      {
+        chainId: unichain.id,
+        rpcUrl: env.RPC_URL,
+      },
+    ],
   }
 }
 

--- a/packages/demo/backend/src/router.ts
+++ b/packages/demo/backend/src/router.ts
@@ -42,6 +42,7 @@ router.get('/wallets', walletController.getAllWallets)
 router.post('/wallet/:userId', walletController.createWallet)
 router.get('/wallet/:userId', walletController.getWallet)
 router.get('/wallet/:userId/balance', walletController.getBalance)
+router.post('/wallet/:userId/fund', walletController.fundWallet)
 
 // Lend endpoints
 router.get('/lend/vaults', lendController.getVaults)

--- a/packages/demo/contracts/.gitignore
+++ b/packages/demo/contracts/.gitignore
@@ -1,0 +1,12 @@
+# Compiler files
+cache/
+out/
+
+# Ignores development broadcast logs
+broadcast/
+
+# Docs
+docs/
+
+# Dotenv file
+.env

--- a/packages/demo/contracts/.solhint.json
+++ b/packages/demo/contracts/.solhint.json
@@ -1,0 +1,6 @@
+{
+  "extends": "solhint:default",
+  "rules": {
+    "no-console": "off"
+  }
+}

--- a/packages/demo/contracts/README.md
+++ b/packages/demo/contracts/README.md
@@ -1,0 +1,94 @@
+## Contracts
+
+This project contains demo contracts that support the Verbs demo application in the `packages/demo` directory. These contracts are **not intended for production use** and are designed specifically to facilitate funding wallets used in the demo environment.
+
+The system includes a Faucet contract with deployment and funding scripts:
+
+### Faucet.sol
+The main faucet contract that allows privileged users to distribute ETH and ERC20 tokens.
+
+**Features:**
+- **Admin-controlled**: Only the admin can drip tokens and manage the contract
+- **ETH dripping**: Send ETH to recipients via `dripETH()`
+- **ERC20 dripping**: Send any ERC20 token to recipients via `dripERC20()`
+- **Fund management**: Admin can withdraw funds and update admin address
+- **Donations**: Anyone can send ETH to the contract via the `receive()` function
+
+**Key Functions:**
+- `dripETH(recipient, amount)` - Send ETH to a recipient
+- `dripERC20(recipient, amount, tokenAddress)` - Send ERC20 tokens to a recipient
+- `withdraw(recipient, amount)` - Admin withdraw ETH
+- `updateAdmin(newAdmin)` - Update the admin address
+
+### Deploy.s.sol
+Forge deployment script that deploys the Faucet contract using CREATE2 for deterministic addresses.
+
+**Features:**
+- Uses CREATE2 for consistent contract addresses across networks
+- Automatically funds the deployed faucet with 100 ETH
+- Configurable admin address via `FAUCET_ADMIN` environment variable
+- Configurable salt via `DEPLOY_SALT` environment variable
+
+**Usage:**
+```bash
+forge script script/Deploy.s.sol:Deploy --rpc-url http://localhost:9545 --broadcast --private-key <your_private_key>
+```
+
+### Fund.s.sol
+Forge script to fund the faucet with USDC tokens from a whale account.
+
+**Prerequisites:**
+1. Impersonate a whale account that has USDC:
+```bash
+cast rpc anvil_impersonateAccount 0x5752e57DcfA070e3822d69498185B706c293C792 --rpc-url http://localhost:9545
+```
+
+**Usage:**
+```bash
+forge script script/Fund.s.sol:Fund \
+  --rpc-url http://localhost:9545 \
+  --broadcast \
+  --unlocked 0x5752e57DcfA070e3822d69498185B706c293C792 \
+  --sender 0x5752e57DcfA070e3822d69498185B706c293C792
+```
+
+**Environment Variables:**
+- `USDC_ADDRESS` - USDC token contract address (default: Unichain USDC)
+- `RECIPIENT_ADDRESS` - Faucet contract address to fund
+- `AMOUNT` - Amount of USDC to transfer (default: 1000 USDC)
+
+## Quick Start Scripts
+
+For convenience, the following npm scripts are available:
+
+### `pnpm deploy:faucet`
+Deploys the Faucet contract using the default Anvil test account. This uses CREATE2 for deterministic addresses and automatically funds the contract with 100 ETH.
+
+```bash
+pnpm deploy:faucet
+```
+
+### `pnpm impersonate:whale`
+Impersonates a USDC whale account on Unichain (`0x5752e57DcfA070e3822d69498185B706c293C792`) that contains sufficient USDC balance for testing.
+
+```bash
+pnpm impersonate:whale
+```
+
+### `pnpm fund:faucet` 
+Funds the deployed faucet with USDC tokens. **This script is specifically designed for Unichain and uses a known USDC whale account.** It first impersonates the whale account, then transfers USDC to the faucet contract.
+
+```bash
+pnpm fund:faucet
+```
+
+### `pnpm deploy:fund:faucet`
+Complete setup script that deploys the faucet and funds it with USDC in one command. Perfect for setting up the entire demo environment.
+
+```bash
+pnpm deploy:fund:faucet
+```
+
+**Note:** The funding scripts are specifically configured for **USDC on Unichain** and use a whale account with a known USDC balance. Ensure you're running against a Unichain fork for the funding to work correctly.
+
+

--- a/packages/demo/contracts/foundry.toml
+++ b/packages/demo/contracts/foundry.toml
@@ -1,0 +1,6 @@
+[profile.default]
+src = "src"
+out = "out"
+libs = ["lib"]
+
+# See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/packages/demo/contracts/package.json
+++ b/packages/demo/contracts/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@eth-optimism/verbs-demo-contracts",
+  "version": "0.0.0",
+  "private": true,
+  "license": "MIT",
+  "scripts": {
+    "clean": "rm -rf build types tsconfig.tsbuildinfo",
+    "compile": "forge compile",
+    "build": "forge build",
+    "deploy:faucet": "forge script script/Deploy.s.sol --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --broadcast",
+    "impersonate:whale": "cast rpc anvil_impersonateAccount 0x5752e57DcfA070e3822d69498185B706c293C792 --rpc-url http://localhost:9545",
+    "fund:faucet": "pnpm impersonate:whale && forge script script/Fund.s.sol --rpc-url http://localhost:9545 --broadcast --unlocked 0x5752e57DcfA070e3822d69498185B706c293C792 --sender 0x5752e57DcfA070e3822d69498185B706c293C792",
+    "deploy:fund:faucet": "pnpm deploy:faucet && pnpm fund:faucet",
+    "test": "forge install && forge test",
+    "lint": "solhint {src,script,test}/**/*.sol && forge fmt --check src test scripts",
+    "lint:fix": "solhint --fix --quiet --noPrompt {src,script,test}/**/*.sol && forge fmt src test script"
+  },
+  "devDependencies": {
+    "solhint": "^4.1.1"
+  },
+  "dependencies": {
+    "solc": "^0.8.26"
+  }
+}

--- a/packages/demo/contracts/remappings.txt
+++ b/packages/demo/contracts/remappings.txt
@@ -1,0 +1,1 @@
+forge-std/=lib/forge-std/src/

--- a/packages/demo/contracts/script/Deploy.s.sol
+++ b/packages/demo/contracts/script/Deploy.s.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {Script, console} from "forge-std/Script.sol";
+import {Vm} from "forge-std/Vm.sol";
+import {Faucet} from "../src/Faucet.sol";
+import {IERC20} from "forge-std/interfaces/IERC20.sol";
+
+contract Deploy is Script {
+    /// @notice Modifier that wraps a function in broadcasting.
+    modifier broadcast() {
+        vm.startBroadcast(msg.sender);
+        _;
+        vm.stopBroadcast();
+    }
+
+    function run() public {
+        string memory rpcUrl = vm.envOr("RPC_URL", string("http://localhost:9545"));
+        console.log("Deploying to RPC: ", rpcUrl);
+        vm.createSelectFork(rpcUrl);
+        deployFaucetContract();
+    }
+
+    function deployFaucetContract() public broadcast returns (address addr_) {
+        // defaults to anvil[0] test account
+        address admin = vm.envOr("FAUCET_ADMIN", address(0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266));
+        bytes memory constructorArgs = abi.encode(admin);
+        bytes memory initCode = abi.encodePacked(type(Faucet).creationCode, constructorArgs);
+        address preComputedAddress = vm.computeCreate2Address(_implSalt(), keccak256(initCode));
+        if (preComputedAddress.code.length > 0) {
+            console.log("Faucet already deployed at %s", preComputedAddress);
+            addr_ = preComputedAddress;
+        } else {
+            addr_ = address(new Faucet{salt: _implSalt()}(admin));
+            console.log("Faucet deployed at %s", addr_);
+        }
+
+        fundContract(addr_);
+    }
+
+    function fundContract(address faucetAddress) public {
+        uint256 ethAmount = 100 ether;
+
+        (bool success,) = faucetAddress.call{value: ethAmount}("");
+        require(success, "Failed to fund faucet");
+        console.log("Funded faucet with %s ETH", ethAmount);
+    }
+
+    /// @notice The CREATE2 salt to be used when deploying a contract.
+    function _implSalt() internal view returns (bytes32) {
+        return keccak256(abi.encodePacked(vm.envOr("DEPLOY_SALT", string("ethers phoenix"))));
+    }
+}

--- a/packages/demo/contracts/script/Fund.s.sol
+++ b/packages/demo/contracts/script/Fund.s.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {Script, console} from "forge-std/Script.sol";
+import {IERC20} from "forge-std/interfaces/IERC20.sol";
+
+// before running this script, run:
+// cast rpc anvil_impersonateAccount <WHALE_ADDRESS> --rpc-url <rpc-url>
+// where <WHALE_ADDRESS> is the address of the account you want to impersonate
+// and <rpc-url> is the RPC URL of the network you want to impersonate
+// for example:
+// cast rpc anvil_impersonateAccount 0x5752e57DcfA070e3822d69498185B706c293C792 --rpc-url http://localhost:9545
+// this will allow you to transfer USDC from the whale account to the recipient account
+// you can then run this script to transfer the USDC to the recipient account
+// forge script script/Fund.s.sol:Fund \
+//   --rpc-url http://localhost:9545 \
+//   --broadcast \
+//   --unlocked 0x5752e57DcfA070e3822d69498185B706c293C792 \
+//   --sender 0x5752e57DcfA070e3822d69498185B706c293C792
+contract Fund is Script {
+    function run() public {
+        // 0x078D782b760474a361dDA0AF3839290b0EF57AD6 is the USDC address on unichain.
+        address usdc = vm.envOr("USDC_ADDRESS", address(0x078D782b760474a361dDA0AF3839290b0EF57AD6));
+        // 0xA8b0621be8F2feadEaFb3d2ff477daCf38bFC2a8 is the address of the faucet contract.
+        address recipient = vm.envOr("RECIPIENT_ADDRESS", address(0xA8b0621be8F2feadEaFb3d2ff477daCf38bFC2a8));
+        uint256 amount = vm.envOr("AMOUNT", uint256(1000e6));
+        vm.startBroadcast();
+        IERC20(usdc).transfer(recipient, amount);
+        vm.stopBroadcast();
+    }
+}

--- a/packages/demo/contracts/src/Faucet.sol
+++ b/packages/demo/contracts/src/Faucet.sol
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {IERC20} from "forge-std/interfaces/IERC20.sol";
+
+/// @title  Faucet
+/// @notice Faucet contract that drips ETH or ERC20 tokens to users.
+contract Faucet {
+    /// @notice Emitted on each drip of ETH.
+    /// @param amount     The amount of funds sent.
+    /// @param recipient  The recipient of the drip.
+    event DripETH(uint256 amount, address indexed recipient);
+
+    /// @notice Emitted on each drip of ERC20 tokens.
+    /// @param amount     The amount of funds sent.
+    /// @param recipient  The recipient of the drip.
+    /// @param token      The address of the ERC20 token.
+    event DripERC20(uint256 amount, address indexed recipient, address indexed token);
+
+    /// @notice Admin address that can configure the faucet.
+    address public ADMIN;
+
+    /// @notice Modifier that makes a function admin privileged.
+    modifier privileged() {
+        require(msg.sender == ADMIN, "Faucet: function can only be called by admin");
+        _;
+    }
+
+    /// @param _admin Admin address that can configure the faucet.
+    constructor(address _admin) {
+        ADMIN = _admin;
+    }
+
+    /// @notice Allows users to donate ETH to this contract.
+    receive() external payable {
+        // Thank you!
+    }
+
+    /// @notice updates the ADMIN address.
+    /// @param _admin New admin address.
+    function updateAdmin(address _admin) public privileged {
+        ADMIN = _admin;
+    }
+
+    /// @notice Allows the admin to withdraw funds.
+    /// @param _recipient Address to receive the funds.
+    /// @param _amount    Amount of ETH in wei to withdraw.
+    function withdraw(address payable _recipient, uint256 _amount) public privileged {
+        (bool success,) = _recipient.call{value: _amount}("");
+        require(success, "Faucet: Failed to execute ETH transfer during withdrawal");
+    }
+
+    /// @notice Drips ETH to a recipient account.
+    /// @param _recipient Address to receive the funds.
+    /// @param _amount    Amount of ETH in wei to drip.
+    function dripETH(address _recipient, uint256 _amount) public privileged {
+        // Execute transfer of ETH to the recipient account without gas limit
+        (bool success,) = _recipient.call{value: _amount}("");
+        require(success, "Faucet: Failed to execute ETH transfer during drip to recipient");
+
+        emit DripETH(_amount, _recipient);
+    }
+
+    /// @notice Drips ERC20 tokens to a recipient account.
+    /// @param _recipient Address to receive the funds.
+    /// @param _amount    Amount of ERC20 tokens to drip.
+    /// @param _token     Address of the ERC20 token.
+    function dripERC20(address _recipient, uint256 _amount, address _token) public privileged {
+        // Execute transfer of ERC20 tokens to the recipient account
+        bool success = IERC20(_token).transfer(_recipient, _amount);
+        require(success, "Faucet: Failed to execute ERC20 transfer during drip to recipient");
+
+        emit DripERC20(_amount, _recipient, _token);
+    }
+}

--- a/packages/demo/contracts/test/Faucet.t.sol
+++ b/packages/demo/contracts/test/Faucet.t.sol
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {Test, console} from "forge-std/Test.sol";
+import {Faucet} from "../src/Faucet.sol";
+import {IERC20} from "forge-std/interfaces/IERC20.sol";
+
+contract MockERC20 is IERC20 {
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+    uint256 public totalSupply;
+    string public name = "Mock Token";
+    string public symbol = "MOCK";
+    uint8 public decimals = 18;
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        balanceOf[msg.sender] -= amount;
+        balanceOf[to] += amount;
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external returns (bool) {
+        allowance[from][msg.sender] -= amount;
+        balanceOf[from] -= amount;
+        balanceOf[to] += amount;
+        return true;
+    }
+
+    function approve(address spender, uint256 amount) external returns (bool) {
+        allowance[msg.sender][spender] = amount;
+        return true;
+    }
+
+    function mint(address to, uint256 amount) external {
+        balanceOf[to] += amount;
+        totalSupply += amount;
+    }
+}
+
+contract FaucetTest is Test {
+    Faucet public faucet;
+    MockERC20 public token;
+    address public admin = address(0x1);
+    address public user = address(0x2);
+
+    function setUp() public {
+        vm.prank(admin);
+        faucet = new Faucet(admin);
+        token = new MockERC20();
+
+        // Fund the faucet with ETH and tokens
+        vm.deal(address(faucet), 10 ether);
+        token.mint(address(faucet), 1000e18);
+    }
+
+    function testConstructor() public view {
+        assertEq(faucet.ADMIN(), admin);
+    }
+
+    function testDripETH() public {
+        uint256 amount = 1 ether;
+        uint256 initialBalance = user.balance;
+
+        vm.prank(admin);
+        faucet.dripETH(user, amount);
+
+        assertEq(user.balance, initialBalance + amount);
+    }
+
+    function testDripERC20() public {
+        uint256 amount = 100e18;
+        uint256 initialBalance = token.balanceOf(user);
+
+        vm.prank(admin);
+        faucet.dripERC20(user, amount, address(token));
+
+        assertEq(token.balanceOf(user), initialBalance + amount);
+    }
+
+    function testWithdraw() public {
+        uint256 amount = 1 ether;
+        uint256 initialBalance = admin.balance;
+
+        vm.prank(admin);
+        faucet.withdraw(payable(admin), amount);
+
+        assertEq(admin.balance, initialBalance + amount);
+    }
+
+    function testUpdateAdmin() public {
+        address newAdmin = address(0x3);
+
+        vm.prank(admin);
+        faucet.updateAdmin(newAdmin);
+
+        assertEq(faucet.ADMIN(), newAdmin);
+    }
+
+    function testOnlyAdminCanDrip() public {
+        vm.prank(user);
+        vm.expectRevert("Faucet: function can only be called by admin");
+        faucet.dripETH(user, 1 ether);
+    }
+
+    function testReceiveETH() public {
+        uint256 amount = 1 ether;
+        uint256 initialBalance = address(faucet).balance;
+
+        vm.deal(user, amount);
+        vm.prank(user);
+        (bool success,) = address(faucet).call{value: amount}("");
+
+        assertTrue(success);
+        assertEq(address(faucet).balance, initialBalance + amount);
+    }
+}

--- a/packages/demo/frontend/package.json
+++ b/packages/demo/frontend/package.json
@@ -23,6 +23,7 @@
     "react-dom": "^18",
     "react-router": "7",
     "react-router-dom": "7",
+    "viem": "^2.24.1",
     "zod": "^4.0.5"
   },
   "devDependencies": {

--- a/packages/demo/frontend/src/api/verbsApi.ts
+++ b/packages/demo/frontend/src/api/verbsApi.ts
@@ -108,6 +108,12 @@ class VerbsApiClient {
       method: 'GET',
     })
   }
+
+  async fundWallet(userId: string): Promise<{ message: string }> {
+    return this.request(`/wallet/${userId}/fund`, {
+      method: 'POST',
+    })
+  }
 }
 
 export const verbsApi = new VerbsApiClient()

--- a/packages/sdk/src/lend/providers/morpho/index.test.ts
+++ b/packages/sdk/src/lend/providers/morpho/index.test.ts
@@ -81,7 +81,7 @@ describe('LendProviderMorpho', () => {
 
   describe('withdraw', () => {
     it('should throw error for unimplemented withdraw functionality', async () => {
-      const asset = '0xBAa5CC21fd487B8Fcc2F632f3F4E8D37262a0842' as Address // USDC
+      const asset = '0x078d782b760474a361dda0af3839290b0ef57ad6' as Address // USDC
       const amount = BigInt('1000000000') // 1000 USDC
       const marketId = '0x38f4f3B6533de0023b9DCd04b02F93d36ad1F9f9' // Gauntlet USDC vault
 
@@ -159,7 +159,7 @@ describe('LendProviderMorpho', () => {
     })
 
     it('should successfully create a lending transaction', async () => {
-      const asset = '0xBAa5CC21fd487B8Fcc2F632f3F4E8D37262a0842' as Address // USDC
+      const asset = '0x078d782b760474a361dda0af3839290b0ef57ad6' as Address // USDC
       const amount = BigInt('1000000000') // 1000 USDC
       const marketId = '0x38f4f3B6533de0023b9DCd04b02F93d36ad1F9f9' // Gauntlet USDC vault
 
@@ -176,7 +176,7 @@ describe('LendProviderMorpho', () => {
     })
 
     it('should find best market when marketId not provided', async () => {
-      const asset = '0xBAa5CC21fd487B8Fcc2F632f3F4E8D37262a0842' as Address // USDC
+      const asset = '0x078d782b760474a361dda0af3839290b0ef57ad6' as Address // USDC
       const amount = BigInt('1000000000') // 1000 USDC
 
       // Mock the market data for getMarketInfo
@@ -197,7 +197,7 @@ describe('LendProviderMorpho', () => {
     })
 
     it('should use custom slippage when provided', async () => {
-      const asset = '0xBAa5CC21fd487B8Fcc2F632f3F4E8D37262a0842' as Address
+      const asset = '0x078d782b760474a361dda0af3839290b0ef57ad6' as Address
       const amount = BigInt('1000000000')
       const marketId = '0x38f4f3B6533de0023b9DCd04b02F93d36ad1F9f9' // Gauntlet USDC vault
       const customSlippage = 100 // 1%

--- a/packages/sdk/src/lend/providers/morpho/vaults.test.ts
+++ b/packages/sdk/src/lend/providers/morpho/vaults.test.ts
@@ -171,7 +171,7 @@ describe('Vault Utilities', () => {
             {
               supplyApr: 0.03, // 3% USDC rewards
               asset: {
-                address: '0xBAa5CC21fd487B8Fcc2F632f3F4E8D37262a0842',
+                address: '0x078d782b760474a361dda0af3839290b0ef57ad6',
                 name: 'USDC',
                 symbol: 'USDC',
                 chain: { id: 130 }, // Unichain = USDC rewards
@@ -213,7 +213,7 @@ describe('Vault Utilities', () => {
                     {
                       supplyApr: 0.02, // 2% reward
                       asset: {
-                        address: '0xBAa5CC21fd487B8Fcc2F632f3F4E8D37262a0842',
+                        address: '0x078d782b760474a361dda0af3839290b0ef57ad6',
                         symbol: 'USDC',
                         chain: { id: 130 }, // USDC reward
                       },

--- a/packages/sdk/src/services/tokenBalance.spec.ts
+++ b/packages/sdk/src/services/tokenBalance.spec.ts
@@ -24,7 +24,7 @@ describe('TokenBalance', () => {
       name: 'USD Coin',
       decimals: 6,
       addresses: {
-        [unichain.id]: '0xBAa5CC21fd487B8Fcc2F632f3F4E8D37262a0842',
+        [unichain.id]: '0x078d782b760474a361dda0af3839290b0ef57ad6',
       },
     }
   })

--- a/packages/sdk/src/supported/tokens.ts
+++ b/packages/sdk/src/supported/tokens.ts
@@ -17,7 +17,7 @@ export const SUPPORTED_TOKENS: Record<string, TokenInfo> = {
     decimals: 6,
     addresses: {
       [mainnet.id]: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
-      [unichain.id]: '0xBAa5CC21fd487B8Fcc2F632f3F4E8D37262a0842',
+      [unichain.id]: '0x078d782b760474a361dda0af3839290b0ef57ad6',
     },
   },
   MORPHO: {

--- a/packages/sdk/src/types/verbs.ts
+++ b/packages/sdk/src/types/verbs.ts
@@ -1,3 +1,5 @@
+import type { ChainConfig } from '@/types/chain.js'
+
 import type { LendConfig, LendProvider } from './lend.js'
 import type { GetAllWalletsOptions, Wallet } from './wallet.js'
 
@@ -40,10 +42,8 @@ export interface VerbsConfig {
   wallet: WalletConfig
   /** Lending provider configuration (optional) */
   lend?: LendConfig
-  /** Chain ID for blockchain interactions */
-  chainId?: number
-  /** RPC URL for blockchain interactions */
-  rpcUrl?: string
+  /** Chains to use for the SDK */
+  chains?: ChainConfig[]
 }
 
 /**

--- a/packages/sdk/src/verbs.test.ts
+++ b/packages/sdk/src/verbs.test.ts
@@ -12,8 +12,6 @@ describe('Verbs SDK - System Tests', () => {
       async () => {
         // Create Verbs instance with Morpho lending configured
         const verbs = new Verbs({
-          chainId: 130, // Unichain
-          rpcUrl: 'https://mainnet.unichain.org/',
           lend: {
             type: 'morpho',
             defaultSlippage: 50,
@@ -74,8 +72,6 @@ describe('Verbs SDK - System Tests', () => {
       'should fetch vault info with enhanced rewards data',
       async () => {
         const verbs = new Verbs({
-          chainId: 130,
-          rpcUrl: 'https://mainnet.unichain.org/',
           lend: {
             type: 'morpho',
             defaultSlippage: 50,
@@ -107,8 +103,6 @@ describe('Verbs SDK - System Tests', () => {
       'should handle non-existent vault gracefully',
       async () => {
         const verbs = new Verbs({
-          chainId: 130,
-          rpcUrl: 'https://mainnet.unichain.org/',
           lend: {
             type: 'morpho',
             defaultSlippage: 50,
@@ -130,8 +124,6 @@ describe('Verbs SDK - System Tests', () => {
 
     it('should list supported network IDs', async () => {
       const verbs = new Verbs({
-        chainId: 130,
-        rpcUrl: 'https://rpc.unichain.org',
         lend: {
           type: 'morpho',
           defaultSlippage: 50,
@@ -151,8 +143,6 @@ describe('Verbs SDK - System Tests', () => {
 
     it.runIf(externalTest())('should get list of vaults', async () => {
       const verbs = new Verbs({
-        chainId: 130,
-        rpcUrl: 'https://mainnet.unichain.org/',
         lend: {
           type: 'morpho',
           defaultSlippage: 50,

--- a/packages/sdk/src/verbs.ts
+++ b/packages/sdk/src/verbs.ts
@@ -1,5 +1,5 @@
 import { createPublicClient, http, type PublicClient } from 'viem'
-import { mainnet, optimism, unichain } from 'viem/chains'
+import { mainnet, unichain } from 'viem/chains'
 
 import { LendProviderMorpho } from '@/lend/index.js'
 import { ChainManager } from '@/services/ChainManager.js'
@@ -27,20 +27,25 @@ export class Verbs implements VerbsInterface {
   private lendProvider?: LendProvider
 
   constructor(config: VerbsConfig) {
-    this.chainManager = new ChainManager([
-      {
-        chainId: unichain.id,
-        rpcUrl: unichain.rpcUrls.default.http[0],
-      },
-    ])
+    this.chainManager = new ChainManager(
+      config.chains || [
+        {
+          chainId: unichain.id,
+          rpcUrl: unichain.rpcUrls.default.http[0],
+        },
+      ],
+    )
     // Create lending provider if configured
     if (config.lend) {
-      const chainId = config.chainId || 130 // Default to Unichain
-      const chain =
-        chainId === 10 ? optimism : chainId === 130 ? unichain : mainnet
+      // TODO: delete this code and just have the lend use the ChainManager
+      const configChain = config.chains?.[0]
+      const chainId = configChain?.chainId || 130 // Default to Unichain
+      const chain = chainId === 130 ? unichain : mainnet
       const publicClient = createPublicClient({
         chain,
-        transport: http(config.rpcUrl),
+        transport: http(
+          configChain?.rpcUrl || unichain.rpcUrls.default.http[0],
+        ),
       }) as PublicClient
       if (config.lend.type === 'morpho') {
         this.lendProvider = new LendProviderMorpho(config.lend, publicClient)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       globals:
         specifier: ^15.0.0
         version: 15.15.0
+      mprocs:
+        specifier: ^0.7.2
+        version: 0.7.3
       nx:
         specifier: ^21.3.2
         version: 21.3.2
@@ -50,9 +53,15 @@ importers:
       resolve-tspaths:
         specifier: ^0.8.18
         version: 0.8.23(typescript@5.8.3)
+      supersim:
+        specifier: ^0.1.0-alpha.58
+        version: 0.1.0-alpha.58
       tsx:
         specifier: ^4.0.0
         version: 4.20.3
+      wait-port:
+        specifier: ^1.1.0
+        version: 1.1.0
 
   packages/demo/backend:
     dependencies:
@@ -62,6 +71,9 @@ importers:
       '@eth-optimism/verbs-sdk':
         specifier: workspace:*
         version: link:../../sdk
+      '@eth-optimism/viem':
+        specifier: ^0.4.13
+        version: 0.4.13(viem@2.33.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.0.5))
       '@hono/node-server':
         specifier: ^1.14.0
         version: 1.17.1(hono@4.8.5)
@@ -83,6 +95,9 @@ importers:
       pino-pretty:
         specifier: ^13.0.0
         version: 13.0.0
+      viem:
+        specifier: ^2.24.1
+        version: 2.33.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.0.5)
       zod:
         specifier: ^4.0.5
         version: 4.0.5
@@ -98,7 +113,17 @@ importers:
         version: 6.21.3
       vitest:
         specifier: ^1.6.1
-        version: 1.6.1(@types/node@20.19.9)(jsdom@23.2.0)
+        version: 1.6.1(@types/node@20.19.9)(jsdom@23.2.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+
+  packages/demo/contracts:
+    dependencies:
+      solc:
+        specifier: ^0.8.26
+        version: 0.8.30
+    devDependencies:
+      solhint:
+        specifier: ^4.1.1
+        version: 4.5.4(typescript@5.8.3)
 
   packages/demo/frontend:
     dependencies:
@@ -117,6 +142,9 @@ importers:
       react-router-dom:
         specifier: '7'
         version: 7.7.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      viem:
+        specifier: ^2.24.1
+        version: 2.33.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.0.5)
       zod:
         specifier: ^4.0.5
         version: 4.0.5
@@ -138,7 +166,7 @@ importers:
         version: 18.3.7(@types/react@18.3.23)
       '@vitejs/plugin-react':
         specifier: ^4.0.3
-        version: 4.7.0(vite@4.5.14(@types/node@22.16.5))
+        version: 4.7.0(vite@4.5.14(@types/node@20.19.9))
       autoprefixer:
         specifier: ^10.4.16
         version: 10.4.21(postcss@8.5.6)
@@ -171,31 +199,31 @@ importers:
         version: 8.38.0(eslint@9.31.0(jiti@1.21.7))(typescript@5.8.3)
       vite:
         specifier: ^4.4.5
-        version: 4.5.14(@types/node@22.16.5)
+        version: 4.5.14(@types/node@20.19.9)
       vitest:
         specifier: ^1.6.1
-        version: 1.6.1(@types/node@22.16.5)(jsdom@23.2.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+        version: 1.6.1(@types/node@20.19.9)(jsdom@23.2.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
 
   packages/sdk:
     dependencies:
       '@eth-optimism/viem':
         specifier: ^0.4.13
-        version: 0.4.13(viem@2.33.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+        version: 0.4.13(viem@2.33.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.0.5))
       '@morpho-org/blue-sdk':
         specifier: ^4.5.1
         version: 4.5.1(@morpho-org/morpho-ts@2.4.1)
       '@morpho-org/blue-sdk-viem':
         specifier: ^3.1.1
-        version: 3.1.1(@morpho-org/blue-sdk@4.5.1(@morpho-org/morpho-ts@2.4.1))(@morpho-org/morpho-ts@2.4.1)(viem@2.33.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+        version: 3.1.1(@morpho-org/blue-sdk@4.5.1(@morpho-org/morpho-ts@2.4.1))(@morpho-org/morpho-ts@2.4.1)(viem@2.33.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.0.5))
       '@morpho-org/morpho-ts':
         specifier: ^2.4.1
         version: 2.4.1
       '@privy-io/server-auth':
         specifier: latest
-        version: 1.28.6(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.33.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+        version: 1.28.6(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.33.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.0.5))
       viem:
         specifier: ^2.24.1
-        version: 2.33.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+        version: 2.33.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.0.5)
     devDependencies:
       '@types/node':
         specifier: ^18
@@ -1504,6 +1532,18 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
+  '@pnpm/config.env-replace@1.1.0':
+    resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
+    engines: {node: '>=12.22.0'}
+
+  '@pnpm/network.ca-file@1.0.2':
+    resolution: {integrity: sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==}
+    engines: {node: '>=12.22.0'}
+
+  '@pnpm/npm-conf@2.3.1':
+    resolution: {integrity: sha512-c83qWb22rNRuB0UaVCI0uRPNRr8Z0FWnEIvT47jiHAmOIUHbBOg5XvV7pM5x+rKn9HRpjxquDbXYSXr3fAKFcw==}
+    engines: {node: '>=12'}
+
   '@privy-io/api-base@1.5.2':
     resolution: {integrity: sha512-0eJBoQNmCSsWSWhzEVSU8WqPm7bgeN6VaAmqeXvjk8Ni0jM8nyTYjmRAqiCSs3mRzsnlQVchkGR6lsMTHkHKbw==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -1643,6 +1683,10 @@ packages:
   '@sinclair/typebox@0.34.38':
     resolution: {integrity: sha512-HpkxMmc2XmZKhvaKIZZThlHmx1L0I/V1hWK1NubtlFnr6ZqdiOpV72TKudZUNQjZNsyDBay72qFEhEvb+bcwcA==}
 
+  '@sindresorhus/is@5.6.0':
+    resolution: {integrity: sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==}
+    engines: {node: '>=14.16'}
+
   '@solana/buffer-layout@4.0.1':
     resolution: {integrity: sha512-E1ImOIAD1tBZFRdjeM4/pzTiTApC0AOBGwyAMS4fwIodCWArzJ3DWdoh8cKxeFM2fElkxBh2Aqts1BPC373rHA==}
     engines: {node: '>=5.10'}
@@ -1669,11 +1713,18 @@ packages:
   '@solana/web3.js@1.98.2':
     resolution: {integrity: sha512-BqVwEG+TaG2yCkBMbD3C4hdpustR4FpuUFRPUmqRZYYlPI9Hg4XMWxHWOWRzHE9Lkc9NDjzXFX7lDXSgzC7R1A==}
 
+  '@solidity-parser/parser@0.18.0':
+    resolution: {integrity: sha512-yfORGUIPgLck41qyN7nbwJRAx17/jAIXCTanHOJZhB6PJ1iAk/84b/xlsVKFSyNyLXIj0dhppoE0+CRws7wlzA==}
+
   '@stablelib/base64@1.0.1':
     resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
 
   '@swc/helpers@0.5.17':
     resolution: {integrity: sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==}
+
+  '@szmarczak/http-timer@5.0.1':
+    resolution: {integrity: sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==}
+    engines: {node: '>=14.16'}
 
   '@testing-library/dom@9.3.4':
     resolution: {integrity: sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==}
@@ -1719,6 +1770,9 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/http-cache-semantics@4.0.4':
+    resolution: {integrity: sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -1901,6 +1955,9 @@ packages:
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
+  ajv@8.17.1:
+    resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
+
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
@@ -1924,6 +1981,10 @@ packages:
   ansi-styles@6.2.1:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
+
+  antlr4@4.13.2:
+    resolution: {integrity: sha512-QiVbZhyy4xAZ17UPEuG3YTOt8ZaoeOR1CvEAqrEsDBsOqINslaB147i9xqljZqoyf5S+EUlGStaj+t22LT9MOg==}
+    engines: {node: '>=16'}
 
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
@@ -1986,6 +2047,13 @@ packages:
 
   assertion-error@1.1.0:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
+
+  ast-parents@0.0.1:
+    resolution: {integrity: sha512-XHusKxKz3zoYk1ic8Un640joHbFMhbqneyoZfoKnEGtf2ey9Uh/IdpcQplODdO/kENaMIWsD0nJm4+wX3UNLHA==}
+
+  astral-regex@2.0.0:
+    resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
+    engines: {node: '>=8'}
 
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
@@ -2117,6 +2185,14 @@ packages:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
 
+  cacheable-lookup@7.0.0:
+    resolution: {integrity: sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==}
+    engines: {node: '>=14.16'}
+
+  cacheable-request@10.2.14:
+    resolution: {integrity: sha512-zkDT5WAF4hSSoUgyfg5tFIxz8XQK+25W/TLVojJTMKBaxevLBBtLxgqguAuVQB8PVW79FVjHcU+GJ9tVbDZ9mQ==}
+    engines: {node: '>=14.16'}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -2201,6 +2277,13 @@ packages:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
 
+  command-exists@1.2.9:
+    resolution: {integrity: sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==}
+
+  commander@10.0.1:
+    resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
+    engines: {node: '>=14'}
+
   commander@12.1.0:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
     engines: {node: '>=18'}
@@ -2220,6 +2303,14 @@ packages:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
 
+  commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
+
+  commander@9.5.0:
+    resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
+    engines: {node: ^12.20.0 || >=14}
+
   comment-parser@1.4.1:
     resolution: {integrity: sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==}
     engines: {node: '>= 12.0.0'}
@@ -2229,6 +2320,9 @@ packages:
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  config-chain@1.1.13:
+    resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -2243,6 +2337,15 @@ packages:
   cosmiconfig@7.1.0:
     resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
     engines: {node: '>=10'}
+
+  cosmiconfig@8.3.6:
+    resolution: {integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=4.9.5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -2306,6 +2409,10 @@ packages:
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
   deep-eql@4.1.4:
     resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
     engines: {node: '>=6'}
@@ -2314,11 +2421,19 @@ packages:
     resolution: {integrity: sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==}
     engines: {node: '>= 0.4'}
 
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
   defaults@1.0.4:
     resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
+
+  defer-to-connect@2.0.1:
+    resolution: {integrity: sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==}
+    engines: {node: '>=10'}
 
   define-data-property@1.1.4:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
@@ -2613,6 +2728,9 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
+  fast-diff@1.3.0:
+    resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
+
   fast-glob@3.3.2:
     resolution: {integrity: sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==}
     engines: {node: '>=8.6.0'}
@@ -2635,6 +2753,9 @@ packages:
 
   fast-stable-stringify@1.0.0:
     resolution: {integrity: sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==}
+
+  fast-uri@3.0.6:
+    resolution: {integrity: sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==}
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
@@ -2694,6 +2815,10 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
+  form-data-encoder@2.1.4:
+    resolution: {integrity: sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==}
+    engines: {node: '>= 14.17'}
+
   form-data@4.0.4:
     resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
     engines: {node: '>= 6'}
@@ -2706,6 +2831,9 @@ packages:
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+
+  fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -2741,6 +2869,10 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
+  get-stream@6.0.1:
+    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
+    engines: {node: '>=10'}
+
   get-stream@8.0.1:
     resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
     engines: {node: '>=16'}
@@ -2764,6 +2896,11 @@ packages:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
     hasBin: true
 
+  glob@8.1.0:
+    resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
+    engines: {node: '>=12'}
+    deprecated: Glob versions prior to v9 are no longer supported
+
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
@@ -2779,6 +2916,13 @@ packages:
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
+
+  got@12.6.1:
+    resolution: {integrity: sha512-mThBblvlAF1d4O5oqyvN+ZxLAYwIJK7bpMxgYqPD9okW0C3qm5FFn7k811QrcuEBwaogR3ngOFoCfs6mRv7teQ==}
+    engines: {node: '>=14.16'}
+
+  graceful-fs@4.2.10:
+    resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
 
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
@@ -2825,9 +2969,16 @@ packages:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
     engines: {node: '>=18'}
 
+  http-cache-semantics@4.2.0:
+    resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
+
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
+
+  http2-wrapper@2.2.1:
+    resolution: {integrity: sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==}
+    engines: {node: '>=10.19.0'}
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
@@ -2867,8 +3018,15 @@ packages:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
 
+  inflight@1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
@@ -3061,6 +3219,9 @@ packages:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
 
+  js-sha3@0.8.0:
+    resolution: {integrity: sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -3107,6 +3268,9 @@ packages:
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
@@ -3131,6 +3295,10 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  latest-version@7.0.0:
+    resolution: {integrity: sha512-KvNT4XqAMzdcL6ka6Tl3i2lYeFDgXNCuIX+xNx6ZMVR1dFq+idXd9FLKNMOIx0t9mJ9/HudyX4oZWXZQ0UJHeg==}
+    engines: {node: '>=14.16'}
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -3170,6 +3338,9 @@ packages:
   lodash.mergewith@4.6.2:
     resolution: {integrity: sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==}
 
+  lodash.truncate@4.4.2:
+    resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==}
+
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
@@ -3183,6 +3354,10 @@ packages:
 
   loupe@2.3.7:
     resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
+
+  lowercase-keys@3.0.0:
+    resolution: {integrity: sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
@@ -3203,6 +3378,10 @@ packages:
 
   mdn-data@2.0.30:
     resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
+
+  memorystream@0.3.1:
+    resolution: {integrity: sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==}
+    engines: {node: '>= 0.10.0'}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -3230,6 +3409,14 @@ packages:
   mimic-fn@4.0.0:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
     engines: {node: '>=12'}
+
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
+  mimic-response@4.0.0:
+    resolution: {integrity: sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
@@ -3259,6 +3446,11 @@ packages:
 
   mlly@1.7.4:
     resolution: {integrity: sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==}
+
+  mprocs@0.7.3:
+    resolution: {integrity: sha512-I1Ptja/UnNVVSV5QEnBdiiwW70HMWJlmnMq6nvw4J7fwZ3s8UZGuf/FG+FTAUr6CLfat8kriHj+mWLx7xsLKSw==}
+    engines: {node: '>=0.10.0'}
+    hasBin: true
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -3303,6 +3495,10 @@ packages:
   normalize-range@0.1.2:
     resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
     engines: {node: '>=0.10.0'}
+
+  normalize-url@8.0.2:
+    resolution: {integrity: sha512-Ee/R3SyN4BuynXcnTaekmaVdbDAEiNrHqjQIA37mHU8G9pf7aaAD4ZX3XjBLo6rsdcxA/gtkcNYZLt30ACgynw==}
+    engines: {node: '>=14.16'}
 
   npm-package-arg@11.0.1:
     resolution: {integrity: sha512-M7s1BD4NxdAvBKUPqqRW957Xwcl/4Zvo8Aj+ANrzvIPzGJZElrH7Z//rSaec2ORcND6FHHLnZeY8qgTpXDMFQQ==}
@@ -3395,6 +3591,10 @@ packages:
     resolution: {integrity: sha512-zAKMgGXUim0Jyd6CXK9lraBnD3H5yPGBPPOkC23a2BG6hsm4Zu6OQSjQuEtV0BHDf4aKHcUFvJiGRrFuW3MG8g==}
     engines: {node: '>=10'}
 
+  os-tmpdir@1.0.2:
+    resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
+    engines: {node: '>=0.10.0'}
+
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
@@ -3406,6 +3606,10 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  p-cancelable@3.0.0:
+    resolution: {integrity: sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==}
+    engines: {node: '>=12.20'}
 
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
@@ -3421,6 +3625,10 @@ packages:
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  package-json@8.1.1:
+    resolution: {integrity: sha512-cbH9IAIJHNj9uXi196JVsRlt7cHKak6u/e6AkL/bkRelZ7rlL3X1YKxsZwa36xipOEKAsdtmaG6aAJoM1fx2zA==}
+    engines: {node: '>=14.16'}
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -3507,6 +3715,10 @@ packages:
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
+  pluralize@8.0.0:
+    resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
+    engines: {node: '>=4'}
+
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
@@ -3556,6 +3768,11 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  prettier@2.8.8:
+    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+
   prettier@3.6.2:
     resolution: {integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==}
     engines: {node: '>=14'}
@@ -3587,6 +3804,9 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
+  proto-list@1.2.4:
+    resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
+
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
@@ -3608,6 +3828,14 @@ packages:
 
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+
+  quick-lru@5.1.1:
+    resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
+    engines: {node: '>=10'}
+
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
 
   react-dom@18.3.1:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
@@ -3689,6 +3917,14 @@ packages:
     resolution: {integrity: sha512-H66BPQMrv+V16t8xtmq+UC0CBpiTBA60V8ibS1QVReIp8T1z8hwFxqcGzm9K6lgsN7sB5edVH8a+ze6Fqm4weA==}
     engines: {node: '>=4'}
 
+  registry-auth-token@5.1.0:
+    resolution: {integrity: sha512-GdekYuwLXLxMuFTwAPg5UKGLW/UXzQrZvH/Zj791BQif5T05T0RsaLfHc9q3ZOKi7n+BoprPD9mJ0O0k4xzUlw==}
+    engines: {node: '>=14'}
+
+  registry-url@6.0.1:
+    resolution: {integrity: sha512-+crtS5QjFRqFCoQmvGduwYWEBng99ZvmFvF+cUJkGYF1L1BfU8C6Zp9T7f5vPAwyLkUExpvK+ANVZmGU49qi4Q==}
+    engines: {node: '>=12'}
+
   regjsgen@0.8.0:
     resolution: {integrity: sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q==}
 
@@ -3706,6 +3942,9 @@ packages:
 
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
+
+  resolve-alpn@1.2.1:
+    resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -3732,6 +3971,10 @@ packages:
   resolve@2.0.0-next.5:
     resolution: {integrity: sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==}
     hasBin: true
+
+  responselike@3.0.0:
+    resolution: {integrity: sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==}
+    engines: {node: '>=14.16'}
 
   restore-cursor@3.1.0:
     resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
@@ -3795,6 +4038,10 @@ packages:
   secure-json-parse@2.7.0:
     resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
 
+  semver@5.7.2:
+    resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
+    hasBin: true
+
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -3852,6 +4099,19 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  slice-ansi@4.0.0:
+    resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
+    engines: {node: '>=10'}
+
+  solc@0.8.30:
+    resolution: {integrity: sha512-9Srk/gndtBmoUbg4CE6ypAzPQlElv8ntbnl6SigUBAzgXKn35v87sj04uZeoZWjtDkdzT0qKFcIo/wl63UMxdw==}
+    engines: {node: '>=12.0.0'}
+    hasBin: true
+
+  solhint@4.5.4:
+    resolution: {integrity: sha512-Cu1XiJXub2q1eCr9kkJ9VPv1sGcmj3V7Zb76B0CoezDOB9bu3DxKIFFH7ggCl9fWpEPD6xBmRLfZrYijkVmujQ==}
+    hasBin: true
 
   sonic-boom@4.2.0:
     resolution: {integrity: sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==}
@@ -3949,6 +4209,10 @@ packages:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
 
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
+
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
@@ -3959,6 +4223,11 @@ packages:
   sucrase@3.35.0:
     resolution: {integrity: sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==}
     engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
+  supersim@0.1.0-alpha.58:
+    resolution: {integrity: sha512-8YHo3j5AvhwDQNWuQvGnN12DBOV1pZYNl2XNM1IMgLydhe3oj9eaWay4F/ZSaSUOJiNPdAv9kDijepXeEAh+6A==}
+    engines: {node: '>=18.0.0'}
     hasBin: true
 
   superstruct@2.0.2:
@@ -3982,6 +4251,10 @@ packages:
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
+  table@6.9.0:
+    resolution: {integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==}
+    engines: {node: '>=10.0.0'}
+
   tailwindcss@3.4.17:
     resolution: {integrity: sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==}
     engines: {node: '>=14.0.0'}
@@ -3996,6 +4269,9 @@ packages:
 
   text-encoding-utf-8@1.0.2:
     resolution: {integrity: sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg==}
+
+  text-table@0.2.0:
+    resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
 
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
@@ -4021,6 +4297,10 @@ packages:
   tinyspy@2.2.1:
     resolution: {integrity: sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==}
     engines: {node: '>=14.0.0'}
+
+  tmp@0.0.33:
+    resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
+    engines: {node: '>=0.6.0'}
 
   tmp@0.2.3:
     resolution: {integrity: sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==}
@@ -4280,6 +4560,11 @@ packages:
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
+
+  wait-port@1.1.0:
+    resolution: {integrity: sha512-3e04qkoN3LxTMLakdqeWth8nih8usyg+sf1Bgdf9wwUkp05iuK1eSY/QpLvscT/+F/gA89+LpUmmgBtesbqI2Q==}
+    engines: {node: '>=10'}
+    hasBin: true
 
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
@@ -5491,9 +5776,9 @@ snapshots:
       pino-pretty: 13.0.0
       prom-client: 15.1.3
 
-  '@eth-optimism/viem@0.4.13(viem@2.33.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
+  '@eth-optimism/viem@0.4.13(viem@2.33.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.0.5))':
     dependencies:
-      viem: 2.33.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.33.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.0.5)
 
   '@hono/node-server@1.17.1(hono@4.8.5)':
     dependencies:
@@ -5558,11 +5843,11 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.4
 
-  '@morpho-org/blue-sdk-viem@3.1.1(@morpho-org/blue-sdk@4.5.1(@morpho-org/morpho-ts@2.4.1))(@morpho-org/morpho-ts@2.4.1)(viem@2.33.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
+  '@morpho-org/blue-sdk-viem@3.1.1(@morpho-org/blue-sdk@4.5.1(@morpho-org/morpho-ts@2.4.1))(@morpho-org/morpho-ts@2.4.1)(viem@2.33.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.0.5))':
     dependencies:
       '@morpho-org/blue-sdk': 4.5.1(@morpho-org/morpho-ts@2.4.1)
       '@morpho-org/morpho-ts': 2.4.1
-      viem: 2.33.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.33.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.0.5)
 
   '@morpho-org/blue-sdk@4.5.1(@morpho-org/morpho-ts@2.4.1)':
     dependencies:
@@ -5706,6 +5991,18 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@pnpm/config.env-replace@1.1.0': {}
+
+  '@pnpm/network.ca-file@1.0.2':
+    dependencies:
+      graceful-fs: 4.2.10
+
+  '@pnpm/npm-conf@2.3.1':
+    dependencies:
+      '@pnpm/config.env-replace': 1.1.0
+      '@pnpm/network.ca-file': 1.0.2
+      config-chain: 1.1.13
+
   '@privy-io/api-base@1.5.2':
     dependencies:
       zod: 3.25.76
@@ -5722,7 +6019,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@privy-io/server-auth@1.28.6(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.33.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
+  '@privy-io/server-auth@1.28.6(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.33.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.0.5))':
     dependencies:
       '@hpke/chacha20poly1305': 1.6.3
       '@hpke/core': 1.7.3
@@ -5739,7 +6036,7 @@ snapshots:
       ts-case-convert: 2.1.0
       type-fest: 3.13.1
     optionalDependencies:
-      viem: 2.33.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.33.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.0.5)
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -5814,7 +6111,7 @@ snapshots:
 
   '@scure/bip32@1.7.0':
     dependencies:
-      '@noble/curves': 1.9.2
+      '@noble/curves': 1.9.4
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
 
@@ -5826,6 +6123,8 @@ snapshots:
   '@sinclair/typebox@0.27.8': {}
 
   '@sinclair/typebox@0.34.38': {}
+
+  '@sindresorhus/is@5.6.0': {}
 
   '@solana/buffer-layout@4.0.1':
     dependencies:
@@ -5871,11 +6170,17 @@ snapshots:
       - typescript
       - utf-8-validate
 
+  '@solidity-parser/parser@0.18.0': {}
+
   '@stablelib/base64@1.0.1': {}
 
   '@swc/helpers@0.5.17':
     dependencies:
       tslib: 2.8.1
+
+  '@szmarczak/http-timer@5.0.1':
+    dependencies:
+      defer-to-connect: 2.0.1
 
   '@testing-library/dom@9.3.4':
     dependencies:
@@ -5944,6 +6249,8 @@ snapshots:
       '@types/node': 20.19.9
 
   '@types/estree@1.0.8': {}
+
+  '@types/http-cache-semantics@4.0.4': {}
 
   '@types/json-schema@7.0.15': {}
 
@@ -6089,7 +6396,7 @@ snapshots:
       '@typescript-eslint/types': 8.38.0
       eslint-visitor-keys: 4.2.1
 
-  '@vitejs/plugin-react@4.7.0(vite@4.5.14(@types/node@22.16.5))':
+  '@vitejs/plugin-react@4.7.0(vite@4.5.14(@types/node@20.19.9))':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.0)
@@ -6097,7 +6404,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 4.5.14(@types/node@22.16.5)
+      vite: 4.5.14(@types/node@20.19.9)
     transitivePeerDependencies:
       - supports-color
 
@@ -6146,6 +6453,11 @@ snapshots:
       typescript: 5.8.3
       zod: 3.25.76
 
+  abitype@1.0.8(typescript@5.8.3)(zod@4.0.5):
+    optionalDependencies:
+      typescript: 5.8.3
+      zod: 4.0.5
+
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
@@ -6171,6 +6483,13 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ajv@8.17.1:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.0.6
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
   ansi-colors@4.1.3: {}
 
   ansi-regex@5.0.1: {}
@@ -6184,6 +6503,8 @@ snapshots:
   ansi-styles@5.2.0: {}
 
   ansi-styles@6.2.1: {}
+
+  antlr4@4.13.2: {}
 
   any-promise@1.3.0: {}
 
@@ -6276,6 +6597,10 @@ snapshots:
       is-array-buffer: 3.0.5
 
   assertion-error@1.1.0: {}
+
+  ast-parents@0.0.1: {}
+
+  astral-regex@2.0.0: {}
 
   async-function@1.0.0: {}
 
@@ -6432,6 +6757,18 @@ snapshots:
 
   cac@6.7.14: {}
 
+  cacheable-lookup@7.0.0: {}
+
+  cacheable-request@10.2.14:
+    dependencies:
+      '@types/http-cache-semantics': 4.0.4
+      get-stream: 6.0.1
+      http-cache-semantics: 4.2.0
+      keyv: 4.5.4
+      mimic-response: 4.0.0
+      normalize-url: 8.0.2
+      responselike: 3.0.0
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -6526,6 +6863,10 @@ snapshots:
     dependencies:
       delayed-stream: 1.0.0
 
+  command-exists@1.2.9: {}
+
+  commander@10.0.1: {}
+
   commander@12.1.0: {}
 
   commander@13.1.0: {}
@@ -6536,11 +6877,20 @@ snapshots:
 
   commander@4.1.1: {}
 
+  commander@8.3.0: {}
+
+  commander@9.5.0: {}
+
   comment-parser@1.4.1: {}
 
   concat-map@0.0.1: {}
 
   confbox@0.1.8: {}
+
+  config-chain@1.1.13:
+    dependencies:
+      ini: 1.3.8
+      proto-list: 1.2.4
 
   convert-source-map@2.0.0: {}
 
@@ -6557,6 +6907,15 @@ snapshots:
       parse-json: 5.2.0
       path-type: 4.0.0
       yaml: 1.10.2
+
+  cosmiconfig@8.3.6(typescript@5.8.3):
+    dependencies:
+      import-fresh: 3.3.1
+      js-yaml: 4.1.0
+      parse-json: 5.2.0
+      path-type: 4.0.0
+    optionalDependencies:
+      typescript: 5.8.3
 
   cross-spawn@7.0.6:
     dependencies:
@@ -6615,6 +6974,10 @@ snapshots:
 
   decimal.js@10.6.0: {}
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
   deep-eql@4.1.4:
     dependencies:
       type-detect: 4.1.0
@@ -6640,11 +7003,15 @@ snapshots:
       which-collection: 1.0.2
       which-typed-array: 1.1.19
 
+  deep-extend@0.6.0: {}
+
   deep-is@0.1.4: {}
 
   defaults@1.0.4:
     dependencies:
       clone: 1.0.4
+
+  defer-to-connect@2.0.1: {}
 
   define-data-property@1.1.4:
     dependencies:
@@ -7126,6 +7493,8 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
+  fast-diff@1.3.0: {}
+
   fast-glob@3.3.2:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -7145,6 +7514,8 @@ snapshots:
   fast-sha256@1.3.0: {}
 
   fast-stable-stringify@1.0.0: {}
+
+  fast-uri@3.0.6: {}
 
   fastq@1.19.1:
     dependencies:
@@ -7195,6 +7566,8 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
+  form-data-encoder@2.1.4: {}
+
   form-data@4.0.4:
     dependencies:
       asynckit: 0.4.0
@@ -7210,6 +7583,8 @@ snapshots:
       js-yaml: 3.14.1
 
   fs-constants@1.0.0: {}
+
+  fs.realpath@1.0.0: {}
 
   fsevents@2.3.3:
     optional: true
@@ -7251,6 +7626,8 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
+  get-stream@6.0.1: {}
+
   get-stream@8.0.1: {}
 
   get-symbol-description@1.1.0:
@@ -7280,6 +7657,14 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
+  glob@8.1.0:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 5.1.6
+      once: 1.4.0
+
   globals@14.0.0: {}
 
   globals@15.15.0: {}
@@ -7290,6 +7675,22 @@ snapshots:
       gopd: 1.2.0
 
   gopd@1.2.0: {}
+
+  got@12.6.1:
+    dependencies:
+      '@sindresorhus/is': 5.6.0
+      '@szmarczak/http-timer': 5.0.1
+      cacheable-lookup: 7.0.0
+      cacheable-request: 10.2.14
+      decompress-response: 6.0.0
+      form-data-encoder: 2.1.4
+      get-stream: 6.0.1
+      http2-wrapper: 2.2.1
+      lowercase-keys: 3.0.0
+      p-cancelable: 3.0.0
+      responselike: 3.0.0
+
+  graceful-fs@4.2.10: {}
 
   graphemer@1.4.0: {}
 
@@ -7327,12 +7728,19 @@ snapshots:
     dependencies:
       whatwg-encoding: 3.1.1
 
+  http-cache-semantics@4.2.0: {}
+
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
+
+  http2-wrapper@2.2.1:
+    dependencies:
+      quick-lru: 5.1.1
+      resolve-alpn: 1.2.1
 
   https-proxy-agent@7.0.6:
     dependencies:
@@ -7366,7 +7774,14 @@ snapshots:
 
   indent-string@4.0.0: {}
 
+  inflight@1.0.6:
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
+
   inherits@2.0.4: {}
+
+  ini@1.3.8: {}
 
   internal-slot@1.1.0:
     dependencies:
@@ -7573,6 +7988,8 @@ snapshots:
 
   joycon@3.1.1: {}
 
+  js-sha3@0.8.0: {}
+
   js-tokens@4.0.0: {}
 
   js-tokens@9.0.1: {}
@@ -7626,6 +8043,8 @@ snapshots:
 
   json-schema-traverse@0.4.1: {}
 
+  json-schema-traverse@1.0.0: {}
+
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json-stringify-safe@5.0.1: {}
@@ -7648,6 +8067,10 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  latest-version@7.0.0:
+    dependencies:
+      package-json: 8.1.1
 
   levn@0.4.1:
     dependencies:
@@ -7679,6 +8102,8 @@ snapshots:
 
   lodash.mergewith@4.6.2: {}
 
+  lodash.truncate@4.4.2: {}
+
   lodash@4.17.21: {}
 
   log-symbols@4.1.0:
@@ -7693,6 +8118,8 @@ snapshots:
   loupe@2.3.7:
     dependencies:
       get-func-name: 2.0.2
+
+  lowercase-keys@3.0.0: {}
 
   lru-cache@10.4.3: {}
 
@@ -7709,6 +8136,8 @@ snapshots:
   math-intrinsics@1.1.0: {}
 
   mdn-data@2.0.30: {}
+
+  memorystream@0.3.1: {}
 
   merge-stream@2.0.0: {}
 
@@ -7728,6 +8157,10 @@ snapshots:
   mimic-fn@2.1.0: {}
 
   mimic-fn@4.0.0: {}
+
+  mimic-response@3.1.0: {}
+
+  mimic-response@4.0.0: {}
 
   min-indent@1.0.1: {}
 
@@ -7758,6 +8191,8 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.1
 
+  mprocs@0.7.3: {}
+
   ms@2.1.3: {}
 
   mz@2.7.0:
@@ -7786,6 +8221,8 @@ snapshots:
   normalize-path@3.0.0: {}
 
   normalize-range@0.1.2: {}
+
+  normalize-url@8.0.2: {}
 
   npm-package-arg@11.0.1:
     dependencies:
@@ -7942,6 +8379,8 @@ snapshots:
       strip-ansi: 6.0.1
       wcwidth: 1.0.1
 
+  os-tmpdir@1.0.2: {}
+
   own-keys@1.0.1:
     dependencies:
       get-intrinsic: 1.3.0
@@ -7952,7 +8391,7 @@ snapshots:
     dependencies:
       '@adraffy/ens-normalize': 1.11.0
       '@noble/ciphers': 1.3.0
-      '@noble/curves': 1.9.2
+      '@noble/curves': 1.9.4
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
@@ -7962,6 +8401,23 @@ snapshots:
       typescript: 5.8.3
     transitivePeerDependencies:
       - zod
+
+  ox@0.8.1(typescript@5.8.3)(zod@4.0.5):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.0
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.4
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.0.8(typescript@5.8.3)(zod@4.0.5)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - zod
+
+  p-cancelable@3.0.0: {}
 
   p-limit@3.1.0:
     dependencies:
@@ -7976,6 +8432,13 @@ snapshots:
       p-limit: 3.1.0
 
   package-json-from-dist@1.0.1: {}
+
+  package-json@8.1.1:
+    dependencies:
+      got: 12.6.1
+      registry-auth-token: 5.1.0
+      registry-url: 6.0.1
+      semver: 7.7.2
 
   parent-module@1.0.1:
     dependencies:
@@ -8071,6 +8534,8 @@ snapshots:
       mlly: 1.7.4
       pathe: 2.0.3
 
+  pluralize@8.0.0: {}
+
   possible-typed-array-names@1.1.0: {}
 
   postcss-import@15.1.0(postcss@8.5.6):
@@ -8112,6 +8577,9 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
+  prettier@2.8.8:
+    optional: true
+
   prettier@3.6.2: {}
 
   pretty-format@27.5.1:
@@ -8147,6 +8615,8 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
+  proto-list@1.2.4: {}
+
   proxy-from-env@1.1.0: {}
 
   psl@1.15.0:
@@ -8165,6 +8635,15 @@ snapshots:
   queue-microtask@1.2.3: {}
 
   quick-format-unescaped@4.0.4: {}
+
+  quick-lru@5.1.1: {}
+
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
 
   react-dom@18.3.1(react@18.3.1):
     dependencies:
@@ -8256,6 +8735,14 @@ snapshots:
       unicode-match-property-ecmascript: 2.0.0
       unicode-match-property-value-ecmascript: 2.2.0
 
+  registry-auth-token@5.1.0:
+    dependencies:
+      '@pnpm/npm-conf': 2.3.1
+
+  registry-url@6.0.1:
+    dependencies:
+      rc: 1.2.8
+
   regjsgen@0.8.0: {}
 
   regjsparser@0.12.0:
@@ -8267,6 +8754,8 @@ snapshots:
   require-from-string@2.0.2: {}
 
   requires-port@1.0.0: {}
+
+  resolve-alpn@1.2.1: {}
 
   resolve-from@4.0.0: {}
 
@@ -8292,6 +8781,10 @@ snapshots:
       is-core-module: 2.16.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+
+  responselike@3.0.0:
+    dependencies:
+      lowercase-keys: 3.0.0
 
   restore-cursor@3.1.0:
     dependencies:
@@ -8386,6 +8879,8 @@ snapshots:
 
   secure-json-parse@2.7.0: {}
 
+  semver@5.7.2: {}
+
   semver@6.3.1: {}
 
   semver@7.7.2: {}
@@ -8453,6 +8948,49 @@ snapshots:
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
+
+  slice-ansi@4.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      astral-regex: 2.0.0
+      is-fullwidth-code-point: 3.0.0
+
+  solc@0.8.30:
+    dependencies:
+      command-exists: 1.2.9
+      commander: 8.3.0
+      follow-redirects: 1.15.9
+      js-sha3: 0.8.0
+      memorystream: 0.3.1
+      semver: 5.7.2
+      tmp: 0.0.33
+    transitivePeerDependencies:
+      - debug
+
+  solhint@4.5.4(typescript@5.8.3):
+    dependencies:
+      '@solidity-parser/parser': 0.18.0
+      ajv: 6.12.6
+      antlr4: 4.13.2
+      ast-parents: 0.0.1
+      chalk: 4.1.2
+      commander: 10.0.1
+      cosmiconfig: 8.3.6(typescript@5.8.3)
+      fast-diff: 1.3.0
+      glob: 8.1.0
+      ignore: 5.3.2
+      js-yaml: 4.1.0
+      latest-version: 7.0.0
+      lodash: 4.17.21
+      pluralize: 8.0.0
+      semver: 7.7.2
+      strip-ansi: 6.0.1
+      table: 6.9.0
+      text-table: 0.2.0
+    optionalDependencies:
+      prettier: 2.8.8
+    transitivePeerDependencies:
+      - typescript
 
   sonic-boom@4.2.0:
     dependencies:
@@ -8571,6 +9109,8 @@ snapshots:
     dependencies:
       min-indent: 1.0.1
 
+  strip-json-comments@2.0.1: {}
+
   strip-json-comments@3.1.1: {}
 
   strip-literal@2.1.1:
@@ -8586,6 +9126,12 @@ snapshots:
       mz: 2.7.0
       pirates: 4.0.7
       ts-interface-checker: 0.1.13
+
+  supersim@0.1.0-alpha.58:
+    dependencies:
+      follow-redirects: 1.15.9
+    transitivePeerDependencies:
+      - debug
 
   superstruct@2.0.2: {}
 
@@ -8615,6 +9161,14 @@ snapshots:
       - encoding
 
   symbol-tree@3.2.4: {}
+
+  table@6.9.0:
+    dependencies:
+      ajv: 8.17.1
+      lodash.truncate: 4.4.2
+      slice-ansi: 4.0.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
 
   tailwindcss@3.4.17:
     dependencies:
@@ -8657,6 +9211,8 @@ snapshots:
 
   text-encoding-utf-8@1.0.2: {}
 
+  text-table@0.2.0: {}
+
   thenify-all@1.6.0:
     dependencies:
       thenify: 3.3.1
@@ -8679,6 +9235,10 @@ snapshots:
   tinypool@0.8.4: {}
 
   tinyspy@2.2.1: {}
+
+  tmp@0.0.33:
+    dependencies:
+      os-tmpdir: 1.0.2
 
   tmp@0.2.3: {}
 
@@ -8858,6 +9418,23 @@ snapshots:
       - utf-8-validate
       - zod
 
+  viem@2.33.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.0.5):
+    dependencies:
+      '@noble/curves': 1.9.2
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.0.8(typescript@5.8.3)(zod@4.0.5)
+      isows: 1.0.7(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      ox: 0.8.1(typescript@5.8.3)(zod@4.0.5)
+      ws: 8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+    optionalDependencies:
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
   vite-node@1.6.1(@types/node@18.19.121):
     dependencies:
       cac: 6.7.14
@@ -8894,31 +9471,13 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@1.6.1(@types/node@22.16.5):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.1
-      pathe: 1.1.2
-      picocolors: 1.1.1
-      vite: 5.4.19(@types/node@22.16.5)
-    transitivePeerDependencies:
-      - '@types/node'
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
-  vite@4.5.14(@types/node@22.16.5):
+  vite@4.5.14(@types/node@20.19.9):
     dependencies:
       esbuild: 0.18.20
       postcss: 8.5.6
       rollup: 3.29.5
     optionalDependencies:
-      '@types/node': 22.16.5
+      '@types/node': 20.19.9
       fsevents: 2.3.3
 
   vite@5.4.19(@types/node@18.19.121):
@@ -8937,15 +9496,6 @@ snapshots:
       rollup: 4.45.1
     optionalDependencies:
       '@types/node': 20.19.9
-      fsevents: 2.3.3
-
-  vite@5.4.19(@types/node@22.16.5):
-    dependencies:
-      esbuild: 0.21.5
-      postcss: 8.5.6
-      rollup: 4.45.1
-    optionalDependencies:
-      '@types/node': 22.16.5
       fsevents: 2.3.3
 
   vitest@1.6.1(@types/node@18.19.121)(jsdom@23.2.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)):
@@ -8983,7 +9533,7 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@1.6.1(@types/node@20.19.9)(jsdom@23.2.0):
+  vitest@1.6.1(@types/node@20.19.9)(jsdom@23.2.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)):
     dependencies:
       '@vitest/expect': 1.6.1
       '@vitest/runner': 1.6.1
@@ -9018,44 +9568,17 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@1.6.1(@types/node@22.16.5)(jsdom@23.2.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)):
-    dependencies:
-      '@vitest/expect': 1.6.1
-      '@vitest/runner': 1.6.1
-      '@vitest/snapshot': 1.6.1
-      '@vitest/spy': 1.6.1
-      '@vitest/utils': 1.6.1
-      acorn-walk: 8.3.4
-      chai: 4.5.0
-      debug: 4.4.1
-      execa: 8.0.1
-      local-pkg: 0.5.1
-      magic-string: 0.30.17
-      pathe: 1.1.2
-      picocolors: 1.1.1
-      std-env: 3.9.0
-      strip-literal: 2.1.1
-      tinybench: 2.9.0
-      tinypool: 0.8.4
-      vite: 5.4.19(@types/node@22.16.5)
-      vite-node: 1.6.1(@types/node@22.16.5)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 22.16.5
-      jsdom: 23.2.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-    transitivePeerDependencies:
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
+
+  wait-port@1.1.0:
+    dependencies:
+      chalk: 4.1.2
+      commander: 9.5.0
+      debug: 4.4.1
+    transitivePeerDependencies:
+      - supports-color
 
   wcwidth@1.0.1:
     dependencies:

--- a/supersim-logs/.gitignore
+++ b/supersim-logs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
Closes https://github.com/ethereum-optimism/verbs/issues/17

# Description

This PR adds a faucet system to support the Verbs demo application, enabling users to fund wallets with ETH and USDC tokens.

Run `pnpm dev` from the `verbs` root to get the demo app spun up against supersim.

## Smart Contracts

- `Faucet.sol` - Admin controlled contract for distributing ETH and ERC20 tokens
- `Deploy.s.sol` - CREATE2 deployment script with automatic ETH funding (100 ETH)
- `Fund.s.sol` - USDC funding script using Unichain whale account impersonation
- `Faucet.t.sol` - Test suite

**Quick Setup:**
```bash
pnpm deploy:fund:faucet  # Deploy faucet + fund with USDC
```

## Backend Changes

**New Endpoint:**
- `GET /wallet/:userId/fund` - Fund selected wallet from faucet contract

## Frontend Changes

**New Command:**
- `wallet fund` - Interactive wallet funding with automatic balance display

## Notes

- **Demo Only**: Not production-ready, specifically for demo environment
- **Unichain Specific**: Funding requires Unichain fork for USDC whale account
