### PR TITLE
feat: smart wallet attribution support

### DIFF
--- a/packages/demo/backend/package.json
+++ b/packages/demo/backend/package.json
@@ -32,7 +32,8 @@
     "dev:local": "LOCAL_DEV=true pnpm dev",
     "start": "node dist/index.js",
     "test": "vitest --run",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "attribution": "tsx scripts/attribution.ts"
   },
   "dependencies": {
     "@clerk/backend": "^2.12.0",

--- a/packages/demo/backend/scripts/attribution.ts
+++ b/packages/demo/backend/scripts/attribution.ts
@@ -1,0 +1,154 @@
+/*
+  Purpose: Find transactions containing a 16-byte attribution suffix appended to ERC-4337 UserOperations.
+
+  What it does:
+  - Scans recent blocks for EntryPoint UserOperationEvent logs in CHUNK_SIZE windows.
+  - Dedupes bundle transaction hashes (newest first), fetches each tx once, and decodes handleOps.
+  - For each user operation, compares the last 16 bytes of callData and initCode to TARGET_SUFFIX.
+  - Prints the first match (block, txHash, opIndex, sender) or reports none within BLOCKS_BACK.
+
+  Config (env):
+  - RPC_URL        JSON-RPC endpoint.
+  - TARGET_SUFFIX  Required 16-byte hex (0x + 32 chars) to match.
+  - BLOCKS_BACK    Max blocks to scan backwards (default 5000).
+  - CHUNK_SIZE     Log query window size in blocks (default 1000).
+  - ENTRYPOINT     EntryPoint address (hardcoded below for convenience).
+*/
+
+import 'dotenv/config'
+
+import type { Address, GetTransactionReturnType, Hex } from 'viem'
+import {
+  createPublicClient,
+  decodeFunctionData,
+  http,
+  parseAbiItem,
+} from 'viem'
+import { baseSepolia } from 'viem/chains'
+
+import { entryPointAbi } from './entrypointAbi.js'
+
+type DecodedUserOp = {
+  sender: Address
+  nonce: bigint
+  initCode: Hex
+  callData: Hex
+  callGasLimit: bigint
+  verificationGasLimit: bigint
+  preVerificationGas: bigint
+  maxFeePerGas: bigint
+  maxPriorityFeePerGas: bigint
+  paymasterAndData: Hex
+  signature: Hex
+}
+
+const RPC_URL = process.env.RPC_URL
+if (!RPC_URL) {
+  throw new Error('RPC_URL is not set')
+}
+const BLOCKS_BACK = Number(process.env.BLOCKS_BACK ?? 5000)
+const TARGET_SUFFIX: Hex = process.env.TARGET_SUFFIX as Hex
+if (!TARGET_SUFFIX) {
+  throw new Error('TARGET_SUFFIX is not set')
+}
+const ENTRYPOINT = '0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789'
+const CHUNK_SIZE = Number(process.env.CHUNK_SIZE ?? 1000)
+
+const client = createPublicClient({
+  chain: baseSepolia,
+  transport: http(RPC_URL),
+})
+
+function extract16ByteSuffix(hex: Hex): Hex | null {
+  const raw = hex.slice(2)
+  if (raw.length < 32) return null // need at least 16 bytes
+  const suffix = `0x${raw.slice(-32)}` as Hex // last 16 bytes (32 hex chars)
+  return /^0x[0-9a-fA-F]{32}$/.test(suffix) ? suffix : null
+}
+
+function findMatchingOpIndex(
+  operations: readonly DecodedUserOp[],
+  tx: GetTransactionReturnType<typeof baseSepolia>,
+): boolean {
+  for (let i = 0; i < operations.length; i++) {
+    const op = operations[i]
+    const callDataSuffix = extract16ByteSuffix(op.callData)
+    const initCodeSuffix = extract16ByteSuffix(op.initCode)
+    if (callDataSuffix === TARGET_SUFFIX || initCodeSuffix === TARGET_SUFFIX) {
+      console.log(
+        `MATCH block=${tx.blockNumber} tx=${tx.hash} opIndex=${i} sender=${op.sender}`,
+      )
+      return true
+    }
+  }
+  return false
+}
+
+async function main() {
+  const latest = await client.getBlockNumber()
+  const from = latest - BigInt(BLOCKS_BACK)
+  console.log(
+    `Scanning logs ${from} -> ${latest} in ${CHUNK_SIZE}-block chunks for UserOperationEvent at ${ENTRYPOINT} (target suffix ${TARGET_SUFFIX})`,
+  )
+
+  let found = false
+
+  for (
+    let chunkEnd = latest;
+    chunkEnd >= from && !found;
+    chunkEnd -= BigInt(CHUNK_SIZE)
+  ) {
+    const tentativeStart = chunkEnd - BigInt(CHUNK_SIZE - 1)
+    const chunkStart = tentativeStart > from ? tentativeStart : from
+    const userOperationEvent =
+      'event UserOperationEvent(bytes32 indexed userOpHash, address indexed sender, address indexed paymaster, uint256 nonce, bool success, uint256 actualGasCost, uint256 actualGasUsed)'
+
+    const logs = await client.getLogs({
+      address: ENTRYPOINT,
+      event: parseAbiItem(userOperationEvent),
+      fromBlock: chunkStart,
+      toBlock: chunkEnd,
+    })
+
+    // Deduplicate tx hashes (newest-first) and iterate once
+    const seen = new Set<string>()
+    const uniqueTxs: Hex[] = []
+    for (let idx = logs.length - 1; idx >= 0; idx--) {
+      const h = logs[idx].transactionHash
+      if (!h) continue
+      if (!seen.has(h)) {
+        seen.add(h)
+        uniqueTxs.push(h)
+      }
+    }
+    console.log(`Found ${uniqueTxs.length} unique txs`)
+
+    for (const txHash of uniqueTxs) {
+      if (found) break
+      const tx = await client.getTransaction({ hash: txHash })
+
+      const input = tx.input
+      try {
+        const decoded = decodeFunctionData({ abi: entryPointAbi, data: input })
+        if (decoded.functionName !== 'handleOps') continue
+        const [ops] = decoded.args
+
+        if (findMatchingOpIndex(ops, tx)) {
+          found = true
+          break
+        }
+      } catch {
+        continue
+      }
+    }
+  }
+
+  if (!found) {
+    console.log('\nNo matches found in the specified block range.')
+  }
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/packages/demo/backend/scripts/entrypointAbi.ts
+++ b/packages/demo/backend/scripts/entrypointAbi.ts
@@ -1,0 +1,798 @@
+export const entryPointAbi = [
+  {
+    inputs: [
+      { internalType: 'uint256', name: 'preOpGas', type: 'uint256' },
+      { internalType: 'uint256', name: 'paid', type: 'uint256' },
+      { internalType: 'uint48', name: 'validAfter', type: 'uint48' },
+      { internalType: 'uint48', name: 'validUntil', type: 'uint48' },
+      { internalType: 'bool', name: 'targetSuccess', type: 'bool' },
+      { internalType: 'bytes', name: 'targetResult', type: 'bytes' },
+    ],
+    name: 'ExecutionResult',
+    type: 'error',
+  },
+  {
+    inputs: [
+      { internalType: 'uint256', name: 'opIndex', type: 'uint256' },
+      { internalType: 'string', name: 'reason', type: 'string' },
+    ],
+    name: 'FailedOp',
+    type: 'error',
+  },
+  {
+    inputs: [{ internalType: 'address', name: 'sender', type: 'address' }],
+    name: 'SenderAddressResult',
+    type: 'error',
+  },
+  {
+    inputs: [{ internalType: 'address', name: 'aggregator', type: 'address' }],
+    name: 'SignatureValidationFailed',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        components: [
+          { internalType: 'uint256', name: 'preOpGas', type: 'uint256' },
+          { internalType: 'uint256', name: 'prefund', type: 'uint256' },
+          { internalType: 'bool', name: 'sigFailed', type: 'bool' },
+          { internalType: 'uint48', name: 'validAfter', type: 'uint48' },
+          { internalType: 'uint48', name: 'validUntil', type: 'uint48' },
+          { internalType: 'bytes', name: 'paymasterContext', type: 'bytes' },
+        ],
+        internalType: 'struct IEntryPoint.ReturnInfo',
+        name: 'returnInfo',
+        type: 'tuple',
+      },
+      {
+        components: [
+          { internalType: 'uint256', name: 'stake', type: 'uint256' },
+          { internalType: 'uint256', name: 'unstakeDelaySec', type: 'uint256' },
+        ],
+        internalType: 'struct IStakeManager.StakeInfo',
+        name: 'senderInfo',
+        type: 'tuple',
+      },
+      {
+        components: [
+          { internalType: 'uint256', name: 'stake', type: 'uint256' },
+          { internalType: 'uint256', name: 'unstakeDelaySec', type: 'uint256' },
+        ],
+        internalType: 'struct IStakeManager.StakeInfo',
+        name: 'factoryInfo',
+        type: 'tuple',
+      },
+      {
+        components: [
+          { internalType: 'uint256', name: 'stake', type: 'uint256' },
+          { internalType: 'uint256', name: 'unstakeDelaySec', type: 'uint256' },
+        ],
+        internalType: 'struct IStakeManager.StakeInfo',
+        name: 'paymasterInfo',
+        type: 'tuple',
+      },
+    ],
+    name: 'ValidationResult',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        components: [
+          { internalType: 'uint256', name: 'preOpGas', type: 'uint256' },
+          { internalType: 'uint256', name: 'prefund', type: 'uint256' },
+          { internalType: 'bool', name: 'sigFailed', type: 'bool' },
+          { internalType: 'uint48', name: 'validAfter', type: 'uint48' },
+          { internalType: 'uint48', name: 'validUntil', type: 'uint48' },
+          { internalType: 'bytes', name: 'paymasterContext', type: 'bytes' },
+        ],
+        internalType: 'struct IEntryPoint.ReturnInfo',
+        name: 'returnInfo',
+        type: 'tuple',
+      },
+      {
+        components: [
+          { internalType: 'uint256', name: 'stake', type: 'uint256' },
+          { internalType: 'uint256', name: 'unstakeDelaySec', type: 'uint256' },
+        ],
+        internalType: 'struct IStakeManager.StakeInfo',
+        name: 'senderInfo',
+        type: 'tuple',
+      },
+      {
+        components: [
+          { internalType: 'uint256', name: 'stake', type: 'uint256' },
+          { internalType: 'uint256', name: 'unstakeDelaySec', type: 'uint256' },
+        ],
+        internalType: 'struct IStakeManager.StakeInfo',
+        name: 'factoryInfo',
+        type: 'tuple',
+      },
+      {
+        components: [
+          { internalType: 'uint256', name: 'stake', type: 'uint256' },
+          { internalType: 'uint256', name: 'unstakeDelaySec', type: 'uint256' },
+        ],
+        internalType: 'struct IStakeManager.StakeInfo',
+        name: 'paymasterInfo',
+        type: 'tuple',
+      },
+      {
+        components: [
+          { internalType: 'address', name: 'aggregator', type: 'address' },
+          {
+            components: [
+              { internalType: 'uint256', name: 'stake', type: 'uint256' },
+              {
+                internalType: 'uint256',
+                name: 'unstakeDelaySec',
+                type: 'uint256',
+              },
+            ],
+            internalType: 'struct IStakeManager.StakeInfo',
+            name: 'stakeInfo',
+            type: 'tuple',
+          },
+        ],
+        internalType: 'struct IEntryPoint.AggregatorStakeInfo',
+        name: 'aggregatorInfo',
+        type: 'tuple',
+      },
+    ],
+    name: 'ValidationResultWithAggregation',
+    type: 'error',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'bytes32',
+        name: 'userOpHash',
+        type: 'bytes32',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'sender',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'factory',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'paymaster',
+        type: 'address',
+      },
+    ],
+    name: 'AccountDeployed',
+    type: 'event',
+  },
+  { anonymous: false, inputs: [], name: 'BeforeExecution', type: 'event' },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'totalDeposit',
+        type: 'uint256',
+      },
+    ],
+    name: 'Deposited',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'aggregator',
+        type: 'address',
+      },
+    ],
+    name: 'SignatureAggregatorChanged',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'totalStaked',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'unstakeDelaySec',
+        type: 'uint256',
+      },
+    ],
+    name: 'StakeLocked',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'withdrawTime',
+        type: 'uint256',
+      },
+    ],
+    name: 'StakeUnlocked',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'withdrawAddress',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'StakeWithdrawn',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'bytes32',
+        name: 'userOpHash',
+        type: 'bytes32',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'sender',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'paymaster',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'nonce',
+        type: 'uint256',
+      },
+      { indexed: false, internalType: 'bool', name: 'success', type: 'bool' },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'actualGasCost',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'actualGasUsed',
+        type: 'uint256',
+      },
+    ],
+    name: 'UserOperationEvent',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'bytes32',
+        name: 'userOpHash',
+        type: 'bytes32',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'sender',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'nonce',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'bytes',
+        name: 'revertReason',
+        type: 'bytes',
+      },
+    ],
+    name: 'UserOperationRevertReason',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'withdrawAddress',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'Withdrawn',
+    type: 'event',
+  },
+  {
+    inputs: [],
+    name: 'SIG_VALIDATION_FAILED',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { internalType: 'bytes', name: 'initCode', type: 'bytes' },
+      { internalType: 'address', name: 'sender', type: 'address' },
+      { internalType: 'bytes', name: 'paymasterAndData', type: 'bytes' },
+    ],
+    name: '_validateSenderAndPaymaster',
+    outputs: [],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { internalType: 'uint32', name: 'unstakeDelaySec', type: 'uint32' },
+    ],
+    name: 'addStake',
+    outputs: [],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [{ internalType: 'address', name: 'account', type: 'address' }],
+    name: 'balanceOf',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [{ internalType: 'address', name: 'account', type: 'address' }],
+    name: 'depositTo',
+    outputs: [],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [{ internalType: 'address', name: '', type: 'address' }],
+    name: 'deposits',
+    outputs: [
+      { internalType: 'uint112', name: 'deposit', type: 'uint112' },
+      { internalType: 'bool', name: 'staked', type: 'bool' },
+      { internalType: 'uint112', name: 'stake', type: 'uint112' },
+      { internalType: 'uint32', name: 'unstakeDelaySec', type: 'uint32' },
+      { internalType: 'uint48', name: 'withdrawTime', type: 'uint48' },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [{ internalType: 'address', name: 'account', type: 'address' }],
+    name: 'getDepositInfo',
+    outputs: [
+      {
+        components: [
+          { internalType: 'uint112', name: 'deposit', type: 'uint112' },
+          { internalType: 'bool', name: 'staked', type: 'bool' },
+          { internalType: 'uint112', name: 'stake', type: 'uint112' },
+          { internalType: 'uint32', name: 'unstakeDelaySec', type: 'uint32' },
+          { internalType: 'uint48', name: 'withdrawTime', type: 'uint48' },
+        ],
+        internalType: 'struct IStakeManager.DepositInfo',
+        name: 'info',
+        type: 'tuple',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { internalType: 'address', name: 'sender', type: 'address' },
+      { internalType: 'uint192', name: 'key', type: 'uint192' },
+    ],
+    name: 'getNonce',
+    outputs: [{ internalType: 'uint256', name: 'nonce', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [{ internalType: 'bytes', name: 'initCode', type: 'bytes' }],
+    name: 'getSenderAddress',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        components: [
+          { internalType: 'address', name: 'sender', type: 'address' },
+          { internalType: 'uint256', name: 'nonce', type: 'uint256' },
+          { internalType: 'bytes', name: 'initCode', type: 'bytes' },
+          { internalType: 'bytes', name: 'callData', type: 'bytes' },
+          { internalType: 'uint256', name: 'callGasLimit', type: 'uint256' },
+          {
+            internalType: 'uint256',
+            name: 'verificationGasLimit',
+            type: 'uint256',
+          },
+          {
+            internalType: 'uint256',
+            name: 'preVerificationGas',
+            type: 'uint256',
+          },
+          { internalType: 'uint256', name: 'maxFeePerGas', type: 'uint256' },
+          {
+            internalType: 'uint256',
+            name: 'maxPriorityFeePerGas',
+            type: 'uint256',
+          },
+          { internalType: 'bytes', name: 'paymasterAndData', type: 'bytes' },
+          { internalType: 'bytes', name: 'signature', type: 'bytes' },
+        ],
+        internalType: 'struct UserOperation',
+        name: 'userOp',
+        type: 'tuple',
+      },
+    ],
+    name: 'getUserOpHash',
+    outputs: [{ internalType: 'bytes32', name: '', type: 'bytes32' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        components: [
+          {
+            components: [
+              { internalType: 'address', name: 'sender', type: 'address' },
+              { internalType: 'uint256', name: 'nonce', type: 'uint256' },
+              { internalType: 'bytes', name: 'initCode', type: 'bytes' },
+              { internalType: 'bytes', name: 'callData', type: 'bytes' },
+              {
+                internalType: 'uint256',
+                name: 'callGasLimit',
+                type: 'uint256',
+              },
+              {
+                internalType: 'uint256',
+                name: 'verificationGasLimit',
+                type: 'uint256',
+              },
+              {
+                internalType: 'uint256',
+                name: 'preVerificationGas',
+                type: 'uint256',
+              },
+              {
+                internalType: 'uint256',
+                name: 'maxFeePerGas',
+                type: 'uint256',
+              },
+              {
+                internalType: 'uint256',
+                name: 'maxPriorityFeePerGas',
+                type: 'uint256',
+              },
+              {
+                internalType: 'bytes',
+                name: 'paymasterAndData',
+                type: 'bytes',
+              },
+              { internalType: 'bytes', name: 'signature', type: 'bytes' },
+            ],
+            internalType: 'struct UserOperation[]',
+            name: 'userOps',
+            type: 'tuple[]',
+          },
+          {
+            internalType: 'contract IAggregator',
+            name: 'aggregator',
+            type: 'address',
+          },
+          { internalType: 'bytes', name: 'signature', type: 'bytes' },
+        ],
+        internalType: 'struct IEntryPoint.UserOpsPerAggregator[]',
+        name: 'opsPerAggregator',
+        type: 'tuple[]',
+      },
+      { internalType: 'address payable', name: 'beneficiary', type: 'address' },
+    ],
+    name: 'handleAggregatedOps',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        components: [
+          { internalType: 'address', name: 'sender', type: 'address' },
+          { internalType: 'uint256', name: 'nonce', type: 'uint256' },
+          { internalType: 'bytes', name: 'initCode', type: 'bytes' },
+          { internalType: 'bytes', name: 'callData', type: 'bytes' },
+          { internalType: 'uint256', name: 'callGasLimit', type: 'uint256' },
+          {
+            internalType: 'uint256',
+            name: 'verificationGasLimit',
+            type: 'uint256',
+          },
+          {
+            internalType: 'uint256',
+            name: 'preVerificationGas',
+            type: 'uint256',
+          },
+          { internalType: 'uint256', name: 'maxFeePerGas', type: 'uint256' },
+          {
+            internalType: 'uint256',
+            name: 'maxPriorityFeePerGas',
+            type: 'uint256',
+          },
+          { internalType: 'bytes', name: 'paymasterAndData', type: 'bytes' },
+          { internalType: 'bytes', name: 'signature', type: 'bytes' },
+        ],
+        internalType: 'struct UserOperation[]',
+        name: 'ops',
+        type: 'tuple[]',
+      },
+      { internalType: 'address payable', name: 'beneficiary', type: 'address' },
+    ],
+    name: 'handleOps',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [{ internalType: 'uint192', name: 'key', type: 'uint192' }],
+    name: 'incrementNonce',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { internalType: 'bytes', name: 'callData', type: 'bytes' },
+      {
+        components: [
+          {
+            components: [
+              { internalType: 'address', name: 'sender', type: 'address' },
+              { internalType: 'uint256', name: 'nonce', type: 'uint256' },
+              {
+                internalType: 'uint256',
+                name: 'callGasLimit',
+                type: 'uint256',
+              },
+              {
+                internalType: 'uint256',
+                name: 'verificationGasLimit',
+                type: 'uint256',
+              },
+              {
+                internalType: 'uint256',
+                name: 'preVerificationGas',
+                type: 'uint256',
+              },
+              { internalType: 'address', name: 'paymaster', type: 'address' },
+              {
+                internalType: 'uint256',
+                name: 'maxFeePerGas',
+                type: 'uint256',
+              },
+              {
+                internalType: 'uint256',
+                name: 'maxPriorityFeePerGas',
+                type: 'uint256',
+              },
+            ],
+            internalType: 'struct EntryPoint.MemoryUserOp',
+            name: 'mUserOp',
+            type: 'tuple',
+          },
+          { internalType: 'bytes32', name: 'userOpHash', type: 'bytes32' },
+          { internalType: 'uint256', name: 'prefund', type: 'uint256' },
+          { internalType: 'uint256', name: 'contextOffset', type: 'uint256' },
+          { internalType: 'uint256', name: 'preOpGas', type: 'uint256' },
+        ],
+        internalType: 'struct EntryPoint.UserOpInfo',
+        name: 'opInfo',
+        type: 'tuple',
+      },
+      { internalType: 'bytes', name: 'context', type: 'bytes' },
+    ],
+    name: 'innerHandleOp',
+    outputs: [
+      { internalType: 'uint256', name: 'actualGasCost', type: 'uint256' },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { internalType: 'address', name: '', type: 'address' },
+      { internalType: 'uint192', name: '', type: 'uint192' },
+    ],
+    name: 'nonceSequenceNumber',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        components: [
+          { internalType: 'address', name: 'sender', type: 'address' },
+          { internalType: 'uint256', name: 'nonce', type: 'uint256' },
+          { internalType: 'bytes', name: 'initCode', type: 'bytes' },
+          { internalType: 'bytes', name: 'callData', type: 'bytes' },
+          { internalType: 'uint256', name: 'callGasLimit', type: 'uint256' },
+          {
+            internalType: 'uint256',
+            name: 'verificationGasLimit',
+            type: 'uint256',
+          },
+          {
+            internalType: 'uint256',
+            name: 'preVerificationGas',
+            type: 'uint256',
+          },
+          { internalType: 'uint256', name: 'maxFeePerGas', type: 'uint256' },
+          {
+            internalType: 'uint256',
+            name: 'maxPriorityFeePerGas',
+            type: 'uint256',
+          },
+          { internalType: 'bytes', name: 'paymasterAndData', type: 'bytes' },
+          { internalType: 'bytes', name: 'signature', type: 'bytes' },
+        ],
+        internalType: 'struct UserOperation',
+        name: 'op',
+        type: 'tuple',
+      },
+      { internalType: 'address', name: 'target', type: 'address' },
+      { internalType: 'bytes', name: 'targetCallData', type: 'bytes' },
+    ],
+    name: 'simulateHandleOp',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        components: [
+          { internalType: 'address', name: 'sender', type: 'address' },
+          { internalType: 'uint256', name: 'nonce', type: 'uint256' },
+          { internalType: 'bytes', name: 'initCode', type: 'bytes' },
+          { internalType: 'bytes', name: 'callData', type: 'bytes' },
+          { internalType: 'uint256', name: 'callGasLimit', type: 'uint256' },
+          {
+            internalType: 'uint256',
+            name: 'verificationGasLimit',
+            type: 'uint256',
+          },
+          {
+            internalType: 'uint256',
+            name: 'preVerificationGas',
+            type: 'uint256',
+          },
+          { internalType: 'uint256', name: 'maxFeePerGas', type: 'uint256' },
+          {
+            internalType: 'uint256',
+            name: 'maxPriorityFeePerGas',
+            type: 'uint256',
+          },
+          { internalType: 'bytes', name: 'paymasterAndData', type: 'bytes' },
+          { internalType: 'bytes', name: 'signature', type: 'bytes' },
+        ],
+        internalType: 'struct UserOperation',
+        name: 'userOp',
+        type: 'tuple',
+      },
+    ],
+    name: 'simulateValidation',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'unlockStake',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address payable',
+        name: 'withdrawAddress',
+        type: 'address',
+      },
+    ],
+    name: 'withdrawStake',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address payable',
+        name: 'withdrawAddress',
+        type: 'address',
+      },
+      { internalType: 'uint256', name: 'withdrawAmount', type: 'uint256' },
+    ],
+    name: 'withdrawTo',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  { stateMutability: 'payable', type: 'receive' },
+] as const

--- a/packages/demo/backend/src/config/verbs.ts
+++ b/packages/demo/backend/src/config/verbs.ts
@@ -23,6 +23,8 @@ export function createVerbsConfig(): VerbsConfig<'privy'> {
       smartWalletConfig: {
         provider: {
           type: 'default',
+          // converts to '0xee4a2159c53ceed04edf4ce23cc97c5c'
+          attributionSuffix: 'verbs',
         },
       },
     },

--- a/packages/sdk/src/test/MockChainManager.ts
+++ b/packages/sdk/src/test/MockChainManager.ts
@@ -126,6 +126,7 @@ export class MockChainManager {
     return {
       sendUserOperation: vi.fn(),
       waitForUserOperationReceipt: vi.fn(),
+      prepareUserOperation: vi.fn(),
     } as any
   }
 }

--- a/packages/sdk/src/types/verbs.ts
+++ b/packages/sdk/src/types/verbs.ts
@@ -64,4 +64,7 @@ export type SmartWalletProvider = DefaultSmartWalletProvider
  */
 export interface DefaultSmartWalletProvider {
   type: 'default'
+  // This string will be converted to a 16-byte hex suffix appended to callData and initCode
+  // on all ERC-4337 UserOperations
+  attributionSuffix?: string
 }

--- a/packages/sdk/src/verbs.ts
+++ b/packages/sdk/src/verbs.ts
@@ -110,6 +110,7 @@ export class Verbs<THostedWalletProviderType extends HostedProviderType> {
       this.smartWalletProvider = new DefaultSmartWalletProvider(
         this.chainManager,
         this.lendProviderInstance,
+        config.smartWalletConfig.provider.attributionSuffix,
       )
     } else {
       throw new Error(


### PR DESCRIPTION
Closes https://github.com/ethereum-optimism/verbs/issues/110

This PR configures a way for us to attribute smart wallet deployment and transactions done through the verbs sdk. It follows the same pattern that the [coinbase account sdk](https://github.com/base/account-sdk/blob/fcf262d352a64c3a0184b6b5543b9b600ae1f56f/packages/account-sdk/src/core/provider/interface.ts#L72-L80) uses and appends a 16 byte attribution suffix to `executeBatch` and `initCode`. 

## Changes
- Adds a 16 byte attribution suffix to the `DefaultSmartWallet` and appends it to `executeBatch` calldata and `initCode`
- Added a script showing an example of how to fetch attributable txs