### PR TITLE
Home + Demo improvements

### DIFF
--- a/packages/demo/frontend/src/App.spec.tsx
+++ b/packages/demo/frontend/src/App.spec.tsx
@@ -16,7 +16,7 @@ describe('App', () => {
     render(<App />)
 
     // Home page should have the Github and Demo buttons
-    expect(screen.getByText('Github')).toBeInTheDocument()
+    expect(screen.getAllByText('Github').length).toBeGreaterThan(0)
     expect(screen.getAllByText('Demo').length).toBeGreaterThan(0)
     const appContainer = document.querySelector(
       '.w-full.h-screen.bg-terminal-bg',

--- a/packages/demo/frontend/src/App.spec.tsx
+++ b/packages/demo/frontend/src/App.spec.tsx
@@ -15,7 +15,6 @@ describe('App', () => {
   it('renders home component at root', () => {
     render(<App />)
 
-    expect(screen.getByText('GitHub')).toBeInTheDocument()
     // Home page should have the Github and Demo buttons
     expect(screen.getByText('Github')).toBeInTheDocument()
     expect(screen.getAllByText('Demo').length).toBeGreaterThan(0)

--- a/packages/demo/frontend/src/components/home/ConfigureSection.tsx
+++ b/packages/demo/frontend/src/components/home/ConfigureSection.tsx
@@ -17,7 +17,7 @@ function ConfigureSection({
 
   const frontendConfigCode = `import { createActions } from '@eth-optimism/actions-sdk/react'
 import { USDC, ETH, WBTC, USDT } from '@eth-optimism/actions-sdk/assets'
-import { ExampleMorphoMarket, ExampleAaveMarket } from '@eth-optimism/actions-sdk/markets'
+import { USDCMorphoMarket, USDCAaveMarket } from '@eth-optimism/actions-sdk/markets'
 import { unichain, optimism, base } from 'config/chains'
 
 const config: ActionsConfig = {
@@ -27,35 +27,25 @@ const config: ActionsConfig = {
   lend: {
     type: 'morpho',
     assetAllowlist: [USDC, ETH, WBTC],
-    assetBlocklist: [USDT],
-    marketAllowlist: [ExampleMorphoMarket],
-    marketBlocklist: [ExampleAaveMarket],
+    assetBlocklist: [],
+    marketAllowlist: [USDCMorphoMarket],
+    marketBlocklist: [],
   },
 
   // Borrow Provider
   borrow: {
     type: 'morpho',
     assetAllowlist: [USDC, ETH, WBTC],
-    assetBlocklist: [USDT],
-    marketAllowlist: [ExampleMorphoMarket],
-    marketBlocklist: [ExampleAaveMarket],
+    assetBlocklist: [],
+    marketAllowlist: [USDCMorphoMarket],
+    marketBlocklist: [],
   },
 
   // Swap Provider
   swap: {
     type: 'uniswap',
-    defaultSlippage: 100,
+    defaultSlippage: 100, // 100 bips or 1%
     assetAllowList: [USDC, ETH, WBTC]
-    marketAllowlist: [
-      { from: ETH, to: USDC },
-      { from: USDC, to: ETH },
-      { from: ETH, to: WBTC },
-      { from: WBTC, to: ETH }
-    ],
-    marketBlocklist: [
-      { from: ETH, to: USDC },
-      { from: USDC, to: ETH },
-    ],
   },
 
   // Chain Provider
@@ -70,7 +60,7 @@ export const actions = createActions(config)`
 
   const backendConfigCode = `import { createActions } from '@eth-optimism/actions-sdk/node'
 import { USDC, ETH, WBTC, USDT } from '@eth-optimism/actions-sdk/assets'
-import { ExampleMorphoMarket, ExampleAaveMarket } from '@eth-optimism/actions-sdk/markets'
+import { USDCMorphoMarket, USDCAaveMarket } from '@eth-optimism/actions-sdk/markets'
 import { unichain, optimism, base } from 'config/chains'
 import { PrivyClient } from '@privy-io/node'
 
@@ -98,35 +88,25 @@ const config: ActionsConfig = {
   lend: {
     type: 'morpho',
     assetAllowlist: [USDC, ETH, WBTC],
-    assetBlocklist: [USDT],
-    marketAllowlist: [ExampleMorphoMarket],
-    marketBlocklist: [ExampleAaveMarket],
+    assetBlocklist: [],
+    marketAllowlist: [USDCMorphoMarket],
+    marketBlocklist: [],
   },
 
   // Borrow Provider
   borrow: {
     type: 'morpho',
     assetAllowlist: [USDC, ETH, WBTC],
-    assetBlocklist: [USDT],
-    marketAllowlist: [ExampleMorphoMarket],
-    marketBlocklist: [ExampleAaveMarket],
+    assetBlocklist: [],
+    marketAllowlist: [USDCMorphoMarket],
+    marketBlocklist: [],
   },
 
   // Swap Provider
   swap: {
     type: 'uniswap',
-    defaultSlippage: 100,
+    defaultSlippage: 100, // 100 bips or 1%
     assetAllowList: [USDC, ETH, WBTC]
-    marketAllowlist: [
-      { from: ETH, to: USDC },
-      { from: USDC, to: ETH },
-      { from: ETH, to: WBTC },
-      { from: WBTC, to: ETH }
-    ],
-    marketBlocklist: [
-      { from: ETH, to: USDC },
-      { from: USDC, to: ETH },
-    ],
   },
 
   // Chain Provider

--- a/packages/demo/frontend/src/components/home/Features.tsx
+++ b/packages/demo/frontend/src/components/home/Features.tsx
@@ -73,7 +73,7 @@ function Features() {
               </svg>
             </div>
             <h3 className="font-semibold mb-2 text-white">Swap</h3>
-            <p className="text-gray-300 text-base">Trade via Dex</p>
+            <p className="text-gray-300 text-base">Trade onchain</p>
           </div>
           <div className="text-center">
             <div className="mb-3 flex justify-center">

--- a/packages/demo/frontend/src/components/home/GettingStarted.tsx
+++ b/packages/demo/frontend/src/components/home/GettingStarted.tsx
@@ -7,6 +7,7 @@ import TakeActionSection from './TakeActionSection'
 
 function GettingStarted() {
   const [openAccordion, setOpenAccordion] = useState<string | null>('install')
+  const [openNestedAccordion, setOpenNestedAccordion] = useState<string | null>(null)
   const [selectedPackageManager, setSelectedPackageManager] = useState('npm')
 
   const packageManagers = {
@@ -38,9 +39,6 @@ function GettingStarted() {
             packageManagers={packageManagers}
           />
 
-          {/* Horizontal line */}
-          <div className="h-px bg-gradient-to-r from-transparent via-gray-600 to-transparent my-4"></div>
-
           {/* Accordion Item 2: Configure */}
           <ConfigureSection
             stepNumber={2}
@@ -52,32 +50,87 @@ function GettingStarted() {
             }
           />
 
-          {/* Horizontal line */}
-          <div className="h-px bg-gradient-to-r from-transparent via-gray-600 to-transparent my-4"></div>
+          {/* Accordion Item 3: Configure Wallet */}
+          <div className="mb-4">
+            <button
+              onClick={() =>
+                setOpenAccordion(
+                  openAccordion === 'configure-wallet' ? null : 'configure-wallet',
+                )
+              }
+              className="w-full flex items-center justify-between py-4 px-6 rounded-lg transition-colors"
+              style={{
+                backgroundColor:
+                  openAccordion === 'configure-wallet'
+                    ? 'rgba(60, 60, 60, 0.5)'
+                    : 'rgba(40, 40, 40, 0.5)',
+              }}
+            >
+              <div className="flex items-center gap-4">
+                <span
+                  className="text-2xl font-medium"
+                  style={{ color: '#FF0420' }}
+                >
+                  3
+                </span>
+                <h3 className="text-lg font-medium text-gray-300">
+                  Configure Wallet
+                </h3>
+              </div>
+              <svg
+                className="w-5 h-5 text-gray-400 transition-transform duration-300"
+                style={{
+                  transform:
+                    openAccordion === 'configure-wallet'
+                      ? 'rotate(180deg)'
+                      : 'rotate(0deg)',
+                }}
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M19 9l-7 7-7-7"
+                />
+              </svg>
+            </button>
+            <div
+              className="overflow-hidden transition-all duration-300 ease-in-out"
+              style={{
+                maxHeight: openAccordion === 'configure-wallet' ? '5000px' : '0',
+                opacity: openAccordion === 'configure-wallet' ? 1 : 0,
+              }}
+            >
+              <div className="pt-6 pb-4">
+                {/* Flexible wallet config container */}
+                <div className="border border-gray-600 rounded-lg p-6">
+                  {/* Accordion Item: BYO Hosted Wallets */}
+                  <HostedWalletsSection
+                    stepNumber=""
+                    openAccordion={openNestedAccordion}
+                    setOpenAccordion={setOpenNestedAccordion}
+                  />
 
-          {/* Accordion Item 3: BYO Hosted Wallets */}
-          <HostedWalletsSection
-            stepNumber={3}
-            openAccordion={openAccordion}
-            setOpenAccordion={setOpenAccordion}
-          />
+                  {/* OR separator */}
+                  <div className="flex items-center my-4">
+                    <div className="flex-1 h-px bg-gradient-to-r from-transparent via-gray-600 to-transparent"></div>
+                    <span className="px-4 text-sm font-medium text-gray-500">OR</span>
+                    <div className="flex-1 h-px bg-gradient-to-r from-transparent via-gray-600 to-transparent"></div>
+                  </div>
 
-          {/* Horizontal line with OR */}
-          <div className="flex items-center my-4">
-            <div className="flex-1 h-px bg-gradient-to-r from-transparent via-gray-600 to-transparent"></div>
-            <span className="px-4 text-sm font-medium text-gray-500">OR</span>
-            <div className="flex-1 h-px bg-gradient-to-r from-transparent via-gray-600 to-transparent"></div>
+                  {/* Accordion Item: Customizable Smart Wallets */}
+                  <SmartWalletsSection
+                    stepNumber=""
+                    openAccordion={openNestedAccordion}
+                    setOpenAccordion={setOpenNestedAccordion}
+                  />
+                </div>
+              </div>
+            </div>
           </div>
-
-          {/* Accordion Item 3 (alternate): Customizable Smart Wallets */}
-          <SmartWalletsSection
-            stepNumber={3}
-            openAccordion={openAccordion}
-            setOpenAccordion={setOpenAccordion}
-          />
-
-          {/* Horizontal line */}
-          <div className="h-px bg-gradient-to-r from-transparent via-gray-600 to-transparent my-4"></div>
 
           {/* Accordion Item 4: Take Action */}
           <TakeActionSection

--- a/packages/demo/frontend/src/components/home/GettingStarted.tsx
+++ b/packages/demo/frontend/src/components/home/GettingStarted.tsx
@@ -6,9 +6,33 @@ import SmartWalletsSection from './SmartWalletsSection'
 import TakeActionSection from './TakeActionSection'
 
 function GettingStarted() {
-  const [openAccordion, setOpenAccordion] = useState<string | null>('install')
-  const [openNestedAccordion, setOpenNestedAccordion] = useState<string | null>(null)
+  const [openAccordions, setOpenAccordions] = useState<Set<string>>(new Set())
+  const [openNestedAccordions, setOpenNestedAccordions] = useState<Set<string>>(new Set())
   const [selectedPackageManager, setSelectedPackageManager] = useState('npm')
+
+  const toggleAccordion = (id: string) => {
+    setOpenAccordions(prev => {
+      const newSet = new Set(prev)
+      if (newSet.has(id)) {
+        newSet.delete(id)
+      } else {
+        newSet.add(id)
+      }
+      return newSet
+    })
+  }
+
+  const toggleNestedAccordion = (id: string) => {
+    setOpenNestedAccordions(prev => {
+      const newSet = new Set(prev)
+      if (newSet.has(id)) {
+        newSet.delete(id)
+      } else {
+        newSet.add(id)
+      }
+      return newSet
+    })
+  }
 
   const packageManagers = {
     npm: 'npm install @eth-optimism/actions-sdk',
@@ -30,10 +54,8 @@ function GettingStarted() {
           {/* Accordion Item 1: Install */}
           <InstallSection
             stepNumber={1}
-            isOpen={openAccordion === 'install'}
-            onToggle={() =>
-              setOpenAccordion(openAccordion === 'install' ? null : 'install')
-            }
+            isOpen={openAccordions.has('install')}
+            onToggle={() => toggleAccordion('install')}
             selectedPackageManager={selectedPackageManager}
             setSelectedPackageManager={setSelectedPackageManager}
             packageManagers={packageManagers}
@@ -42,26 +64,18 @@ function GettingStarted() {
           {/* Accordion Item 2: Configure */}
           <ConfigureSection
             stepNumber={2}
-            isOpen={openAccordion === 'configure'}
-            onToggle={() =>
-              setOpenAccordion(
-                openAccordion === 'configure' ? null : 'configure',
-              )
-            }
+            isOpen={openAccordions.has('configure')}
+            onToggle={() => toggleAccordion('configure')}
           />
 
           {/* Accordion Item 3: Configure Wallet */}
           <div className="mb-4">
             <button
-              onClick={() =>
-                setOpenAccordion(
-                  openAccordion === 'configure-wallet' ? null : 'configure-wallet',
-                )
-              }
+              onClick={() => toggleAccordion('configure-wallet')}
               className="w-full flex items-center justify-between py-4 px-6 rounded-lg transition-colors"
               style={{
                 backgroundColor:
-                  openAccordion === 'configure-wallet'
+                  openAccordions.has('configure-wallet')
                     ? 'rgba(60, 60, 60, 0.5)'
                     : 'rgba(40, 40, 40, 0.5)',
               }}
@@ -81,7 +95,7 @@ function GettingStarted() {
                 className="w-5 h-5 text-gray-400 transition-transform duration-300"
                 style={{
                   transform:
-                    openAccordion === 'configure-wallet'
+                    openAccordions.has('configure-wallet')
                       ? 'rotate(180deg)'
                       : 'rotate(0deg)',
                 }}
@@ -100,8 +114,8 @@ function GettingStarted() {
             <div
               className="overflow-hidden transition-all duration-300 ease-in-out"
               style={{
-                maxHeight: openAccordion === 'configure-wallet' ? '5000px' : '0',
-                opacity: openAccordion === 'configure-wallet' ? 1 : 0,
+                maxHeight: openAccordions.has('configure-wallet') ? '5000px' : '0',
+                opacity: openAccordions.has('configure-wallet') ? 1 : 0,
               }}
             >
               <div className="pt-6 pb-4">
@@ -110,8 +124,18 @@ function GettingStarted() {
                   {/* Accordion Item: BYO Hosted Wallets */}
                   <HostedWalletsSection
                     stepNumber=""
-                    openAccordion={openNestedAccordion}
-                    setOpenAccordion={setOpenNestedAccordion}
+                    openAccordion={openNestedAccordions.has('byo-wallet') ? 'byo-wallet' : null}
+                    setOpenAccordion={(val) => {
+                      if (val === 'byo-wallet') {
+                        toggleNestedAccordion('byo-wallet')
+                      } else {
+                        setOpenNestedAccordions(prev => {
+                          const newSet = new Set(prev)
+                          newSet.delete('byo-wallet')
+                          return newSet
+                        })
+                      }
+                    }}
                   />
 
                   {/* OR separator */}
@@ -124,8 +148,18 @@ function GettingStarted() {
                   {/* Accordion Item: Customizable Smart Wallets */}
                   <SmartWalletsSection
                     stepNumber=""
-                    openAccordion={openNestedAccordion}
-                    setOpenAccordion={setOpenNestedAccordion}
+                    openAccordion={openNestedAccordions.has('smart-wallet') ? 'smart-wallet' : null}
+                    setOpenAccordion={(val) => {
+                      if (val === 'smart-wallet') {
+                        toggleNestedAccordion('smart-wallet')
+                      } else {
+                        setOpenNestedAccordions(prev => {
+                          const newSet = new Set(prev)
+                          newSet.delete('smart-wallet')
+                          return newSet
+                        })
+                      }
+                    }}
                   />
                 </div>
               </div>
@@ -135,12 +169,8 @@ function GettingStarted() {
           {/* Accordion Item 4: Take Action */}
           <TakeActionSection
             stepNumber={4}
-            isOpen={openAccordion === 'take-action'}
-            onToggle={() =>
-              setOpenAccordion(
-                openAccordion === 'take-action' ? null : 'take-action',
-              )
-            }
+            isOpen={openAccordions.has('take-action')}
+            onToggle={() => toggleAccordion('take-action')}
           />
         </div>
       </div>

--- a/packages/demo/frontend/src/components/home/GettingStarted.tsx
+++ b/packages/demo/frontend/src/components/home/GettingStarted.tsx
@@ -172,6 +172,49 @@ function GettingStarted() {
             isOpen={openAccordions.has('take-action')}
             onToggle={() => toggleAccordion('take-action')}
           />
+
+          {/* CTA Section */}
+          <div className="pt-16 text-center">
+            <h3 className="text-2xl font-medium text-gray-300 mb-6">
+              Ready to get started?
+            </h3>
+            <div className="flex flex-row gap-4 justify-center">
+              <a
+                href="/earn"
+                className="bg-white text-black px-8 py-3 rounded-lg font-medium hover:bg-gray-200 inline-flex items-center justify-center gap-2 transition-colors duration-200"
+              >
+                <svg
+                  className="w-5 h-5"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+                  />
+                </svg>
+                Demo
+              </a>
+              <a
+                href="https://github.com/ethereum-optimism/actions"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="border border-gray-600 text-white px-8 py-3 rounded-lg font-medium hover:bg-gray-700 inline-flex items-center justify-center gap-2 transition-colors duration-200"
+              >
+                <svg
+                  className="w-5 h-5"
+                  fill="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+                </svg>
+                Github
+              </a>
+            </div>
+          </div>
         </div>
       </div>
     </>

--- a/packages/demo/frontend/src/components/home/Hero.tsx
+++ b/packages/demo/frontend/src/components/home/Hero.tsx
@@ -64,23 +64,8 @@ function Hero() {
 
             <div className="flex flex-row gap-4 justify-center mb-8">
               <a
-                href="https://github.com/ethereum-optimism/actions"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="bg-white text-black px-8 py-3 rounded-lg font-medium hover:bg-gray-200 inline-flex items-center justify-center gap-2 transition-colors duration-200 flex-1 sm:flex-initial"
-              >
-                <svg
-                  className="w-5 h-5"
-                  fill="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
-                </svg>
-                Github
-              </a>
-              <a
                 href="/earn"
-                className="border border-gray-600 text-white px-8 py-3 rounded-lg font-medium hover:bg-gray-700 inline-flex items-center justify-center gap-2 transition-colors duration-200 flex-1 sm:flex-initial"
+                className="bg-white text-black px-8 py-3 rounded-lg font-medium hover:bg-gray-200 inline-flex items-center justify-center gap-2 transition-colors duration-200 flex-1 sm:flex-initial"
               >
                 <svg
                   className="w-5 h-5"
@@ -96,6 +81,21 @@ function Hero() {
                   />
                 </svg>
                 Demo
+              </a>
+              <a
+                href="https://github.com/ethereum-optimism/actions"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="border border-gray-600 text-white px-8 py-3 rounded-lg font-medium hover:bg-gray-700 inline-flex items-center justify-center gap-2 transition-colors duration-200 flex-1 sm:flex-initial"
+              >
+                <svg
+                  className="w-5 h-5"
+                  fill="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+                </svg>
+                Github
               </a>
             </div>
           </div>

--- a/packages/demo/frontend/src/components/home/HostedWalletsSection.tsx
+++ b/packages/demo/frontend/src/components/home/HostedWalletsSection.tsx
@@ -6,7 +6,7 @@ import TurnkeyLogo from '@/assets/turnkey-logo-white.svg'
 import TabbedCodeBlock from './TabbedCodeBlock'
 
 interface HostedWalletsSectionProps {
-  stepNumber: number
+  stepNumber: number | string
   openAccordion: string | null
   setOpenAccordion: (value: string | null) => void
 }
@@ -128,14 +128,16 @@ const wallet = await actions.wallet.hostedWalletToActionsWallet({
           }}
         >
           <div className="flex items-center gap-4">
-            <span
-              className="text-2xl font-medium"
-              style={{ color: colors.actionsRed }}
-            >
-              {stepNumber}
-            </span>
+            {stepNumber && (
+              <span
+                className="text-2xl font-medium"
+                style={{ color: colors.actionsRed }}
+              >
+                {stepNumber}
+              </span>
+            )}
             <h3 className="text-lg font-medium text-gray-300">
-              BYO Hosted Wallets
+              Hosted Wallets
             </h3>
           </div>
           <svg

--- a/packages/demo/frontend/src/components/home/HostedWalletsSection.tsx
+++ b/packages/demo/frontend/src/components/home/HostedWalletsSection.tsx
@@ -23,11 +23,13 @@ function HostedWalletsSection({
   const privyFrontendCode = `import { actions } from './config'
 import { useWallets } from '@privy-io/react-auth'
 
+// PRIVY: Fetch wallet
 const { wallets } = useWallets()
 const embeddedWallet = wallets.find(
   (wallet) => wallet.walletClientType === 'privy',
 )
 
+// ACTIONS: Let wallet make onchain Actions
 const actionsWallet = await actions.wallet.hostedWalletToActionsWallet({
   connectedWallet: embeddedWallet,
 })`
@@ -37,10 +39,12 @@ import { PrivyClient } from '@privy-io/node'
 
 const privyClient = new PrivyClient(env.PRIVY_APP_ID, env.PRIVY_APP_SECRET)
 
+// PRIVY: Create wallet
 const privyWallet = await privyClient.walletApi.createWallet({
   chainType: 'ethereum',
 })
 
+// ACTIONS: Let wallet make onchain Actions
 const wallet = await actions.wallet.hostedWalletToActionsWallet({
   walletId: privyWallet.id,
   address: privyWallet.address,
@@ -49,8 +53,10 @@ const wallet = await actions.wallet.hostedWalletToActionsWallet({
   const dynamicCode = `import { actions } from './config'
 import { useDynamicContext } from "@dynamic-labs/sdk-react-core"
 
+// DYNAMIC: Fetch wallet
 const { primaryWallet } = useDynamicContext()
 
+// ACTIONS: Let wallet make onchain Actions
 const verbsDynamicWallet = await actions.wallet.hostedWalletToVerbsWallet({
   wallet: primaryWallet,
 })`
@@ -58,6 +64,7 @@ const verbsDynamicWallet = await actions.wallet.hostedWalletToVerbsWallet({
   const turnkeyFrontendCode = `import { actions } from './config'
 import { useTurnkey } from "@turnkey/react-wallet-kit"
 
+// TURNKEY: Fetch wallet
 const { wallets, createWallet, refreshWallets, httpClient, session } = useTurnkey()
 
 const wallet = await createWallet({
@@ -67,6 +74,7 @@ const wallet = await createWallet({
 
 const walletAddress = wallet.accounts[0].address
 
+// ACTIONS: Let wallet make onchain Actions
 const actionsWallet = await actions.wallet.hostedWalletToActionsWallet({
   client: httpClient,
   organizationId: session.organizationId,
@@ -84,6 +92,7 @@ const turnkeyClient = new Turnkey({
   defaultOrganizationId: env.TURNKEY_ORGANIZATION_ID,
 })
 
+// TURNKEY: Create wallet
 const turnkeyWallet = await turnkeyClient.apiClient().createWallet({
   walletName: 'ETH Wallet',
   accounts: [{
@@ -94,6 +103,7 @@ const turnkeyWallet = await turnkeyClient.apiClient().createWallet({
   }],
 })
 
+// ACTIONS: Let wallet make onchain Actions
 const wallet = await actions.wallet.hostedWalletToActionsWallet({
   organizationId: turnkeyWallet.activity.organizationId,
   signWith: turnkeyWallet.addresses[0],

--- a/packages/demo/frontend/src/components/home/Overview.tsx
+++ b/packages/demo/frontend/src/components/home/Overview.tsx
@@ -1,8 +1,6 @@
 import CodeBlock from './CodeBlock'
 
-const exampleCode = `import { wallet } from 'actions'
-
-// Enable asset lending in DeFi
+const exampleCode = `// Enable asset lending in DeFi
 const receipt1 = wallet.lend.openPosition({
   amount: 1,
   asset: USDC,

--- a/packages/demo/frontend/src/components/home/Overview.tsx
+++ b/packages/demo/frontend/src/components/home/Overview.tsx
@@ -37,7 +37,7 @@ function Overview() {
         <h2 className="text-3xl font-medium text-gray-300 mb-4">Overview</h2>
         <div className="h-px bg-gradient-to-r from-gray-600 via-gray-500 to-transparent mb-4"></div>
         <p className="text-gray-300 mb-4">
-          Actions is an open source SDK for onchain actions:{' '}
+          Actions is an open source TypeScript SDK for onchain actions:{' '}
           <strong>Lend</strong>, <strong>Borrow</strong>, <strong>Swap</strong>,{' '}
           <strong>Pay</strong>, without managing complex infrastructure or
           custody.

--- a/packages/demo/frontend/src/components/home/Overview.tsx
+++ b/packages/demo/frontend/src/components/home/Overview.tsx
@@ -16,7 +16,7 @@ const receipt2 = wallet.borrow.openPosition({
   ...ExampleAaveMarket
 })
 
-// Token swap via DEX of choice
+// Swap between tokens onchain
 const receipt3 = wallet.swap.execute({
   amountIn: 1,
   assetIn: USDC,

--- a/packages/demo/frontend/src/components/home/SmartWalletsSection.tsx
+++ b/packages/demo/frontend/src/components/home/SmartWalletsSection.tsx
@@ -6,7 +6,7 @@ import TurnkeyLogo from '@/assets/turnkey-logo-white.svg'
 import TabbedCodeBlock from './TabbedCodeBlock'
 
 interface SmartWalletsSectionProps {
-  stepNumber: number
+  stepNumber: number | string
   openAccordion: string | null
   setOpenAccordion: (value: string | null) => void
 }
@@ -160,14 +160,16 @@ const { wallet } = await actions.wallet.createSmartWallet({
           }}
         >
           <div className="flex items-center gap-4">
-            <span
-              className="text-2xl font-medium"
-              style={{ color: colors.actionsRed }}
-            >
-              {stepNumber}
-            </span>
+            {stepNumber && (
+              <span
+                className="text-2xl font-medium"
+                style={{ color: colors.actionsRed }}
+              >
+                {stepNumber}
+              </span>
+            )}
             <h3 className="text-lg font-medium text-gray-300">
-              Customizable Smart Wallets
+              Smart Wallets
             </h3>
           </div>
           <svg

--- a/packages/demo/frontend/src/components/home/SmartWalletsSection.tsx
+++ b/packages/demo/frontend/src/components/home/SmartWalletsSection.tsx
@@ -24,15 +24,18 @@ function SmartWalletsSection({
   const privyFrontendCode = `import { actions } from './config'
 import { useWallets } from '@privy-io/react-auth'
 
+// PRIVY: Fetch wallet
 const { wallets } = useWallets()
 const embeddedWallet = wallets.find(
   (wallet) => wallet.walletClientType === 'privy',
 )
 
+// ACTIONS: Create signer from hosted wallet
 const signer = await actions.wallet.createSigner({
   connectedWallet: embeddedWallet,
 })
 
+// ACTIONS: Create smart wallet capable of Actions
 const { wallet } = await actions.wallet.createSmartWallet({
   signer: signer
 })`
@@ -41,15 +44,18 @@ const { wallet } = await actions.wallet.createSmartWallet({
 import { PrivyClient } from '@privy-io/node'
 import { getAddress } from 'viem'
 
+// PRIVY: Create wallet
 const privyWallet = await privyClient.walletApi.createWallet({
   chainType: 'ethereum',
 })
 
+// ACTIONS: Create signer from hosted wallet
 const privySigner = await actions.wallet.createSigner({
   walletId: privyWallet.id,
   address: getAddress(privyWallet.address),
 })
 
+// ACTIONS: Create smart wallet capable of Actions
 const { wallet } = await actions.wallet.createSmartWallet({
   signer: privySigner
 })`
@@ -57,9 +63,13 @@ const { wallet } = await actions.wallet.createSmartWallet({
   const dynamicFrontendCode = `import { actions } from './config'
 import { useDynamicContext } from "@dynamic-labs/sdk-react-core"
 
+// DYNAMIC: Fetch wallet
 const { primaryWallet } = useDynamicContext()
 
+// ACTIONS: Create signer from hosted wallet
 const signer = await actions.wallet.createSigner({wallet: primaryWallet})
+
+// ACTIONS: Create smart wallet capable of Actions
 const { wallet } = await actions.wallet.createSmartWallet({
   signer: signer
 })`
@@ -69,6 +79,7 @@ const { wallet } = await actions.wallet.createSmartWallet({
   const turnkeyFrontendCode = `import { actions } from './config'
 import { useTurnkey } from "@turnkey/react-wallet-kit"
 
+// TURNKEY: Fetch wallet
 const { wallets, user, createWallet, refreshWallets, httpClient, session } = useTurnkey()
 useEffect(() => {
   async function createEmbeddedWallet() {
@@ -84,12 +95,16 @@ const embeddedWallet = wallets.find(
 )
 
 const walletAddress = embeddedWallet.accounts[0].address
+
+// ACTIONS: Create signer from hosted wallet
 const signer = await actions.wallet.createSigner({
   client: httpClient,
   organizationId: session.organizationId,
   signWith: walletAddress,
   ethereumAddress: walletAddress
 })
+
+// ACTIONS: Create smart wallet capable of Actions
 const { wallet } = await actions.wallet.createSmartWallet({
   signer: signer
 })`
@@ -104,6 +119,7 @@ const turnkeyClient = new Turnkey({
   defaultOrganizationId: env.TURNKEY_ORGANIZATION_ID,
 })
 
+// TURNKEY: Create wallet
 const turnkeyWallet = await turnkeyClient.apiClient().createWallet({
   walletName: 'ETH Wallet',
   accounts: [{
@@ -114,11 +130,13 @@ const turnkeyWallet = await turnkeyClient.apiClient().createWallet({
   }],
 })
 
+// ACTIONS: Create signer from hosted wallet
 const turnkeySigner = await actions.wallet.createSigner({
   organizationId: turnkeyWallet.activity.organizationId,
   signWith: turnkeyWallet.addresses[0],
 })
 
+// ACTIONS: Create smart wallet capable of Actions
 const { wallet } = await actions.wallet.createSmartWallet({
   signer: turnkeySigner
 })`

--- a/packages/demo/frontend/src/components/home/TakeActionSection.tsx
+++ b/packages/demo/frontend/src/components/home/TakeActionSection.tsx
@@ -8,21 +8,25 @@ interface TakeActionSectionProps {
 }
 
 function TakeActionSection({ stepNumber, isOpen, onToggle }: TakeActionSectionProps) {
-  const codeExample = `// Enable asset lending in DeFi
+  const codeExample = `import { wallet } from 'actions'
+import { USDC, USDT, ETH } from '@eth-optimism/actions-sdk/assets'
+import { USDCMorphoMarket, USDCAaveMarket } from '@eth-optimism/actions-sdk/markets'
+
+// Enable asset lending in DeFi
 const receipt1 = wallet.lend.openPosition({
   amount: 1,
   asset: USDC,
-  ...ExampleMorphoMarket
+  ...USDCMorphoMarket
 })
 
 // Use lent assets as collateral
 const receipt2 = wallet.borrow.openPosition({
   amount: 1,
   asset: USDT,
-  ...ExampleAaveMarket
+  ...USDCAaveMarket
 })
 
-// Token swap via DEX of choice
+// Swap between tokens onchain
 const receipt3 = wallet.swap.execute({
   amountIn: 1,
   assetIn: USDC,

--- a/packages/demo/frontend/src/components/nav/NavBar.tsx
+++ b/packages/demo/frontend/src/components/nav/NavBar.tsx
@@ -31,7 +31,7 @@ function NavBar({ fullWidth = false, rightElement, showDemo = false, visible = t
             {rightElement}
             {showDemo && (
               <a
-                href="/demo"
+                href="/earn"
                 className="flex items-center space-x-2 px-2 py-2 text-sm text-gray-300 hover:text-white transition-colors duration-200"
               >
                 <span>Demo</span>


### PR DESCRIPTION
[issue](https://github.com/ethereum-optimism/actions/issues/192)

- [x] Make all blocklists in config empty arrays
- [x] Remove swap market pairings for now from config, keep solo asset allow lists.
- [x] Mention this is a typescript sdk in the sentence in overview section
- [x] Add comment converting config swap slippage to bips
- [x] Nav demo button is wrong link, should be /earn.
- [x] "Token swap via DEX of choice" -> "Swap between tokens onchain"
- [x] "Trade via Dex" -> Trade onchain
- [x] In BYO + Customizable example code, add comments which code is coming from wallet library vs actions.
- [x] Clean up BYO + Customizable sections 
- [x] Allow all accordions to stay open, but default all to closed on load
- [x] Add import wallet + import assets + import markets to Take Action code (see other example code). Remove import wallet from overview code.
- [x] Add another CTA for the demo + docs after Take Actions section
