### PR TITLE
Demo improvements

### DIFF
--- a/packages/demo/backend/src/services/wallet.ts
+++ b/packages/demo/backend/src/services/wallet.ts
@@ -19,6 +19,8 @@ import { mintableErc20Abi } from '@/abis/mintableErc20Abi.js'
 import { getActions, getPrivyClient } from '@/config/actions.js'
 import { USDC } from '@/config/assets.js'
 
+import { getBlockExplorerUrls } from './lend.js'
+
 /**
  * Options for getting all wallets
  * @description Parameters for filtering and paginating wallet results
@@ -241,21 +243,16 @@ export async function fundWallet(wallet: SmartWallet): Promise<{
 
   const result = await wallet.sendBatch(calls, baseSepolia.id)
 
-  // Import getBlockExplorerUrls helper
-  const { getBlockExplorerUrls } = await import('./lend.js')
-
-  // Extract transaction hashes and user op hash using type guards
   let transactionHashes: Address[] | undefined
   let userOpHash: Address | undefined
 
   if (Array.isArray(result)) {
-    // Batch of EOA transactions
-    transactionHashes = result.map((r: EOATransactionReceipt) => r.transactionHash)
+    transactionHashes = result.map(
+      (r: EOATransactionReceipt) => r.transactionHash,
+    )
   } else if ('userOpHash' in result) {
-    // UserOperation transaction
     userOpHash = (result as UserOperationTransactionReceipt).userOpHash
   } else {
-    // Single EOA transaction
     transactionHashes = [(result as EOATransactionReceipt).transactionHash]
   }
 

--- a/packages/demo/frontend/src/api/actionsApi.ts
+++ b/packages/demo/frontend/src/api/actionsApi.ts
@@ -109,7 +109,14 @@ class ActionsApiClient {
   async fundWallet(
     userId: string,
     headers: HeadersInit = {},
-  ): Promise<{ success: boolean; to: string; amount: bigint }> {
+  ): Promise<{
+    success: boolean
+    to: string
+    amount: string
+    transactionHashes?: Address[]
+    userOpHash?: Address
+    blockExplorerUrls?: string[]
+  }> {
     return this.request(`/wallet/${userId}/fund`, {
       method: 'POST',
       headers,

--- a/packages/demo/frontend/src/components/Action.tsx
+++ b/packages/demo/frontend/src/components/Action.tsx
@@ -229,7 +229,6 @@ function Action({
     }
   }, [user?.id, marketChainId, marketAddress, loggedApi])
 
-  // Poll position every 5 seconds to show interest accumulation
   useEffect(() => {
     if (!user?.id || !marketChainId || !marketAddress) return
 

--- a/packages/demo/frontend/src/components/Action.tsx
+++ b/packages/demo/frontend/src/components/Action.tsx
@@ -314,70 +314,76 @@ function Action({
             className="flex items-center gap-2"
             style={{ position: 'relative' }}
           >
-            <span
-              style={{
-                color: '#000',
-                fontSize: '14px',
-              }}
-            >
-              Demo APY
-            </span>
             <div
-              onMouseEnter={() => setShowTooltip(true)}
-              onMouseLeave={() => setShowTooltip(false)}
-              style={{
-                position: 'relative',
-                display: 'inline-flex',
-                cursor: 'pointer',
-              }}
+              className="inline-flex items-center gap-1"
+              style={{ position: 'relative' }}
             >
-              <svg
-                width="16"
-                height="16"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="#666666"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
+              <span
+                style={{
+                  color: '#000',
+                  fontSize: '14px',
+                }}
               >
-                <circle cx="12" cy="12" r="10" />
-                <line x1="12" y1="8" x2="12" y2="12" />
-                <line x1="12" y1="16" x2="12.01" y2="16" />
-              </svg>
-              {showTooltip && (
-                <div
-                  style={{
-                    position: 'absolute',
-                    bottom: '100%',
-                    left: '50%',
-                    transform: 'translateX(-50%) translateY(-8px)',
-                    padding: '8px 12px',
-                    backgroundColor: 'rgba(0, 0, 0, 0.56)',
-                    color: '#FFFFFF',
-                    fontSize: '12px',
-                    borderRadius: '6px',
-                    whiteSpace: 'nowrap',
-                    zIndex: 10,
-                    boxShadow: '0 2px 8px rgba(0,0,0,0.15)',
-                  }}
+                APY
+              </span>
+              <div
+                onMouseEnter={() => setShowTooltip(true)}
+                onMouseLeave={() => setShowTooltip(false)}
+                style={{
+                  position: 'relative',
+                  display: 'inline-flex',
+                  cursor: 'pointer',
+                }}
+              >
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="#666666"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
                 >
-                  For demo only. Real APYs vary by market and provider.
+                  <circle cx="12" cy="12" r="10" />
+                  <line x1="12" y1="8" x2="12" y2="12" />
+                  <line x1="12" y1="16" x2="12.01" y2="16" />
+                </svg>
+                {showTooltip && (
                   <div
                     style={{
                       position: 'absolute',
-                      top: '100%',
+                      bottom: '100%',
                       left: '50%',
-                      transform: 'translateX(-50%)',
-                      width: 0,
-                      height: 0,
-                      borderLeft: '4px solid transparent',
-                      borderRight: '4px solid transparent',
-                      borderTop: '4px solid rgba(0, 0, 0, 0.56)',
+                      transform: 'translateX(-50%) translateY(-8px)',
+                      padding: '8px 12px',
+                      backgroundColor: 'rgba(0, 0, 0, 0.56)',
+                      color: '#FFFFFF',
+                      fontSize: '12px',
+                      borderRadius: '6px',
+                      whiteSpace: 'nowrap',
+                      zIndex: 10,
+                      boxShadow: '0 2px 8px rgba(0,0,0,0.15)',
                     }}
-                  />
-                </div>
-              )}
+                  >
+                    Annual Percentage Yield: the rate of return earned on an
+                    investment over one year
+                    <div
+                      style={{
+                        position: 'absolute',
+                        top: '100%',
+                        left: '50%',
+                        transform: 'translateX(-50%)',
+                        width: 0,
+                        height: 0,
+                        borderLeft: '4px solid transparent',
+                        borderRight: '4px solid transparent',
+                        borderTop: '4px solid rgba(0, 0, 0, 0.56)',
+                      }}
+                    />
+                  </div>
+                )}
+              </div>
             </div>
           </div>
           {isLoadingApy ? (

--- a/packages/demo/frontend/src/components/Action.tsx
+++ b/packages/demo/frontend/src/components/Action.tsx
@@ -96,7 +96,9 @@ function Action({
   }, [loggedApi])
 
   const handleMaxClick = () => {
-    setAmount(mode === 'lend' ? usdcBalance : depositedAmount || '0')
+    const maxAmount = mode === 'lend' ? usdcBalance : depositedAmount || '0'
+    const rounded = parseFloat(maxAmount).toFixed(2)
+    setAmount(rounded)
   }
 
   const handleAmountChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/packages/demo/frontend/src/components/ActivityLog.tsx
+++ b/packages/demo/frontend/src/components/ActivityLog.tsx
@@ -50,7 +50,7 @@ function ActivityLog() {
             <line x1="3" y1="18" x2="3.01" y2="18" />
           </svg>
           <h2 className="text-lg font-semibold" style={{ color: '#1a1b1e' }}>
-            Activity Log
+            Under the Hood
           </h2>
         </div>
       </div>

--- a/packages/demo/frontend/src/components/ActivityLog.tsx
+++ b/packages/demo/frontend/src/components/ActivityLog.tsx
@@ -90,6 +90,8 @@ function ActivityLog() {
                 request={activity.request}
                 response={activity.response}
                 blockExplorerUrl={activity.blockExplorerUrl}
+                isTransaction={activity.isTransaction}
+                isFromPreviousSession={activity.isFromPreviousSession}
               />
             ))
           ) : (

--- a/packages/demo/frontend/src/components/ActivityLog.tsx
+++ b/packages/demo/frontend/src/components/ActivityLog.tsx
@@ -1,4 +1,5 @@
 import ActivityLogItem from './ActivityLogItem'
+import Info from './Info'
 import { useActivityLog } from '../contexts/ActivityLogContext'
 
 function ActivityLog() {
@@ -22,55 +23,69 @@ function ActivityLog() {
 
   return (
     <div
-      className="h-full p-6 overflow-y-auto"
+      className="h-full flex flex-col overflow-y-auto"
       style={{
         backgroundColor: '#FFFFFF',
         borderLeft: '1px solid #E0E2EB',
         fontFamily: 'Inter, system-ui, -apple-system, sans-serif',
       }}
     >
-      <div className="flex items-center gap-2 mb-4">
-        <svg
-          width="20"
-          height="20"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="#1a1b1e"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        >
-          <line x1="8" y1="6" x2="21" y2="6" />
-          <line x1="8" y1="12" x2="21" y2="12" />
-          <line x1="8" y1="18" x2="21" y2="18" />
-          <line x1="3" y1="6" x2="3.01" y2="6" />
-          <line x1="3" y1="12" x2="3.01" y2="12" />
-          <line x1="3" y1="18" x2="3.01" y2="18" />
-        </svg>
-        <h2 className="text-lg font-semibold" style={{ color: '#1a1b1e' }}>
-          Activity Log
-        </h2>
+      <div className="p-6">
+        <div className="flex items-center gap-2 mb-4">
+          <svg
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="#1a1b1e"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <line x1="8" y1="6" x2="21" y2="6" />
+            <line x1="8" y1="12" x2="21" y2="12" />
+            <line x1="8" y1="18" x2="21" y2="18" />
+            <line x1="3" y1="6" x2="3.01" y2="6" />
+            <line x1="3" y1="12" x2="3.01" y2="12" />
+            <line x1="3" y1="18" x2="3.01" y2="18" />
+          </svg>
+          <h2 className="text-lg font-semibold" style={{ color: '#1a1b1e' }}>
+            Activity Log
+          </h2>
+        </div>
+
+        <div>
+          {activities.length > 0 ? (
+            activities.map((activity) => (
+              <ActivityLogItem
+                key={activity.id}
+                type={activity.type}
+                action={activity.action}
+                amount={activity.amount || '0'}
+                timestamp={formatTimestamp(activity.timestamp)}
+                status={activity.status}
+                request={activity.request}
+                response={activity.response}
+                blockExplorerUrl={activity.blockExplorerUrl}
+              />
+            ))
+          ) : (
+            <div
+              style={{
+                color: '#9CA3AF',
+                textAlign: 'center',
+                padding: '2rem',
+              }}
+            >
+              No activity yet
+            </div>
+          )}
+        </div>
       </div>
 
-      <div>
-        {activities.length > 0 ? (
-          activities.map((activity) => (
-            <ActivityLogItem
-              key={activity.id}
-              type={activity.type}
-              action={activity.action}
-              amount={activity.amount || '0'}
-              timestamp={formatTimestamp(activity.timestamp)}
-              status={activity.status}
-            />
-          ))
-        ) : (
-          <div
-            style={{ color: '#9CA3AF', textAlign: 'center', padding: '2rem' }}
-          >
-            No activity yet
-          </div>
-        )}
+      {/* Info section at bottom */}
+      <div className="mt-auto p-6">
+        <Info />
       </div>
     </div>
   )

--- a/packages/demo/frontend/src/components/ActivityLog.tsx
+++ b/packages/demo/frontend/src/components/ActivityLog.tsx
@@ -23,14 +23,14 @@ function ActivityLog() {
 
   return (
     <div
-      className="h-full flex flex-col overflow-y-auto"
+      className="h-full flex flex-col"
       style={{
         backgroundColor: '#FFFFFF',
         borderLeft: '1px solid #E0E2EB',
         fontFamily: 'Inter, system-ui, -apple-system, sans-serif',
       }}
     >
-      <div className="p-6">
+      <div className="p-6 pb-0">
         <div className="flex items-center gap-2 mb-4">
           <svg
             width="20"
@@ -53,8 +53,31 @@ function ActivityLog() {
             Activity Log
           </h2>
         </div>
+      </div>
 
-        <div>
+      <div
+        className="flex-1 overflow-y-auto"
+        style={{
+          scrollbarWidth: 'thin',
+          scrollbarColor: '#D1D5DB #F3F4F6',
+        }}
+      >
+        <style>{`
+          .activity-log-scroll::-webkit-scrollbar {
+            width: 8px;
+          }
+          .activity-log-scroll::-webkit-scrollbar-track {
+            background: #F3F4F6;
+          }
+          .activity-log-scroll::-webkit-scrollbar-thumb {
+            background: #D1D5DB;
+            border-radius: 4px;
+          }
+          .activity-log-scroll::-webkit-scrollbar-thumb:hover {
+            background: #9CA3AF;
+          }
+        `}</style>
+        <div className="activity-log-scroll">
           {activities.length > 0 ? (
             activities.map((activity) => (
               <ActivityLogItem
@@ -84,8 +107,11 @@ function ActivityLog() {
       </div>
 
       {/* Info section at bottom */}
-      <div className="mt-auto p-6">
-        <Info />
+      <div className="mt-auto">
+        <div style={{ borderTop: '1px solid #E0E2EB' }} />
+        <div className="p-6 pt-6">
+          <Info />
+        </div>
       </div>
     </div>
   )

--- a/packages/demo/frontend/src/components/ActivityLogItem.tsx
+++ b/packages/demo/frontend/src/components/ActivityLogItem.tsx
@@ -241,7 +241,7 @@ function ActivityLogItem({
 
           {/* Right side: Clock icon + Chevron toggle */}
           <div className="flex items-center gap-1">
-            {isTransaction && (
+            {isFromPreviousSession && (
               <svg
                 width="14"
                 height="14"

--- a/packages/demo/frontend/src/components/ActivityLogItem.tsx
+++ b/packages/demo/frontend/src/components/ActivityLogItem.tsx
@@ -35,8 +35,8 @@ const TYPE_CONFIG = {
   },
   wallet: {
     label: 'Wallet',
-    bg: '#E0E7FF',
-    stroke: '#6366F1',
+    bg: '#FEF3C7',
+    stroke: '#F59E0B',
   },
 } as const
 
@@ -120,17 +120,49 @@ export const ACTIVITY_CONFIG: Record<string, ActivityConfigEntry> = {
 // Helper to get action config by action name (for ActivityLogItem component)
 const ACTION_CONFIG: Record<
   string,
-  { description: string; apiMethod: string }
-> = Object.values(ACTIVITY_CONFIG).reduce(
-  (acc, config) => {
-    acc[config.action] = {
-      description: config.description,
-      apiMethod: config.apiMethod,
-    }
-    return acc
+  { description: string; apiMethod: string; tooltip: string }
+> = {
+  getMarket: {
+    description: 'Get market',
+    apiMethod: 'actions.lend.getMarket()',
+    tooltip: 'Fetches available lending markets',
   },
-  {} as Record<string, { description: string; apiMethod: string }>,
-)
+  getPosition: {
+    description: 'Get position',
+    apiMethod: 'wallet.lend.getPosition()',
+    tooltip: "Returns a wallet's market positions",
+  },
+  deposit: {
+    description: 'Open lending position',
+    apiMethod: 'wallet.lend.openPosition()',
+    tooltip: 'Opens a new lending position',
+  },
+  withdraw: {
+    description: 'Close lending position',
+    apiMethod: 'wallet.lend.closePosition()',
+    tooltip: 'Closes an existing lending position',
+  },
+  mint: {
+    description: 'Mint demo USDC',
+    apiMethod: 'wallet.fund()',
+    tooltip: 'Funds a wallet with demo tokens',
+  },
+  getBalance: {
+    description: 'Get wallet balance',
+    apiMethod: 'wallet.getBalance()',
+    tooltip: 'Retrieves wallet token balances',
+  },
+  send: {
+    description: 'Send tokens',
+    apiMethod: 'wallet.sendTokens()',
+    tooltip: 'Transfers tokens to another address',
+  },
+  create: {
+    description: 'Create smart wallet',
+    apiMethod: 'actions.wallet.createSmartWallet()',
+    tooltip: 'Creates a new smart wallet',
+  },
+}
 
 function ActivityLogItem({
   type,
@@ -151,6 +183,7 @@ function ActivityLogItem({
 
   const description = actionConfig?.description || `${typeConfig.label} action`
   const apiMethod = actionConfig?.apiMethod || 'actions()'
+  const tooltip = actionConfig?.tooltip
 
   // Placeholder data for now
   const displayRequest = request || { walletId: '0x1234...', amount: 100 }
@@ -229,6 +262,13 @@ function ActivityLogItem({
           className="px-4 pb-4 space-y-3"
           style={{ backgroundColor: '#F9FAFB' }}
         >
+          {/* Description */}
+          {tooltip && (
+            <div className="text-xs pt-2" style={{ color: '#1F2937' }}>
+              {tooltip}
+            </div>
+          )}
+
           {/* Request */}
           <div>
             <div

--- a/packages/demo/frontend/src/components/ActivityLogItem.tsx
+++ b/packages/demo/frontend/src/components/ActivityLogItem.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react'
+// TODO: Re-enable useState in next PR when expand functionality is restored
+// import { useState } from 'react'
 
 interface ActivityLogItemProps {
   type: 'lend' | 'withdraw' | 'fund' | 'wallet'
@@ -150,7 +151,7 @@ const ACTION_CONFIG: Record<
     tooltip: 'Funds a wallet with demo tokens',
   },
   getBalance: {
-    description: 'Get wallet balance',
+    description: 'Get balance',
     apiMethod: 'wallet.getBalance()',
     tooltip: 'Retrieves wallet token balances',
   },
@@ -175,7 +176,9 @@ function ActivityLogItem({
   blockExplorerUrl,
   isFromPreviousSession,
 }: ActivityLogItemProps) {
-  const [isExpanded, setIsExpanded] = useState(false)
+  // TODO: Re-enable expand state in next PR when request/response data is improved
+  // const [isExpanded, setIsExpanded] = useState(false)
+  const isExpanded = false
   const statusColor = STATUS_CONFIG[status]?.color || '#666666'
   const typeConfig = TYPE_CONFIG[type] || {
     label: type,
@@ -188,11 +191,9 @@ function ActivityLogItem({
   const apiMethod = actionConfig?.apiMethod || 'actions()'
   const tooltip = actionConfig?.tooltip
 
-  // Placeholder data for now
-  const displayRequest = request || { walletId: '0x1234...', amount: 100 }
-  const displayResponse = response || { success: true, txHash: '0xabcd...' }
-  const displayBlockExplorerUrl =
-    blockExplorerUrl || 'https://base-sepolia.blockscout.com/tx/0x...'
+  // Use real data when available
+  const displayRequest = request
+  const displayResponse = response
 
   return (
     <div
@@ -238,8 +239,35 @@ function ActivityLogItem({
             </div>
           </div>
 
-          {/* Right side: Clock icon + Chevron toggle */}
-          <div className="flex items-center gap-1">
+          {/* Right side: Block Explorer link, Clock icon - aligned with top row */}
+          <div
+            className="flex items-center gap-0.5"
+            style={{ marginTop: '1px', marginRight: '-2px' }}
+          >
+            {blockExplorerUrl && (
+              <a
+                href={blockExplorerUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex-shrink-0 hover:bg-gray-100 rounded transition-all"
+                style={{ color: '#9CA3AF', padding: '2px' }}
+                title="View on Block Explorer"
+              >
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <path d="M7 17L17 7"></path>
+                  <path d="M7 7h10v10"></path>
+                </svg>
+              </a>
+            )}
             {isFromPreviousSession && (
               <svg
                 width="14"
@@ -255,7 +283,8 @@ function ActivityLogItem({
                 <polyline points="12 6 12 12 16 14"></polyline>
               </svg>
             )}
-            <button
+            {/* TODO: Re-enable expand button in next PR when request/response data is improved */}
+            {/* <button
               className="flex-shrink-0 p-1 hover:bg-gray-100 rounded transition-all"
               style={{ color: '#9CA3AF' }}
               onClick={() => setIsExpanded(!isExpanded)}
@@ -276,7 +305,7 @@ function ActivityLogItem({
               >
                 <path d="M6 9l6 6 6-6"></path>
               </svg>
-            </button>
+            </button> */}
           </div>
         </div>
       </div>
@@ -294,28 +323,30 @@ function ActivityLogItem({
             </div>
           )}
 
-          {/* Request */}
-          <div>
-            <div
-              className="text-xs font-semibold mb-1"
-              style={{ color: '#6B7280' }}
-            >
-              Request
+          {/* Params */}
+          {displayRequest && (
+            <div>
+              <div
+                className="text-xs font-semibold mb-1"
+                style={{ color: '#6B7280' }}
+              >
+                Params
+              </div>
+              <pre
+                className="text-xs p-2 rounded overflow-x-auto"
+                style={{
+                  backgroundColor: '#1F2937',
+                  color: '#D1D5DB',
+                  fontFamily: 'monospace',
+                }}
+              >
+                {JSON.stringify(displayRequest, null, 2)}
+              </pre>
             </div>
-            <pre
-              className="text-xs p-2 rounded overflow-x-auto"
-              style={{
-                backgroundColor: '#1F2937',
-                color: '#D1D5DB',
-                fontFamily: 'monospace',
-              }}
-            >
-              {JSON.stringify(displayRequest, null, 2)}
-            </pre>
-          </div>
+          )}
 
           {/* Response */}
-          {status === 'confirmed' && (
+          {status === 'confirmed' && displayResponse && (
             <div>
               <div
                 className="text-xs font-semibold mb-1"
@@ -340,7 +371,7 @@ function ActivityLogItem({
           {status === 'confirmed' && blockExplorerUrl && (
             <div>
               <a
-                href={displayBlockExplorerUrl}
+                href={blockExplorerUrl}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-xs flex items-center gap-1 hover:underline"

--- a/packages/demo/frontend/src/components/ActivityLogItem.tsx
+++ b/packages/demo/frontend/src/components/ActivityLogItem.tsx
@@ -25,8 +25,8 @@ const TYPE_CONFIG = {
   },
   withdraw: {
     label: 'Lend',
-    bg: '#FEE2E2',
-    stroke: '#EF4444',
+    bg: '#DBEAFE',
+    stroke: '#3B82F6',
   },
   fund: {
     label: 'Fund',

--- a/packages/demo/frontend/src/components/ActivityLogItem.tsx
+++ b/packages/demo/frontend/src/components/ActivityLogItem.tsx
@@ -24,7 +24,7 @@ const TYPE_CONFIG = {
     stroke: '#3B82F6',
   },
   withdraw: {
-    label: 'Withdraw',
+    label: 'Lend',
     bg: '#FEE2E2',
     stroke: '#EF4444',
   },

--- a/packages/demo/frontend/src/components/ActivityLogItem.tsx
+++ b/packages/demo/frontend/src/components/ActivityLogItem.tsx
@@ -173,7 +173,6 @@ function ActivityLogItem({
   request,
   response,
   blockExplorerUrl,
-  isTransaction,
   isFromPreviousSession,
 }: ActivityLogItemProps) {
   const [isExpanded, setIsExpanded] = useState(false)

--- a/packages/demo/frontend/src/components/ActivityLogItem.tsx
+++ b/packages/demo/frontend/src/components/ActivityLogItem.tsx
@@ -9,6 +9,8 @@ interface ActivityLogItemProps {
   request?: Record<string, unknown>
   response?: Record<string, unknown>
   blockExplorerUrl?: string
+  isTransaction?: boolean
+  isFromPreviousSession?: boolean
 }
 
 const STATUS_CONFIG = {
@@ -171,6 +173,8 @@ function ActivityLogItem({
   request,
   response,
   blockExplorerUrl,
+  isTransaction,
+  isFromPreviousSession,
 }: ActivityLogItemProps) {
   const [isExpanded, setIsExpanded] = useState(false)
   const statusColor = STATUS_CONFIG[status]?.color || '#666666'
@@ -198,7 +202,12 @@ function ActivityLogItem({
         borderColor: '#E5E7EB',
       }}
     >
-      <div className="px-4 py-3 hover:bg-gray-50">
+      <div
+        className="px-4 py-3 hover:bg-gray-50"
+        style={{
+          opacity: isFromPreviousSession ? 0.6 : 1,
+        }}
+      >
         <div className="flex items-start justify-between gap-3">
           <div className="flex-1 min-w-0">
             {/* Top row: Label badge + Action description */}
@@ -230,29 +239,46 @@ function ActivityLogItem({
             </div>
           </div>
 
-          {/* Right side: Chevron toggle */}
-          <button
-            className="flex-shrink-0 p-1 hover:bg-gray-100 rounded transition-all"
-            style={{ color: '#9CA3AF' }}
-            onClick={() => setIsExpanded(!isExpanded)}
-          >
-            <svg
-              width="16"
-              height="16"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              style={{
-                transform: isExpanded ? 'rotate(180deg)' : 'rotate(0deg)',
-                transition: 'transform 0.2s',
-              }}
+          {/* Right side: Clock icon + Chevron toggle */}
+          <div className="flex items-center gap-1">
+            {isTransaction && (
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="#9CA3AF"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <circle cx="12" cy="12" r="10"></circle>
+                <polyline points="12 6 12 12 16 14"></polyline>
+              </svg>
+            )}
+            <button
+              className="flex-shrink-0 p-1 hover:bg-gray-100 rounded transition-all"
+              style={{ color: '#9CA3AF' }}
+              onClick={() => setIsExpanded(!isExpanded)}
             >
-              <path d="M6 9l6 6 6-6"></path>
-            </svg>
-          </button>
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                style={{
+                  transform: isExpanded ? 'rotate(180deg)' : 'rotate(0deg)',
+                  transition: 'transform 0.2s',
+                }}
+              >
+                <path d="M6 9l6 6 6-6"></path>
+              </svg>
+            </button>
+          </div>
         </div>
       </div>
 

--- a/packages/demo/frontend/src/components/Earn.tsx
+++ b/packages/demo/frontend/src/components/Earn.tsx
@@ -397,6 +397,14 @@ function EarnContent() {
             </div>
 
             <div className="space-y-6">
+              <Info />
+              <LentBalance
+                depositedAmount={depositedAmount}
+                apy={apy}
+                isLoadingPosition={isLoadingPosition}
+                isLoadingApy={isLoadingApy}
+                isInitialLoad={isInitialLoad}
+              />
               <Action
                 usdcBalance={usdcBalance}
                 isLoadingBalance={isLoadingBalance}
@@ -410,14 +418,6 @@ function EarnContent() {
                 }}
                 onPositionUpdate={handlePositionUpdate}
               />
-              <LentBalance
-                depositedAmount={depositedAmount}
-                apy={apy}
-                isLoadingPosition={isLoadingPosition}
-                isLoadingApy={isLoadingApy}
-                isInitialLoad={isInitialLoad}
-              />
-              <Info />
             </div>
           </div>
         </div>

--- a/packages/demo/frontend/src/components/Earn.tsx
+++ b/packages/demo/frontend/src/components/Earn.tsx
@@ -7,7 +7,6 @@ import {
   useSessionSigners,
   type WalletWithMetadata,
 } from '@privy-io/react-auth'
-import Info from './Info'
 import Action from './Action'
 import LentBalance from './LentBalance'
 import ActivityLog from './ActivityLog'
@@ -397,7 +396,6 @@ function EarnContent() {
             </div>
 
             <div className="space-y-6">
-              <Info />
               <LentBalance
                 depositedAmount={depositedAmount}
                 apy={apy}

--- a/packages/demo/frontend/src/components/Info.tsx
+++ b/packages/demo/frontend/src/components/Info.tsx
@@ -1,16 +1,14 @@
 function Info() {
   return (
     <div
-      className="w-full p-8"
+      className="w-full"
       style={{
         backgroundColor: '#FFFFFF',
-        border: '1px solid #E0E2EB',
-        borderRadius: '24px',
         fontFamily: 'Inter, system-ui, -apple-system, sans-serif',
       }}
     >
-      <h2 className="text-2xl font-semibold mb-6" style={{ color: '#1a1b1e' }}>
-        What's Happening Under the Hood
+      <h2 className="text-lg font-semibold mb-6" style={{ color: '#1a1b1e' }}>
+        Under the Hood
       </h2>
 
       <ul

--- a/packages/demo/frontend/src/components/Info.tsx
+++ b/packages/demo/frontend/src/components/Info.tsx
@@ -7,6 +7,9 @@ function Info() {
         fontFamily: 'Inter, system-ui, -apple-system, sans-serif',
       }}
     >
+      <h3 className="text-sm font-semibold mb-3" style={{ color: '#1a1b1e' }}>
+        What's happening?
+      </h3>
       <ul
         className="space-y-3 mb-8"
         style={{ color: '#000000', fontSize: '14px' }}

--- a/packages/demo/frontend/src/components/Info.tsx
+++ b/packages/demo/frontend/src/components/Info.tsx
@@ -7,10 +7,6 @@ function Info() {
         fontFamily: 'Inter, system-ui, -apple-system, sans-serif',
       }}
     >
-      <h2 className="text-lg font-semibold mb-6" style={{ color: '#1a1b1e' }}>
-        Under the Hood
-      </h2>
-
       <ul
         className="space-y-3 mb-8"
         style={{ color: '#000000', fontSize: '14px' }}

--- a/packages/demo/frontend/src/components/LentBalance.tsx
+++ b/packages/demo/frontend/src/components/LentBalance.tsx
@@ -113,6 +113,7 @@ function LentBalance({
                     fontSize: '12px',
                     fontWeight: 500,
                     fontFamily: 'Inter',
+                    minWidth: '100px',
                   }}
                 >
                   Value
@@ -141,7 +142,7 @@ function LentBalance({
                           fontFamily: 'Inter',
                         }}
                       >
-                        Gauntlet USDC
+                        Gauntlet
                       </span>
                     </div>
                   )}
@@ -194,7 +195,9 @@ function LentBalance({
                 </td>
                 <td style={{ padding: '16px 8px', textAlign: 'right' }}>
                   {isInitialLoad || isLoadingApy ? (
-                    <Shimmer width="50px" height="20px" borderRadius="4px" />
+                    <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+                      <Shimmer width="50px" height="20px" borderRadius="4px" />
+                    </div>
                   ) : (
                     <span
                       style={{
@@ -210,7 +213,9 @@ function LentBalance({
                 </td>
                 <td style={{ padding: '16px 8px', textAlign: 'right' }}>
                   {isInitialLoad || isLoadingPosition ? (
-                    <Shimmer width="70px" height="20px" borderRadius="4px" />
+                    <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+                      <Shimmer width="70px" height="20px" borderRadius="4px" />
+                    </div>
                   ) : (
                     <span
                       style={{

--- a/packages/demo/frontend/src/components/LentBalance.tsx
+++ b/packages/demo/frontend/src/components/LentBalance.tsx
@@ -16,7 +16,6 @@ function LentBalance({
   isLoadingApy,
   isInitialLoad = false,
 }: LentBalanceProps) {
-
   // Format deposited amount to 4 decimals and return parts
   const formatDepositedAmount = (amount: string) => {
     const num = parseFloat(amount)
@@ -195,7 +194,9 @@ function LentBalance({
                 </td>
                 <td style={{ padding: '16px 8px', textAlign: 'right' }}>
                   {isInitialLoad || isLoadingApy ? (
-                    <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+                    <div
+                      style={{ display: 'flex', justifyContent: 'flex-end' }}
+                    >
                       <Shimmer width="50px" height="20px" borderRadius="4px" />
                     </div>
                   ) : (
@@ -213,7 +214,9 @@ function LentBalance({
                 </td>
                 <td style={{ padding: '16px 8px', textAlign: 'right' }}>
                   {isInitialLoad || isLoadingPosition ? (
-                    <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+                    <div
+                      style={{ display: 'flex', justifyContent: 'flex-end' }}
+                    >
                       <Shimmer width="70px" height="20px" borderRadius="4px" />
                     </div>
                   ) : (

--- a/packages/demo/frontend/src/components/LentBalance.tsx
+++ b/packages/demo/frontend/src/components/LentBalance.tsx
@@ -16,6 +16,7 @@ function LentBalance({
   isLoadingApy,
   isInitialLoad = false,
 }: LentBalanceProps) {
+
   // Format deposited amount to 4 decimals and return parts
   const formatDepositedAmount = (amount: string) => {
     const num = parseFloat(amount)

--- a/packages/demo/frontend/src/contexts/ActivityLogContext.tsx
+++ b/packages/demo/frontend/src/contexts/ActivityLogContext.tsx
@@ -14,6 +14,9 @@ export type ActivityEntry = {
   amount?: string
   timestamp: string
   status: 'pending' | 'confirmed' | 'error'
+  request?: Record<string, unknown>
+  response?: Record<string, unknown>
+  blockExplorerUrl?: string
 }
 
 type ActivityLogContextType = {

--- a/packages/demo/frontend/src/contexts/ActivityLogContext.tsx
+++ b/packages/demo/frontend/src/contexts/ActivityLogContext.tsx
@@ -57,14 +57,16 @@ export function ActivityLogProvider({ children }: { children: ReactNode }) {
       return []
     }
   })
-  const nextIdRef = useRef((() => {
-    try {
-      const stored = localStorage.getItem(NEXT_ID_KEY)
-      return stored ? parseInt(stored, 10) : 1
-    } catch {
-      return 1
-    }
-  })())
+  const nextIdRef = useRef(
+    (() => {
+      try {
+        const stored = localStorage.getItem(NEXT_ID_KEY)
+        return stored ? parseInt(stored, 10) : 1
+      } catch {
+        return 1
+      }
+    })(),
+  )
   const activityKeysRef = useRef<Map<string, number>>(new Map())
 
   // Sync transaction activities to localStorage whenever they change

--- a/packages/demo/frontend/src/hooks/useLoggedActionsApi.ts
+++ b/packages/demo/frontend/src/hooks/useLoggedActionsApi.ts
@@ -49,6 +49,7 @@ export function useLoggedActionsApi() {
               action: config.action,
               amount,
               status: 'pending',
+              isTransaction: false,
             })
 
             try {
@@ -76,6 +77,7 @@ export function useLoggedActionsApi() {
               action: config.action,
               amount,
               status: 'pending',
+              isTransaction: true,
             })
             activeCallsMap.set(callKey, id)
           } else {

--- a/packages/demo/frontend/src/hooks/useLoggedActionsApi.ts
+++ b/packages/demo/frontend/src/hooks/useLoggedActionsApi.ts
@@ -39,6 +39,9 @@ export function useLoggedActionsApi() {
             ? config.getAmount(...args)
             : undefined
 
+          // Console log the function call
+          console.log(`[${config.apiMethod}]`)
+
           // For read-only operations, always create a new entry (no retry logic)
           if (config.isReadOnly) {
             const id = addActivityRef.current({

--- a/packages/demo/frontend/src/hooks/useLoggedActionsApi.ts
+++ b/packages/demo/frontend/src/hooks/useLoggedActionsApi.ts
@@ -55,7 +55,25 @@ export function useLoggedActionsApi() {
             try {
               // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
               const result = await (original as Function).apply(target, args)
-              updateActivityRef.current(id, { status: 'confirmed' })
+
+              // Map params based on the method
+              let sdkParams
+              if (prop === 'getPosition') {
+                // getPosition(marketId, walletId) -> wallet.lend.getPosition({ marketId })
+                sdkParams = { marketId: args[0] }
+              } else if (prop === 'getMarkets') {
+                // getMarkets() -> actions.lend.getMarkets()
+                sdkParams = undefined
+              } else if (prop === 'getWalletBalance') {
+                // getWalletBalance(userId) -> wallet.getBalance()
+                sdkParams = undefined
+              }
+
+              updateActivityRef.current(id, {
+                status: 'confirmed',
+                response: result,
+                request: sdkParams,
+              })
               return result
             } catch (error) {
               updateActivityRef.current(id, { status: 'error' })
@@ -93,9 +111,65 @@ export function useLoggedActionsApi() {
 
             // Update with actual amount from result if available
             const finalAmount = result?.amount || amount
+
+            // Extract blockExplorerUrl from transaction response
+            let blockExplorerUrl: string | undefined
+            if (result?.transaction?.blockExplorerUrls) {
+              blockExplorerUrl = result.transaction.blockExplorerUrls[0]
+            } else if (result?.blockExplorerUrls) {
+              blockExplorerUrl = result.blockExplorerUrls[0]
+            }
+
+            // Map backend params to SDK function signatures
+            let sdkParams: Record<string, unknown> | undefined
+            let sdkResponse: Record<string, unknown> | undefined
+
+            switch (prop) {
+              case 'openLendPosition':
+              case 'closeLendPosition':
+                // Backend params: (walletId, amount, tokenAddress, marketId)
+                // SDK signature: wallet.lend.openPosition({ amount, asset, marketId })
+                sdkParams = {
+                  amount: args[1],
+                  asset: {
+                    address: { [args[3]?.chainId]: args[2] },
+                    metadata: { symbol: 'USDC' }, // TODO: get from result
+                  },
+                  marketId: args[3],
+                }
+                // Backend returns: { transaction: { transactionHashes, userOpHash, blockExplorerUrls, amount, tokenAddress, marketId } }
+                // SDK returns: { transactionHash, userOpHash, ... } (LendTransactionReceipt)
+                sdkResponse = result?.transaction
+                  ? {
+                      transactionHash:
+                        result.transaction.transactionHashes?.[0],
+                      userOpHash: result.transaction.userOpHash,
+                    }
+                  : undefined
+                break
+
+              case 'fundWallet':
+                // Backend params: (userId)
+                // SDK signature: wallet.fund()
+                sdkParams = undefined
+                // Backend returns: { success, to, amount, transactionHashes, userOpHash, blockExplorerUrls }
+                sdkResponse = {
+                  transactionHash: result?.transactionHashes?.[0],
+                  userOpHash: result?.userOpHash,
+                }
+                break
+
+              default:
+                sdkParams = undefined
+                sdkResponse = undefined
+            }
+
             updateActivityRef.current(id, {
               status: 'confirmed',
               amount: finalAmount,
+              response: sdkResponse || result,
+              request: sdkParams,
+              blockExplorerUrl,
             })
 
             // Clear the active call since it succeeded


### PR DESCRIPTION
- [x] Move "under the hood" to the top
- [x] put the market balances section after under the hood 
- [x] Replace the diagonal arrow button in activity log items with one that opens up the item as an accordion. Add request + response json info in code blocks to this new details pane. if there's an associated block explorer link, include it.
- [x] Add activity log request info to console log as well for snooping devs.
- [x] Save activity logs to the user's localStorage
- [x] Replace “Withdraw” label with “Lend” in activity log
- [x] Call it "Developer Activity Log"
- [x] Add tool tip on hover of activity log functions that embeds info like "Actions SDK function that returns a wallet's market positions".
- [x] “Welcome to actions demo modal” can be removed.
- [x] Remove “Demo” from Demo APY
- [x] APY tooltip should define APY
- [x] Make Max button amount rounded to the nearest 2 decimals
- [x]  bug where we tried to withdraw too close to the max. https://base-sepolia.blockscout.com/address/0xA0bdfCC571053e2dDdd0Cb673F4b7B568561b411?tab=user_ops
- [x] Make interest increase in real time by polling getMarket, but do not include this polling in the activity log.