### PR TITLE
feat: type-safe hosted wallet generics

### DIFF
--- a/packages/demo/backend/src/config/verbs.ts
+++ b/packages/demo/backend/src/config/verbs.ts
@@ -4,9 +4,9 @@ import { baseSepolia, unichain } from 'viem/chains'
 
 import { env } from './env.js'
 
-let verbsInstance: Verbs
+let verbsInstance: Verbs<'privy'>
 
-export function createVerbsConfig(): VerbsConfig {
+export function createVerbsConfig(): VerbsConfig<'privy'> {
   return {
     wallet: {
       hostedWalletConfig: {
@@ -53,7 +53,7 @@ export function createVerbsConfig(): VerbsConfig {
   }
 }
 
-export function initializeVerbs(config?: VerbsConfig): void {
+export function initializeVerbs(config?: VerbsConfig<'privy'>): void {
   const verbsConfig = config || createVerbsConfig()
   verbsInstance = new Verbs(verbsConfig)
 }

--- a/packages/sdk/src/types/verbs.ts
+++ b/packages/sdk/src/types/verbs.ts
@@ -1,5 +1,8 @@
 import type { ChainConfig } from '@/types/chain.js'
-import type { HostedProviderUnion } from '@/wallet/providers/hostedProvider.types.js'
+import type {
+  HostedProviderType,
+  ProviderSpec,
+} from '@/wallet/providers/hostedProvider.types.js'
 
 import type { LendConfig } from './lend.js'
 
@@ -7,9 +10,11 @@ import type { LendConfig } from './lend.js'
  * Verbs SDK configuration
  * @description Configuration object for initializing the Verbs SDK
  */
-export interface VerbsConfig {
+export interface VerbsConfig<
+  THostedWalletProviderType extends HostedProviderType,
+> {
   /** Wallet configuration */
-  wallet: WalletConfig
+  wallet: WalletConfig<THostedWalletProviderType>
   /** Lending provider configuration (optional) */
   lend?: LendConfig
   /** Chains to use for the SDK */
@@ -20,9 +25,9 @@ export interface VerbsConfig {
  * Wallet configuration
  * @description Configuration for wallet providers
  */
-export type WalletConfig = {
+export type WalletConfig<THostedProviderType extends HostedProviderType> = {
   /** Hosted wallet configuration */
-  hostedWalletConfig: HostedWalletConfig
+  hostedWalletConfig: HostedWalletConfig<THostedProviderType>
   /** Smart wallet configuration for ERC-4337 infrastructure */
   smartWalletConfig: SmartWalletConfig
 }
@@ -31,9 +36,11 @@ export type WalletConfig = {
  * Hosted wallet configuration
  * @description Configuration for hosted wallets / signers
  */
-export interface HostedWalletConfig {
+export interface HostedWalletConfig<
+  THostedProviderType extends HostedProviderType,
+> {
   /** Wallet provider for account creation, management, and signing */
-  provider: HostedProviderUnion
+  provider: ProviderSpec<THostedProviderType>
 }
 
 /**

--- a/packages/sdk/src/verbs.ts
+++ b/packages/sdk/src/verbs.ts
@@ -2,9 +2,12 @@ import { LendProviderMorpho } from '@/lend/index.js'
 import { ChainManager } from '@/services/ChainManager.js'
 import type { LendProvider } from '@/types/lend.js'
 import type { VerbsConfig } from '@/types/verbs.js'
-import type { HostedWalletProvider } from '@/wallet/providers/base/HostedWalletProvider.js'
 import type { SmartWalletProvider } from '@/wallet/providers/base/SmartWalletProvider.js'
 import { DefaultSmartWalletProvider } from '@/wallet/providers/DefaultSmartWalletProvider.js'
+import type {
+  HostedProviderInstanceMap,
+  HostedProviderType,
+} from '@/wallet/providers/hostedProvider.types.js'
 import { HostedWalletProviderRegistry } from '@/wallet/providers/HostedWalletProviderRegistry.js'
 import { WalletNamespace } from '@/wallet/WalletNamespace.js'
 import { WalletProvider } from '@/wallet/WalletProvider.js'
@@ -13,15 +16,18 @@ import { WalletProvider } from '@/wallet/WalletProvider.js'
  * Main Verbs SDK class
  * @description Core implementation of the Verbs SDK
  */
-export class Verbs {
-  public readonly wallet: WalletNamespace
+export class Verbs<THostedWalletProviderType extends HostedProviderType> {
+  public readonly wallet: WalletNamespace<
+    HostedProviderInstanceMap[THostedWalletProviderType],
+    SmartWalletProvider
+  >
   private chainManager: ChainManager
   private lendProvider?: LendProvider
-  private hostedWalletProvider!: HostedWalletProvider
+  private hostedWalletProvider!: HostedProviderInstanceMap[THostedWalletProviderType]
   private smartWalletProvider!: SmartWalletProvider
   private hostedWalletProviderRegistry: HostedWalletProviderRegistry
 
-  constructor(config: VerbsConfig) {
+  constructor(config: VerbsConfig<THostedWalletProviderType>) {
     this.chainManager = new ChainManager(config.chains)
     this.hostedWalletProviderRegistry = new HostedWalletProviderRegistry()
 
@@ -58,7 +64,9 @@ export class Verbs {
    * @param config - Wallet configuration
    * @returns WalletProvider instance
    */
-  private createWalletProvider(config: VerbsConfig['wallet']) {
+  private createWalletProvider(
+    config: VerbsConfig<THostedWalletProviderType>['wallet'],
+  ) {
     const hostedWalletProviderConfig = config.hostedWalletConfig.provider
     const factory = this.hostedWalletProviderRegistry.getFactory(
       hostedWalletProviderConfig.type,
@@ -100,7 +108,9 @@ export class Verbs {
    * @param config - Wallet configuration
    * @returns WalletNamespace instance
    */
-  private createWalletNamespace(config: VerbsConfig['wallet']) {
+  private createWalletNamespace(
+    config: VerbsConfig<THostedWalletProviderType>['wallet'],
+  ) {
     const walletProvider = this.createWalletProvider(config)
     return new WalletNamespace(walletProvider)
   }

--- a/packages/sdk/src/wallet/WalletNamespace.ts
+++ b/packages/sdk/src/wallet/WalletNamespace.ts
@@ -7,14 +7,20 @@ import type { SmartWallet } from '@/wallet/base/SmartWallet.js'
 import type { Wallet } from '@/wallet/base/Wallet.js'
 import type { WalletProvider } from '@/wallet/WalletProvider.js'
 
+import type { HostedWalletProvider } from './providers/base/HostedWalletProvider.js'
+import type { SmartWalletProvider } from './providers/base/SmartWalletProvider.js'
+
 /**
  * Wallet namespace that provides unified wallet operations
  * @description Provides access to wallet functionality through a single provider interface
  */
-export class WalletNamespace {
-  private provider: WalletProvider
+export class WalletNamespace<
+  H extends HostedWalletProvider = HostedWalletProvider,
+  S extends SmartWalletProvider = SmartWalletProvider,
+> {
+  private provider: WalletProvider<H, S>
 
-  constructor(provider: WalletProvider) {
+  constructor(provider: WalletProvider<H, S>) {
     this.provider = provider
   }
 
@@ -24,7 +30,7 @@ export class WalletNamespace {
    * advanced functionality beyond the unified interface is needed
    * @returns The configured hosted wallet provider instance
    */
-  get hostedWalletProvider() {
+  get hostedWalletProvider(): H {
     return this.provider.hostedWalletProvider
   }
 
@@ -34,7 +40,7 @@ export class WalletNamespace {
    * advanced functionality beyond the unified interface is needed
    * @returns The configured smart wallet provider instance
    */
-  get smartWalletProvider() {
+  get smartWalletProvider(): S {
     return this.provider.smartWalletProvider
   }
 

--- a/packages/sdk/src/wallet/WalletProvider.ts
+++ b/packages/sdk/src/wallet/WalletProvider.ts
@@ -15,10 +15,13 @@ import type { SmartWalletProvider } from '@/wallet/providers/base/SmartWalletPro
  * @description Main wallet provider that combines hosted wallet and smart wallet functionality.
  * Provides a unified interface for all wallet operations while supporting pluggable providers.
  */
-export class WalletProvider {
+export class WalletProvider<
+  H extends HostedWalletProvider,
+  S extends SmartWalletProvider = SmartWalletProvider,
+> {
   constructor(
-    public readonly hostedWalletProvider: HostedWalletProvider,
-    public readonly smartWalletProvider: SmartWalletProvider,
+    public readonly hostedWalletProvider: H,
+    public readonly smartWalletProvider: S,
   ) {}
 
   /**

--- a/packages/sdk/src/wallet/providers/HostedWalletProviderRegistry.ts
+++ b/packages/sdk/src/wallet/providers/HostedWalletProviderRegistry.ts
@@ -23,7 +23,9 @@ export class HostedWalletProviderRegistry {
     })
   }
 
-  getFactory<TType extends HostedProviderType>(type: TType) {
+  getFactory<TType extends HostedProviderType>(
+    type: TType,
+  ): HostedProviderFactory<TType> {
     const factory = this.registry.get(type) as
       | HostedProviderFactory<TType>
       | undefined

--- a/packages/sdk/src/wallet/providers/PrivyHostedWalletProvider.ts
+++ b/packages/sdk/src/wallet/providers/PrivyHostedWalletProvider.ts
@@ -18,9 +18,9 @@ export class PrivyHostedWalletProvider extends HostedWalletProvider {
    */
   constructor(
     private readonly privyClient: PrivyClient,
-    private readonly chainManager: ChainManager,
+    chainManager: ChainManager,
   ) {
-    super()
+    super(chainManager)
   }
 
   async toVerbsWallet(

--- a/packages/sdk/src/wallet/providers/base/HostedWalletProvider.ts
+++ b/packages/sdk/src/wallet/providers/base/HostedWalletProvider.ts
@@ -1,3 +1,4 @@
+import type { ChainManager } from '@/services/ChainManager.js'
 import type { HostedWalletToVerbsWalletOptions } from '@/types/wallet.js'
 import type { Wallet } from '@/wallet/base/Wallet.js'
 
@@ -8,6 +9,11 @@ import type { Wallet } from '@/wallet/base/Wallet.js'
  * as signers for smart wallets or standalone wallet functionality.
  */
 export abstract class HostedWalletProvider {
+  protected chainManager: ChainManager
+
+  protected constructor(chainManager: ChainManager) {
+    this.chainManager = chainManager
+  }
   /**
    * Convert a hosted wallet to a Verbs wallet
    * @description Converts a hosted wallet to a Verbs wallet instance.

--- a/packages/sdk/src/wallet/providers/hostedProvider.types.ts
+++ b/packages/sdk/src/wallet/providers/hostedProvider.types.ts
@@ -2,13 +2,17 @@ import type { PrivyClient } from '@privy-io/server-auth'
 
 import type { ChainManager } from '@/services/ChainManager.js'
 import type { HostedWalletProvider } from '@/wallet/providers/base/HostedWalletProvider.js'
+import type { PrivyHostedWalletProvider } from '@/wallet/providers/PrivyHostedWalletProvider.js'
 
 export interface PrivyOptions {
   privyClient: PrivyClient
 }
-
 export interface HostedProviderConfigMap {
   privy: PrivyOptions
+}
+
+export interface HostedProviderInstanceMap {
+  privy: PrivyHostedWalletProvider
 }
 
 export type HostedProviderType = keyof HostedProviderConfigMap
@@ -17,15 +21,17 @@ export interface HostedProviderDeps {
   chainManager: ChainManager
 }
 
+export type ProviderSpec<TType extends HostedProviderType> = {
+  type: TType
+  config: HostedProviderConfigMap[TType]
+}
+
 export interface HostedProviderFactory<
   TType extends HostedProviderType = HostedProviderType,
   TOptions = HostedProviderConfigMap[TType],
+  TInstance extends HostedWalletProvider = HostedProviderInstanceMap[TType],
 > {
   type: TType
   validateOptions(options: unknown): options is TOptions
-  create(deps: HostedProviderDeps, options: TOptions): HostedWalletProvider
+  create(deps: HostedProviderDeps, options: TOptions): TInstance
 }
-
-export type HostedProviderUnion = {
-  [K in HostedProviderType]: { type: K; config: HostedProviderConfigMap[K] }
-}[HostedProviderType]


### PR DESCRIPTION
## Description
This PR introduces first-class, compile-time typing of the hosted wallet provider across the SDK

## Changes
- Make `VerbsConfig` and `HostedWalletConfig` generic over `HostedProviderType` and replace unions with a typed `ProviderSpec`
- Add `HostedProviderInstanceMap` and update `HostedProviderFactory` to return concrete provider instances keyed by type.
- `Generic`-ize `WalletProvider` and `WalletNamespace` to propagate concrete hosted/smart provider types.

## Why
- Ensures end-to-end type safety for hosted providers (no `as` casts).
- Improves pluggability: adding a new provider updates a central type map and preserves strong typing.
