### PR TITLE
Add context for GitHub token in CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,6 +257,7 @@ workflows:
           name: Publish new versions
           context:
             - circleci-repo-actions # for GITHUB_TOKEN_GOVERNANCE && NPM_TOKEN
+            - circleci-repo-readonly-authenticated-github-token #needed for MISE
           filters:
             branches:
               only: main
@@ -266,6 +267,7 @@ workflows:
           prepare-snapshot: true
           context:
             - circleci-repo-actions # for GITHUB_TOKEN_GOVERNANCE && NPM_TOKEN
+            - circleci-repo-readonly-authenticated-github-token #needed for MISE
           filters:
             branches:
               only: main


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

This pull request makes a minor update to the CircleCI workflow configuration by adding an additional context needed for MISE. This ensures that jobs in the publish and snapshot workflows have access to the required authentication tokens.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
