### PR TITLE
refactor: deduplicate earn component

### DIFF
--- a/packages/demo/backend/src/controllers/lend.ts
+++ b/packages/demo/backend/src/controllers/lend.ts
@@ -4,6 +4,7 @@ import type { Address } from 'viem'
 import { z } from 'zod'
 
 import type { AuthContext } from '@/middleware/auth.js'
+import { serializeBigInt } from '@/utils/serializers.js'
 
 import { validateRequest } from '../helpers/validation.js'
 import * as lendService from '../services/lend.js'
@@ -11,6 +12,36 @@ import * as lendService from '../services/lend.js'
 const OpenPositionRequestSchema = z.object({
   body: z.object({
     walletId: z.string().min(1, 'walletId is required'),
+    amount: z.number().positive('amount must be positive'),
+    tokenAddress: z
+      .string()
+      .regex(/^0x[a-fA-F0-9]{40}$/, 'Invalid token address format'),
+    marketId: z.object({
+      address: z
+        .string()
+        .regex(/^0x[a-fA-F0-9]{40}$/, 'Invalid market address format'),
+      chainId: z.number().positive('chainId must be positive'),
+    }),
+  }),
+})
+
+const OpenPositionV1RequestSchema = z.object({
+  body: z.object({
+    amount: z.number().positive('amount must be positive'),
+    tokenAddress: z
+      .string()
+      .regex(/^0x[a-fA-F0-9]{40}$/, 'Invalid token address format'),
+    marketId: z.object({
+      address: z
+        .string()
+        .regex(/^0x[a-fA-F0-9]{40}$/, 'Invalid market address format'),
+      chainId: z.number().positive('chainId must be positive'),
+    }),
+  }),
+})
+
+const ClosePositionV1RequestSchema = z.object({
+  body: z.object({
     amount: z.number().positive('amount must be positive'),
     tokenAddress: z
       .string()
@@ -60,6 +91,24 @@ export async function getMarkets(c: Context) {
       markets.map((market) => lendService.formatMarketResponse(market)),
     )
     return c.json({ markets: formattedMarkets })
+  } catch (error) {
+    return c.json(
+      {
+        error: 'Failed to get markets',
+        message: error instanceof Error ? error.message : 'Unknown error',
+      },
+      500,
+    )
+  }
+}
+
+/**
+ * GET - Retrieve all available lending markets
+ */
+export async function getMarketsV1(c: Context) {
+  try {
+    const markets = await lendService.getMarkets()
+    return c.json({ result: serializeBigInt(markets) })
   } catch (error) {
     return c.json(
       {
@@ -139,6 +188,50 @@ export async function getPosition(c: Context) {
 }
 
 /**
+ *
+ */
+export async function openPositionV1(c: Context) {
+  try {
+    const validation = await validateRequest(c, OpenPositionV1RequestSchema)
+    if (!validation.success) return validation.response
+
+    const {
+      body: { amount, tokenAddress, marketId },
+    } = validation.data
+    const auth = c.get('auth') as AuthContext | undefined
+    if (!auth || !auth.userId) {
+      return c.json({ error: 'Unauthorized' }, 401)
+    }
+
+    const result = await lendService.openPositionV1({
+      userId: auth.userId,
+      amount,
+      tokenAddress: tokenAddress as Address,
+      marketId: {
+        address: marketId.address as Address,
+        chainId: marketId.chainId as SupportedChainId,
+      },
+      isUserWallet: Boolean(auth?.userId),
+    })
+
+    return c.json({ result: serializeBigInt(result) })
+  } catch (error) {
+    console.error('[openPositionV1] ERROR:', {
+      error,
+      message: error instanceof Error ? error.message : 'Unknown error',
+      stack: error instanceof Error ? error.stack : undefined,
+    })
+    return c.json(
+      {
+        error: 'Failed to open position',
+        message: error instanceof Error ? error.message : 'Unknown error',
+      },
+      500,
+    )
+  }
+}
+
+/**
  * POST - Open a lending position
  */
 export async function openPosition(c: Context) {
@@ -174,6 +267,50 @@ export async function openPosition(c: Context) {
     return c.json(
       {
         error: 'Failed to open position',
+        message: error instanceof Error ? error.message : 'Unknown error',
+      },
+      500,
+    )
+  }
+}
+
+/**
+ * POST - Close a lending position
+ */
+export async function closePositionV1(c: Context) {
+  try {
+    const validation = await validateRequest(c, ClosePositionV1RequestSchema)
+    if (!validation.success) return validation.response
+
+    const {
+      body: { amount, tokenAddress, marketId },
+    } = validation.data
+    const auth = c.get('auth') as AuthContext | undefined
+    if (!auth || !auth.userId) {
+      return c.json({ error: 'Unauthorized' }, 401)
+    }
+
+    const result = await lendService.closePositionV1({
+      userId: auth.userId,
+      amount,
+      tokenAddress: tokenAddress as Address,
+      marketId: {
+        address: marketId.address as Address,
+        chainId: marketId.chainId as SupportedChainId,
+      },
+      isUserWallet: Boolean(auth?.userId),
+    })
+
+    return c.json({ result: serializeBigInt(result) })
+  } catch (error) {
+    console.error('[closePosition] ERROR:', {
+      error,
+      message: error instanceof Error ? error.message : 'Unknown error',
+      stack: error instanceof Error ? error.stack : undefined,
+    })
+    return c.json(
+      {
+        error: 'Failed to close position',
         message: error instanceof Error ? error.message : 'Unknown error',
       },
       500,

--- a/packages/demo/backend/src/controllers/wallet.ts
+++ b/packages/demo/backend/src/controllers/wallet.ts
@@ -1,5 +1,6 @@
+import type { SupportedChainId } from '@eth-optimism/actions-sdk'
 import type { Context } from 'hono'
-import type { Address } from 'viem'
+import { type Address } from 'viem'
 import { z } from 'zod'
 
 import type { AuthContext } from '@/middleware/auth.js'
@@ -16,6 +17,15 @@ import { serializeBigInt } from '../utils/serializers.js'
 const UserIdParamSchema = z.object({
   params: z.object({
     userId: z.string().min(1, 'User ID is required').trim(),
+  }),
+})
+
+const LendPositionRequestSchema = z.object({
+  params: z.object({
+    chainId: z.string().min(1, 'chainId is required'),
+    marketAddress: z
+      .string()
+      .regex(/^0x[a-fA-F0-9]{40}$/, 'Invalid market address format'),
   }),
 })
 
@@ -191,6 +201,63 @@ export class WalletController {
         500,
       )
     }
+  }
+
+  /**
+   * GET - Get wallet balance by user ID
+   */
+  async getBalanceV1(c: Context) {
+    try {
+      const auth = c.get('auth') as AuthContext | undefined
+
+      if (!auth || !auth.userId) {
+        return c.json({ error: 'Unauthorized' }, 401)
+      }
+
+      const wallet = await walletService.getWallet(auth.userId, true)
+      if (!wallet) {
+        throw new Error('Wallet not found')
+      }
+      const balance = await walletService.getWalletBalance(wallet)
+      return c.json({ result: serializeBigInt(balance) })
+    } catch (error) {
+      console.error(error)
+      return c.json(
+        {
+          error: 'Failed to get balance',
+          message: error instanceof Error ? error.message : 'Unknown error',
+        },
+        500,
+      )
+    }
+  }
+
+  /**
+   * GET - Lend position for a wallet
+   */
+  async getLendPosition(c: Context) {
+    const validation = await validateRequest(c, LendPositionRequestSchema)
+    if (!validation.success) return validation.response
+    const {
+      params: { marketAddress, chainId },
+    } = validation.data
+    const marketId = {
+      address: marketAddress as Address,
+      chainId: Number(chainId) as SupportedChainId,
+    }
+
+    const auth = c.get('auth') as AuthContext | undefined
+
+    if (!auth || !auth.userId) {
+      return c.json({ error: 'Unauthorized' }, 401)
+    }
+
+    const wallet = await walletService.getWallet(auth.userId, true)
+    if (!wallet) {
+      throw new Error('Wallet not found')
+    }
+    const position = await walletService.getLendPosition({ marketId, wallet })
+    return c.json({ result: serializeBigInt(position) })
   }
 
   /**

--- a/packages/demo/backend/src/router.ts
+++ b/packages/demo/backend/src/router.ts
@@ -42,6 +42,14 @@ router.get('/version', (c) => {
 // router.post('/wallet/:userId', authMiddleware, walletController.createWallet)
 
 router.get('/wallets', walletController.getAllWallets)
+router.get('/wallet/balance', authMiddleware, walletController.getBalanceV1)
+router.post('/wallet/send', walletController.sendTokens)
+router.get(
+  '/wallet/lend/:chainId/:marketAddress/position',
+  authMiddleware,
+  walletController.getLendPosition,
+)
+// Parameterized routes
 router.post('/wallet/:userId', walletController.createWallet)
 router.get('/wallet/:userId', authMiddleware, walletController.getWallet)
 router.get(
@@ -50,10 +58,10 @@ router.get(
   walletController.getBalance,
 )
 router.post('/wallet/:userId/fund', authMiddleware, walletController.fundWallet)
-router.post('/wallet/send', walletController.sendTokens)
 
 // Lend endpoints
 router.get('/lend/markets', lendController.getMarkets)
+router.get('/v1/lend/markets', lendController.getMarketsV1)
 router.get('/lend/market/:chainId/:marketAddress', lendController.getMarket)
 router.get(
   '/lend/market/:chainId/:marketAddress/position/:walletId',
@@ -61,7 +69,17 @@ router.get(
 )
 router.post('/lend/position/open', authMiddleware, lendController.openPosition)
 router.post(
+  '/v1/lend/position/open',
+  authMiddleware,
+  lendController.openPositionV1,
+)
+router.post(
   '/lend/position/close',
   authMiddleware,
   lendController.closePosition,
+)
+router.post(
+  '/v1/lend/position/close',
+  authMiddleware,
+  lendController.closePositionV1,
 )

--- a/packages/demo/backend/src/services/wallet.ts
+++ b/packages/demo/backend/src/services/wallet.ts
@@ -1,9 +1,11 @@
 import type {
   EOATransactionReceipt,
+  LendMarketId,
   SmartWallet,
   TokenBalance,
   TransactionData,
   UserOperationTransactionReceipt,
+  Wallet,
 } from '@eth-optimism/actions-sdk'
 import {
   getAssetAddress,
@@ -151,6 +153,18 @@ export async function getBalance(userId: string): Promise<TokenBalance[]> {
   return getWalletBalance(wallet)
 }
 
+export async function getWalletBalanceV1(
+  wallet: SmartWallet,
+): Promise<TokenBalance[]> {
+  // Get regular token balances
+  const tokenBalances = await wallet.getBalance().catch((error) => {
+    console.error(error)
+    throw error
+  })
+
+  return tokenBalances
+}
+
 export async function getWalletBalance(
   wallet: SmartWallet,
 ): Promise<TokenBalance[]> {
@@ -215,6 +229,16 @@ export async function getWalletBalance(
     // Return just token balances if vault balance fetching fails
     return tokenBalances
   }
+}
+
+export async function getLendPosition({
+  wallet,
+  marketId,
+}: {
+  marketId: LendMarketId
+  wallet: Wallet
+}) {
+  return wallet.lend!.getPosition({ marketId })
 }
 
 export async function fundWallet(wallet: SmartWallet): Promise<{

--- a/packages/demo/frontend/src/components/ActivityLogItem.tsx
+++ b/packages/demo/frontend/src/components/ActivityLogItem.tsx
@@ -64,7 +64,21 @@ export const ACTIVITY_CONFIG: Record<string, ActivityConfigEntry> = {
     apiMethod: 'actions.lend.getMarket()',
     isReadOnly: true,
   },
+  getMarketsV1: {
+    type: 'lend',
+    action: 'getMarket',
+    description: 'Get market',
+    apiMethod: 'actions.lend.getMarket()',
+    isReadOnly: true,
+  },
   getPosition: {
+    type: 'lend',
+    action: 'getPosition',
+    description: 'Get position',
+    apiMethod: 'wallet.lend.getPosition()',
+    isReadOnly: true,
+  },
+  getPositionV1: {
     type: 'lend',
     action: 'getPosition',
     description: 'Get position',
@@ -78,9 +92,23 @@ export const ACTIVITY_CONFIG: Record<string, ActivityConfigEntry> = {
     apiMethod: 'wallet.lend.openPosition()',
     getAmount: (_walletId: string, amount: number) => amount.toString(),
   },
+  openLendPositionV1: {
+    type: 'lend',
+    action: 'deposit',
+    description: 'Open lending position',
+    apiMethod: 'wallet.lend.openPosition()',
+    getAmount: (_walletId: string, amount: number) => amount.toString(),
+  },
 
   // Withdraw operations
   closeLendPosition: {
+    type: 'withdraw',
+    action: 'withdraw',
+    description: 'Close lending position',
+    apiMethod: 'wallet.lend.closePosition()',
+    getAmount: (_walletId: string, amount: number) => amount.toString(),
+  },
+  closeLendPositionV1: {
     type: 'withdraw',
     action: 'withdraw',
     description: 'Close lending position',
@@ -99,6 +127,13 @@ export const ACTIVITY_CONFIG: Record<string, ActivityConfigEntry> = {
 
   // Wallet operations
   getWalletBalance: {
+    type: 'wallet',
+    action: 'getBalance',
+    description: 'Get wallet balance',
+    apiMethod: 'wallet.getBalance()',
+    isReadOnly: true,
+  },
+  getWalletBalanceV1: {
     type: 'wallet',
     action: 'getBalance',
     description: 'Get wallet balance',

--- a/packages/demo/frontend/src/components/EarnWithDynamicWallet.tsx
+++ b/packages/demo/frontend/src/components/EarnWithDynamicWallet.tsx
@@ -1,11 +1,17 @@
 import { useDynamicWallet } from '@/hooks/useDynamicWallet'
 import { EarnWithFrontendWallet } from './EarnWithFrontendWallet'
-import { useDynamicContext } from '@dynamic-labs/sdk-react-core'
+import { useDynamicContext, useIsLoggedIn } from '@dynamic-labs/sdk-react-core'
 import { WALLET_PROVIDER_CONFIGS } from '@/constants/walletProviders'
+import { LoginWithDynamic } from './LoginWithDynamic'
 
 export function EarnWithDynamicWallet() {
   const { smartWallet } = useDynamicWallet()
   const { handleLogOut } = useDynamicContext()
+  const isLoggedIn = useIsLoggedIn()
+
+  if (!isLoggedIn) {
+    return <LoginWithDynamic />
+  }
 
   return (
     <EarnWithFrontendWallet

--- a/packages/demo/frontend/src/components/EarnWithFrontendWallet.tsx
+++ b/packages/demo/frontend/src/components/EarnWithFrontendWallet.tsx
@@ -1,29 +1,14 @@
-import { useIsLoggedIn } from '@dynamic-labs/sdk-react-core'
-import { LoginWithDynamic } from './LoginWithDynamic'
 import { useActions } from '@/hooks/useActions'
-import { useCallback, useEffect, useRef, useState } from 'react'
-import type { Address } from 'viem'
-import { encodeFunctionData, formatUnits } from 'viem'
-import {
-  getAssetAddress,
-  getTokenBySymbol,
-  SUPPORTED_TOKENS,
-} from '@eth-optimism/actions-sdk/react'
-import type {
-  EOATransactionReceipt,
-  LendMarket,
-  LendMarketPosition,
-  LendTransactionReceipt,
-  SupportedChainId,
-  TokenBalance,
-  UserOperationTransactionReceipt,
-  Wallet,
-} from '@eth-optimism/actions-sdk/react'
+import { encodeFunctionData } from 'viem'
+import { getTokenBySymbol } from '@eth-optimism/actions-sdk/react'
+import type { LendMarketId, Wallet } from '@eth-optimism/actions-sdk/react'
 import { mintableErc20Abi } from '@/abis/mintableErc20Abi'
-import { baseSepolia, chainById, unichain } from '@eth-optimism/viem/chains'
+import { baseSepolia } from '@eth-optimism/viem/chains'
 import Earn from './Earn'
-import { USDCDemoVault } from '@/constants/markets'
 import type { WalletProviderConfig } from '@/constants/walletProviders'
+import { useBalanceOperations } from '@/hooks/useBalanceOperations'
+import { useCallback } from 'react'
+import type { LendExecutePositionParams } from '@/types/api'
 
 export interface EarnWithFrontendWalletProps {
   wallet: Wallet | null
@@ -36,376 +21,68 @@ export function EarnWithFrontendWallet({
   selectedProvider,
   logout,
 }: EarnWithFrontendWalletProps) {
-  const isLoggedIn = useIsLoggedIn()
   const { actions } = useActions()
 
-  const [usdcBalance, setUsdcBalance] = useState<string>('0')
-  const [isLoadingBalance, setIsLoadingBalance] = useState(false)
-  const [walletCreated, setWalletCreated] = useState(false)
-  const [depositedAmount, setDepositedAmount] = useState<string | null>(null)
-  const [apy, setApy] = useState<number | null>(null)
-  const [isLoadingPosition, setIsLoadingPosition] = useState(false)
-  const [isLoadingApy, setIsLoadingApy] = useState(true)
-  const [isInitialLoad, setIsInitialLoad] = useState(true)
-  // Market data for transactions
-  const [marketData, setMarketData] = useState<{
-    marketId: { chainId: SupportedChainId; address: Address }
-    assetAddress: Address
-  } | null>(null)
-  const hasInitiatedMarketFetch = useRef(false)
-
-  const marketChainId = marketData?.marketId.chainId
-  const marketAddress = marketData?.marketId.address
-
-  // Function to fetch wallet balance
-  const fetchBalance = useCallback(async () => {
-    if (!wallet) {
-      return
-    }
-    try {
-      setIsLoadingBalance(true)
-      const tokenBalances = await wallet.getBalance()
-      const vaults = await actions.lend.getMarkets()
-
-      const vaultBalances = await Promise.all(
-        vaults.map(async (vault) => {
-          try {
-            const vaultBalance = await wallet.lend!.getPosition({
-              marketId: vault.marketId,
-            })
-
-            // Only include vaults with non-zero balances
-            if (vaultBalance.balance > 0n) {
-              // Create a TokenBalance object for the vault
-              const formattedBalance = formatUnits(vaultBalance.balance, 6) // Assuming 6 decimals for vault shares
-
-              // Get asset address for the vault's chain
-              const assetAddress = getAssetAddress(
-                vault.asset,
-                vault.marketId.chainId,
-              )
-
-              return {
-                symbol: `${vault.name}`,
-                totalBalance: vaultBalance.balance,
-                totalFormattedBalance: formattedBalance,
-                chainBalances: [
-                  {
-                    chainId: vaultBalance.marketId.chainId,
-                    balance: vaultBalance.balance,
-                    tokenAddress: assetAddress,
-                    formattedBalance: formattedBalance,
-                  },
-                ],
-              } as TokenBalance
-            }
-            return null
-          } catch (error) {
-            console.error(error)
-            return null
-          }
+  // Memoize operation functions to prevent infinite loops
+  const getTokenBalances = useCallback(
+    async () => wallet!.getBalance(),
+    [wallet],
+  )
+  const getMarkets = useCallback(
+    async () => actions.lend.getMarkets(),
+    [actions],
+  )
+  const getPosition = useCallback(
+    async (marketId: LendMarketId) => wallet!.lend!.getPosition({ marketId }),
+    [wallet],
+  )
+  const mintUSDC = useCallback(async () => {
+    const walletAddress = wallet!.address
+    const amountInDecimals = BigInt(Math.floor(parseFloat('100') * 1000000))
+    const calls = [
+      {
+        to: getTokenBySymbol('USDC_DEMO')!.address[baseSepolia.id]!,
+        data: encodeFunctionData({
+          abi: mintableErc20Abi,
+          functionName: 'mint',
+          args: [walletAddress, amountInDecimals],
         }),
-      )
-
-      const validVaultBalances = vaultBalances.filter(
-        (balance): balance is NonNullable<typeof balance> => balance !== null,
-      )
-
-      const balanceResult = {
-        balance: [...tokenBalances, ...validVaultBalances],
-      }
-
-      // Find USDC balance (try USDC_DEMO first not USDC)
-      const usdcToken = balanceResult.balance.find(
-        (token) => token.symbol === 'USDC_DEMO',
-      )
-
-      if (usdcToken && usdcToken.totalBalance > 0) {
-        // Parse the balance (it's in smallest unit, divide by 1e6 for USDC)
-        const balance = parseFloat(`${usdcToken.totalBalance}`) / 1e6
-        // Floor to 2 decimals to ensure we never try to send more than we have
-        const flooredBalance = Math.floor(balance * 100) / 100
-        setUsdcBalance(flooredBalance.toFixed(2))
-      } else {
-        setUsdcBalance('0.00')
-      }
-    } catch {
-      setUsdcBalance('0.00')
-    } finally {
-      setIsLoadingBalance(false)
-    }
-  }, [wallet, actions])
-
-  const handleMintUSDC = useCallback(async () => {
-    if (!wallet) return
-
-    try {
-      setIsLoadingBalance(true)
-      const walletAddress = wallet.address
-      const amountInDecimals = BigInt(Math.floor(parseFloat('100') * 1000000))
-      const calls = [
-        {
-          to: getTokenBySymbol('USDC_DEMO')!.address[baseSepolia.id]!,
-          data: encodeFunctionData({
-            abi: mintableErc20Abi,
-            functionName: 'mint',
-            args: [walletAddress, amountInDecimals],
-          }),
-          value: 0n,
-        },
-      ]
-
-      await wallet.sendBatch(calls, baseSepolia.id)
-
-      // Transaction succeeded - optimistically update balance with the minted amount (100 USDC)
-      const currentBalance = parseFloat(usdcBalance)
-      const mintedAmount = 100
-      const newOptimisticBalance = (currentBalance + mintedAmount).toFixed(2)
-      setUsdcBalance(newOptimisticBalance)
-      setIsLoadingBalance(false)
-
-      // Fetch actual balance to verify/correct the optimistic update
-      const balanceResult = await wallet.getBalance()
-      const usdcToken = balanceResult.find(
-        (token) => token.symbol === 'USDC_DEMO',
-      )
-
-      if (usdcToken && usdcToken.totalBalance > 0) {
-        const actualBalance = parseFloat(`${usdcToken.totalBalance}`) / 1e6
-        const flooredBalance = Math.floor(actualBalance * 100) / 100
-        const actualBalanceStr = flooredBalance.toFixed(2)
-
-        // Only update if different from optimistic value
-        if (actualBalanceStr !== newOptimisticBalance) {
-          setUsdcBalance(actualBalanceStr)
-        }
-      }
-    } catch (error) {
-      console.error('Error minting USDC:', error)
-      setIsLoadingBalance(false)
-      await fetchBalance()
-    }
-  }, [wallet, fetchBalance])
-
-  // Fetch balance when user logs in
-  useEffect(() => {
-    const initializeWallet = async () => {
-      if (isLoggedIn && wallet && !walletCreated) {
-        try {
-          await fetchBalance()
-          setWalletCreated(true)
-        } catch (error) {
-          console.error('Error fetching balance:', error)
-        }
-      }
-    }
-
-    initializeWallet()
-  }, [isLoggedIn, wallet, walletCreated, fetchBalance])
-
-  // Fetch market APY and data on mount
-  useEffect(() => {
-    const fetchMarketApy = async () => {
-      // Skip if already initiated (prevents double-fetch in StrictMode)
-      if (hasInitiatedMarketFetch.current) {
-        console.log('[getMarkets] Skipping - already initiated')
-        return
-      }
-
-      hasInitiatedMarketFetch.current = true
-      console.log('[getMarkets] Fetching market data...')
-
-      try {
-        setIsLoadingApy(true)
-        const markets = await actions.lend.getMarkets()
-        const formattedMarkets = await Promise.all(
-          markets.map((market) => formatMarketResponse(market)),
-        )
-        const result = { markets: formattedMarkets }
-
-        const market = result.markets.find(
-          (market) =>
-            market.marketId.address === USDCDemoVault.address &&
-            market.marketId.chainId === USDCDemoVault.chainId,
-        )
-
-        if (market) {
-          setApy(market.apy.total)
-
-          // Store market data for transactions
-          const assetAddress = (market.asset.address[market.marketId.chainId] ||
-            Object.values(market.asset.address)[0]) as Address
-
-          setMarketData({
-            marketId: market.marketId,
-            assetAddress,
-          })
-        }
-      } catch {
-        // Error fetching market APY
-      } finally {
-        setIsLoadingApy(false)
-        setIsInitialLoad(false)
-      }
-    }
-
-    fetchMarketApy()
-  }, [
-    actions,
-    hasInitiatedMarketFetch,
-    setIsLoadingApy,
-    setIsInitialLoad,
-    setMarketData,
-    setApy,
-  ])
-
-  const fetchPosition = useCallback(
-    async (backgroundPolling: boolean = false) => {
-      if (!wallet || !marketChainId || !marketAddress) return
-
-      try {
-        if (!backgroundPolling) {
-          setIsLoadingPosition(true)
-        }
-        const balance = await wallet.lend!.getPosition({
-          marketId: {
-            chainId: marketData.marketId.chainId as SupportedChainId,
-            address: marketData.marketId.address,
-          },
-        })
-        const position = await formatMarketBalanceResponse(balance)
-        setDepositedAmount(position.balanceFormatted)
-      } catch {
-        // Silently fail polling - don't reset to 0.00
-        if (!backgroundPolling) {
-          setDepositedAmount('0.00')
-        }
-      } finally {
-        if (!backgroundPolling) {
-          setIsLoadingPosition(false)
-        }
-      }
-    },
-    [wallet, marketData],
+        value: 0n,
+      },
+    ]
+    await wallet!.sendBatch(calls, baseSepolia.id)
+  }, [wallet])
+  const openPosition = useCallback(
+    async (positionParams: LendExecutePositionParams) =>
+      wallet!.lend!.openPosition(positionParams),
+    [wallet],
   )
-
-  // Fetch position when market data is available or user changes
-  useEffect(() => {
-    if (wallet && marketChainId && marketAddress) {
-      fetchPosition()
-    }
-  }, [wallet, marketChainId, marketAddress])
-
-  useEffect(() => {
-    if (!wallet || !marketChainId || !marketAddress) return
-
-    const intervalId = setInterval(() => fetchPosition(true), 5000)
-    return () => clearInterval(intervalId)
-  }, [wallet, marketChainId, marketAddress])
-
-  const executePositon = useCallback(
-    async (operation: 'open' | 'close', amount: number) => {
-      if (!wallet || !marketData) {
-        throw new Error('User or market data not available')
-      }
-      const marketId = marketData.marketId
-      const tokenAddress = marketData.assetAddress
-
-      const asset = SUPPORTED_TOKENS.find(
-        (token) =>
-          token.address[marketId.chainId as SupportedChainId] === tokenAddress,
-      )
-      if (!asset) {
-        const error = `Asset not found for token address: ${tokenAddress}`
-        console.error('[executePosition] ERROR:', error)
-        throw new Error(error)
-      }
-
-      const positionParams = { amount, asset, marketId }
-
-      const result =
-        operation === 'open'
-          ? await wallet.lend!.openPosition(positionParams)
-          : await wallet.lend!.closePosition(positionParams)
-
-      const transactionHashes = isEOATransactionReceipt(result)
-        ? [result.transactionHash]
-        : isBatchEOATransactionReceipt(result)
-          ? result.map((receipt) => receipt.transactionHash)
-          : undefined
-
-      const userOpHash = isUserOperationTransactionReceipt(result)
-        ? result.userOpHash
-        : undefined
-
-      const blockExplorerUrls = await getBlockExplorerUrls(
-        marketId.chainId,
-        transactionHashes,
-        userOpHash,
-      )
-
-      const transaction = {
-        transactionHashes,
-        userOpHash,
-        blockExplorerUrls,
-        amount,
-        tokenAddress,
-        marketId,
-      }
-
-      return { transaction }
-    },
-    [wallet, marketData],
+  const closePosition = useCallback(
+    async (positionParams: LendExecutePositionParams) =>
+      wallet!.lend!.closePosition(positionParams),
+    [wallet],
   )
+  const isReady = useCallback(() => !!wallet, [wallet])
 
-  // Handle transaction (lend or withdraw)
-  const handleTransaction = useCallback(
-    async (mode: 'lend' | 'withdraw', amount: number) => {
-      if (!wallet || !marketData) {
-        throw new Error('User or market data not available')
-      }
-
-      const result =
-        mode === 'lend'
-          ? await executePositon('open', amount)
-          : await executePositon('close', amount)
-
-      // Get the first transaction hash if available, or use userOpHash for account abstraction
-      const txHash =
-        result.transaction.transactionHashes?.[0] ||
-        result.transaction.userOpHash
-
-      const explorerUrl = result.transaction.blockExplorerUrls?.[0]
-
-      // Refresh position after successful transaction with a small delay to ensure state is updated
-      setTimeout(async () => {
-        if (wallet && marketData) {
-          try {
-            await fetchPosition()
-          } catch {
-            setDepositedAmount('0.00')
-          }
-        }
-      }, 1000)
-
-      // Also refresh wallet balance
-      if (wallet) {
-        setTimeout(async () => {
-          await fetchBalance()
-        }, 2000)
-      }
-
-      return {
-        transactionHash: txHash,
-        blockExplorerUrl: explorerUrl,
-      }
-    },
-    [wallet, marketData, fetchBalance],
-  )
-
-  if (!isLoggedIn) {
-    return <LoginWithDynamic />
-  }
+  const {
+    usdcBalance,
+    isLoadingBalance,
+    handleMintUSDC,
+    isLoadingApy,
+    apy,
+    isInitialLoad,
+    isLoadingPosition,
+    depositedAmount,
+    handleTransaction,
+  } = useBalanceOperations({
+    getTokenBalances,
+    getMarkets,
+    getPosition,
+    mintUSDC,
+    openPosition,
+    closePosition,
+    isReady,
+  })
 
   return (
     <Earn
@@ -424,82 +101,4 @@ export function EarnWithFrontendWallet({
       onTransaction={handleTransaction}
     />
   )
-}
-
-async function formatMarketResponse(market: LendMarket) {
-  return {
-    marketId: market.marketId,
-    name: market.name,
-    asset: market.asset,
-    supply: {
-      totalAssets: formatUnits(
-        market.supply.totalAssets,
-        market.asset.metadata.decimals,
-      ),
-      totalShares: formatUnits(market.supply.totalShares, 18),
-    },
-    apy: market.apy,
-    metadata: market.metadata,
-  }
-}
-
-async function formatMarketBalanceResponse(
-  balance: LendMarketPosition,
-): Promise<{
-  balance: string
-  balanceFormatted: string
-  shares: string
-  sharesFormatted: string
-}> {
-  return {
-    balance: balance.balanceFormatted,
-    balanceFormatted: balance.balanceFormatted,
-    shares: balance.sharesFormatted,
-    sharesFormatted: balance.sharesFormatted,
-  }
-}
-
-function isEOATransactionReceipt(
-  receipt: LendTransactionReceipt,
-): receipt is EOATransactionReceipt {
-  return !Array.isArray(receipt) && !('userOpHash' in receipt)
-}
-
-function isBatchEOATransactionReceipt(
-  receipt: LendTransactionReceipt,
-): receipt is EOATransactionReceipt[] {
-  return Array.isArray(receipt)
-}
-
-function isUserOperationTransactionReceipt(
-  receipt: LendTransactionReceipt,
-): receipt is UserOperationTransactionReceipt {
-  return 'userOpHash' in receipt
-}
-
-async function getBlockExplorerUrls(
-  chainId: SupportedChainId,
-  transactionHashes?: string[],
-  userOpHash?: string,
-): Promise<string[]> {
-  const chain = chainById[chainId]
-  if (!chain) {
-    throw new Error(`Chain not found for chainId: ${chainId}`)
-  }
-
-  let url = `${chain.blockExplorers?.default.url}`
-  if (chain.id === unichain.id) {
-    url = `https://unichain.blockscout.com`
-  }
-  if (chain.id === baseSepolia.id) {
-    url = `https://base-sepolia.blockscout.com`
-  }
-
-  if (userOpHash) {
-    return [`${url}/op/${userOpHash}`]
-  }
-  if (!transactionHashes) {
-    throw new Error('Transaction hashes not found')
-  }
-  return transactionHashes.map((hash) => `${url}/tx/${hash}`)
 }

--- a/packages/demo/frontend/src/components/EarnWithServerWallet.tsx
+++ b/packages/demo/frontend/src/components/EarnWithServerWallet.tsx
@@ -1,9 +1,12 @@
-import { useState, useCallback, useEffect, useRef } from 'react'
-import type { Address } from 'viem'
+import { useState, useCallback, useEffect } from 'react'
+import { type Address } from 'viem'
 import { useLoggedActionsApi } from '../hooks/useLoggedActionsApi'
 import Earn from './Earn'
 import { actionsApi } from '@/api/actionsApi'
 import type { WalletProviderConfig } from '@/constants/walletProviders'
+import { type LendMarketId } from '@eth-optimism/actions-sdk/react'
+import { useBalanceOperations } from '@/hooks/useBalanceOperations'
+import type { LendExecutePositionParams } from '@/types/api'
 
 interface EarnWithServerWalletProps {
   ready: boolean
@@ -33,25 +36,78 @@ export function EarnWithServerWallet({
   const loggedApi = useLoggedActionsApi()
 
   // State for wallet balance and lend position
-  const [usdcBalance, setUsdcBalance] = useState<string>('0')
-  const [isLoadingBalance, setIsLoadingBalance] = useState(false)
-  const hasInitializedWallet = useRef(false)
-  const [depositedAmount, setDepositedAmount] = useState<string | null>(null)
-  const [apy, setApy] = useState<number | null>(null)
-  const [isLoadingPosition, setIsLoadingPosition] = useState(false)
-  const [isLoadingApy, setIsLoadingApy] = useState(true)
-  const [isInitialLoad, setIsInitialLoad] = useState(true)
   const [walletAddress, setWalletAddress] = useState<Address | null>(null)
 
-  // Market data for transactions
-  const [marketData, setMarketData] = useState<{
-    marketId: { chainId: number; address: Address }
-    assetAddress: Address
-  } | null>(null)
-  const hasInitiatedMarketFetch = useRef(false)
+  // Memoize operation functions to prevent infinite loops
+  const getTokenBalances = useCallback(async () => {
+    const headers = await getAuthHeaders()
+    return loggedApi.getWalletBalanceV1(headers)
+  }, [getAuthHeaders, loggedApi])
 
-  const marketChainId = marketData?.marketId.chainId
-  const marketAddress = marketData?.marketId.address
+  const getMarkets = useCallback(async () => {
+    const headers = await getAuthHeaders()
+    return loggedApi.getMarketsV1(headers)
+  }, [getAuthHeaders, loggedApi])
+
+  const getPosition = useCallback(
+    async (marketId: LendMarketId) => {
+      const headers = await getAuthHeaders()
+      return loggedApi.getPositionV1({ marketId }, headers)
+    },
+    [getAuthHeaders, loggedApi],
+  )
+
+  const getPositionSilent = useCallback(
+    async (marketId: LendMarketId) => {
+      const headers = await getAuthHeaders()
+      return actionsApi.getPositionV1({ marketId }, headers)
+    },
+    [getAuthHeaders],
+  )
+
+  const mintUSDC = useCallback(async () => {
+    const headers = await getAuthHeaders()
+    await loggedApi.fundWallet(userId!, headers)
+  }, [getAuthHeaders, loggedApi, userId])
+
+  const openPosition = useCallback(
+    async (positionParams: LendExecutePositionParams) => {
+      const headers = await getAuthHeaders()
+      return loggedApi.openLendPositionV1(positionParams, headers)
+    },
+    [getAuthHeaders, loggedApi],
+  )
+
+  const closePosition = useCallback(
+    async (positionParams: LendExecutePositionParams) => {
+      const headers = await getAuthHeaders()
+      return loggedApi.closeLendPositionV1(positionParams, headers)
+    },
+    [getAuthHeaders, loggedApi],
+  )
+
+  const isReady = useCallback(() => !!userId, [userId])
+
+  const {
+    usdcBalance,
+    isLoadingBalance,
+    handleMintUSDC,
+    isLoadingApy,
+    apy,
+    isInitialLoad,
+    isLoadingPosition,
+    depositedAmount,
+    handleTransaction,
+  } = useBalanceOperations({
+    getTokenBalances,
+    getMarkets,
+    getPosition,
+    getPositionSilent,
+    mintUSDC,
+    openPosition,
+    closePosition,
+    isReady,
+  })
 
   const fetchWalletAddress = useCallback(
     async (userId: string) => {
@@ -62,255 +118,11 @@ export function EarnWithServerWallet({
     [getAuthHeaders, loggedApi],
   )
 
-  // Function to fetch wallet balance
-  const fetchBalance = useCallback(
-    async (userId: string) => {
-      try {
-        setIsLoadingBalance(true)
-        const headers = await getAuthHeaders()
-        const balanceResult = await loggedApi.getWalletBalance(userId, headers)
-
-        // Find USDC balance (try USDC_DEMO first not USDC)
-        const usdcToken = balanceResult.balance.find(
-          (token) => token.symbol === 'USDC_DEMO',
-        )
-
-        if (usdcToken && parseFloat(usdcToken.totalBalance) > 0) {
-          // Parse the balance (it's in smallest unit, divide by 1e6 for USDC)
-          const balance = parseFloat(usdcToken.totalBalance) / 1e6
-          // Floor to 2 decimals to ensure we never try to send more than we have
-          const flooredBalance = Math.floor(balance * 100) / 100
-          setUsdcBalance(flooredBalance.toFixed(2))
-        } else {
-          setUsdcBalance('0.00')
-        }
-      } catch {
-        setUsdcBalance('0.00')
-      } finally {
-        setIsLoadingBalance(false)
-      }
-    },
-    [getAuthHeaders, loggedApi],
-  )
-
-  // Function to mint demo USDC
-  const handleMintUSDC = useCallback(async () => {
-    if (!userId) return
-
-    try {
-      setIsLoadingBalance(true)
-      const headers = await getAuthHeaders()
-      await loggedApi.fundWallet(userId, headers)
-
-      // Transaction succeeded - optimistically update balance with the minted amount (100 USDC)
-      const currentBalance = parseFloat(usdcBalance)
-      const mintedAmount = 100
-      const newOptimisticBalance = (currentBalance + mintedAmount).toFixed(2)
-      setUsdcBalance(newOptimisticBalance)
-      setIsLoadingBalance(false)
-
-      // Fetch actual balance to verify/correct the optimistic update
-      const balanceResult = await loggedApi.getWalletBalance(userId, headers)
-      const usdcToken = balanceResult.balance.find(
-        (token) => token.symbol === 'USDC_DEMO',
-      )
-
-      if (usdcToken && parseFloat(usdcToken.totalBalance) > 0) {
-        const actualBalance = parseFloat(usdcToken.totalBalance) / 1e6
-        const flooredBalance = Math.floor(actualBalance * 100) / 100
-        const actualBalanceStr = flooredBalance.toFixed(2)
-
-        // Only update if different from optimistic value
-        if (actualBalanceStr !== newOptimisticBalance) {
-          setUsdcBalance(actualBalanceStr)
-        }
-      }
-    } catch (error) {
-      console.error('Error minting USDC:', error)
-      // Revert to actual balance on error
-      setIsLoadingBalance(false)
-      if (userId) {
-        await fetchBalance(userId)
-      }
-    }
-  }, [userId, getAuthHeaders, loggedApi, fetchBalance, usdcBalance])
-
-  // Fetch balance when user logs in
-  useEffect(() => {
-    if (!userId || hasInitializedWallet.current) {
-      return
-    }
-
-    hasInitializedWallet.current = true
-
-    const initializeWallet = async () => {
-      try {
-        await fetchBalance(userId)
-      } catch (error) {
-        console.error('Error fetching balance:', error)
-        hasInitializedWallet.current = false // Reset on error so it can retry
-      }
-    }
-
-    initializeWallet()
-  }, [userId, fetchBalance])
-
   useEffect(() => {
     if (userId) {
       fetchWalletAddress(userId)
     }
   }, [userId, fetchWalletAddress])
-
-  // Fetch market APY and data on mount
-  useEffect(() => {
-    const fetchMarketApy = async () => {
-      // Skip if already initiated (prevents double-fetch in StrictMode)
-      if (hasInitiatedMarketFetch.current) {
-        console.log('[getMarkets] Skipping - already initiated')
-        return
-      }
-
-      hasInitiatedMarketFetch.current = true
-      console.log('[getMarkets] Fetching market data...')
-
-      try {
-        setIsLoadingApy(true)
-        const result = await loggedApi.getMarkets()
-
-        // Get the USDC Demo Vault (Base Sepolia) at index 1
-        if (result.markets.length > 1) {
-          const market = result.markets[1]
-          setApy(market.apy.total)
-
-          // Store market data for transactions
-          const assetAddress = (market.asset.address[market.marketId.chainId] ||
-            Object.values(market.asset.address)[0]) as Address
-
-          setMarketData({
-            marketId: market.marketId,
-            assetAddress,
-          })
-        }
-      } catch {
-        // Error fetching market APY
-      } finally {
-        setIsLoadingApy(false)
-        setIsInitialLoad(false)
-      }
-    }
-
-    fetchMarketApy()
-  }, [loggedApi])
-
-  const fetchPosition = useCallback(
-    async (backgroundPolling: boolean = false) => {
-      if (!userId || !marketChainId || !marketAddress) return
-
-      const api = backgroundPolling ? actionsApi : loggedApi
-
-      try {
-        if (!backgroundPolling) {
-          setIsLoadingPosition(true)
-        }
-        const position = await api.getPosition(
-          {
-            chainId: marketChainId,
-            address: marketData.marketId.address,
-          },
-          userId,
-        )
-        setDepositedAmount(position.balanceFormatted)
-      } catch {
-        // Silently fail polling - don't reset to 0.00
-        if (!backgroundPolling) {
-          setDepositedAmount('0.00')
-        }
-      } finally {
-        if (!backgroundPolling) {
-          setIsLoadingPosition(false)
-        }
-      }
-    },
-    [userId, marketChainId, marketAddress, loggedApi, actionsApi],
-  )
-
-  // Fetch position when market data is available or user changes
-  useEffect(() => {
-    if (userId && marketChainId && marketAddress) {
-      fetchPosition()
-    }
-  }, [userId, marketChainId, marketAddress, loggedApi])
-
-  useEffect(() => {
-    if (!userId || !marketChainId || !marketAddress) return
-
-    const intervalId = setInterval(() => fetchPosition(true), 5000)
-    return () => clearInterval(intervalId)
-  }, [userId, marketChainId, marketAddress])
-
-  // Handle transaction (lend or withdraw)
-  const handleTransaction = useCallback(
-    async (mode: 'lend' | 'withdraw', amount: number) => {
-      if (!userId || !marketData) {
-        throw new Error('User or market data not available')
-      }
-
-      const headers = await getAuthHeaders()
-
-      const result =
-        mode === 'lend'
-          ? await loggedApi.openLendPosition(
-              userId,
-              amount,
-              marketData.assetAddress,
-              marketData.marketId,
-              headers,
-            )
-          : await loggedApi.closeLendPosition(
-              userId,
-              amount,
-              marketData.assetAddress,
-              marketData.marketId,
-              headers,
-            )
-
-      // Get the first transaction hash if available, or use userOpHash for account abstraction
-      const txHash =
-        result.transaction.transactionHashes?.[0] ||
-        result.transaction.userOpHash
-
-      // Use the block explorer URL from the backend (first one in the array)
-      const explorerUrl = result.transaction.blockExplorerUrls?.[0]
-
-      // Refresh position after successful transaction with a small delay to ensure state is updated
-      setTimeout(async () => {
-        if (userId && marketData) {
-          try {
-            const position = await loggedApi.getPosition(
-              marketData.marketId,
-              userId,
-            )
-            setDepositedAmount(position.balanceFormatted)
-          } catch {
-            setDepositedAmount('0.00')
-          }
-        }
-      }, 1000)
-
-      // Also refresh wallet balance
-      if (userId) {
-        setTimeout(async () => {
-          await fetchBalance(userId)
-        }, 2000)
-      }
-
-      return {
-        transactionHash: txHash,
-        blockExplorerUrl: explorerUrl,
-      }
-    },
-    [userId, marketData, getAuthHeaders, loggedApi, fetchBalance],
-  )
 
   return (
     <Earn

--- a/packages/demo/frontend/src/hooks/useBalanceOperations.ts
+++ b/packages/demo/frontend/src/hooks/useBalanceOperations.ts
@@ -1,0 +1,411 @@
+import { useState, useCallback, useEffect, useRef } from 'react'
+import { formatUnits, type Address } from 'viem'
+import { getAssetAddress, SUPPORTED_TOKENS } from '@eth-optimism/actions-sdk'
+import type { TokenBalance } from '@eth-optimism/actions-sdk/react'
+import type {
+  LendMarket,
+  LendMarketId,
+  LendMarketPosition,
+  LendTransactionReceipt,
+  SupportedChainId,
+} from '@eth-optimism/actions-sdk'
+import { formatMarketResponse } from '@/utils/formatters'
+import { USDCDemoVault } from '@/constants/markets'
+import type { LendExecutePositionParams } from '@/types/api'
+import {
+  isBatchEOATransactionReceipt,
+  isEOATransactionReceipt,
+  isUserOperationTransactionReceipt,
+} from '@/utils/receiptTypeGuards'
+import { getBlockExplorerUrls } from '@/utils/blockExplorer'
+
+export interface UseBalanceOperationsConfig {
+  getTokenBalances: () => Promise<TokenBalance[]>
+  getMarkets: () => Promise<LendMarket[]>
+  getPosition: (marketId: LendMarket['marketId']) => Promise<LendMarketPosition>
+  getPositionSilent?: (
+    marketId: LendMarket['marketId'],
+  ) => Promise<LendMarketPosition>
+  mintUSDC: () => Promise<void>
+  openPosition: (
+    positionParams: LendExecutePositionParams,
+  ) => Promise<LendTransactionReceipt>
+  closePosition: (
+    positionParams: LendExecutePositionParams,
+  ) => Promise<LendTransactionReceipt>
+  /** Predicate to check if balance operations can be executed */
+  isReady: () => boolean
+}
+
+export function useBalanceOperations(params: UseBalanceOperationsConfig) {
+  const {
+    getTokenBalances,
+    getMarkets,
+    getPosition,
+    mintUSDC,
+    isReady,
+    openPosition,
+    closePosition,
+  } = params
+  const [isLoadingPosition, setIsLoadingPosition] = useState(false)
+  const [depositedAmount, setDepositedAmount] = useState<string | null>(null)
+  const [usdcBalance, setUsdcBalance] = useState<string>('0.00')
+  const [isLoadingBalance, setIsLoadingBalance] = useState(false)
+  const [isLoadingApy, setIsLoadingApy] = useState(true)
+  const [apy, setApy] = useState<number | null>(null)
+  const [marketData, setMarketData] = useState<{
+    marketId: LendMarketId
+    assetAddress: Address
+  } | null>(null)
+  const marketChainId = marketData?.marketId.chainId
+  const marketAddress = marketData?.marketId.address
+  const [isInitialLoad, setIsInitialLoad] = useState(true)
+
+  const hasInitialized = useRef(false)
+  const hasInitiatedMarketFetch = useRef(false)
+
+  const fetchBalance = useCallback(async () => {
+    try {
+      setIsLoadingBalance(true)
+      const tokenBalances = await getTokenBalances()
+      const vaults = await getMarkets()
+
+      const vaultBalances = await Promise.all(
+        vaults.map(async (vault) => {
+          try {
+            const vaultBalance = await getPosition(vault.marketId)
+
+            // Only include vaults with non-zero balances
+            if (vaultBalance.balance > 0n) {
+              // Create a TokenBalance object for the vault
+              const formattedBalance = formatUnits(vaultBalance.balance, 6)
+
+              // Get asset address for the vault's chain
+              const assetAddress = getAssetAddress(
+                vault.asset,
+                vault.marketId.chainId,
+              )
+
+              return {
+                symbol: `${vault.name}`,
+                totalBalance: vaultBalance.balance,
+                totalFormattedBalance: formattedBalance,
+                chainBalances: [
+                  {
+                    chainId: vaultBalance.marketId.chainId,
+                    balance: vaultBalance.balance,
+                    tokenAddress: assetAddress,
+                    formattedBalance: formattedBalance,
+                  },
+                ],
+              } as TokenBalance
+            }
+            return null
+          } catch (error) {
+            console.error(error)
+            return null
+          }
+        }),
+      )
+
+      const validVaultBalances = vaultBalances.filter(
+        (balance): balance is NonNullable<typeof balance> => balance !== null,
+      )
+
+      const balanceResult = {
+        balance: [...tokenBalances, ...validVaultBalances],
+      }
+
+      // Find USDC balance (try USDC_DEMO first not USDC)
+      const usdcToken = balanceResult.balance.find(
+        (token) => token.symbol === 'USDC_DEMO',
+      )
+
+      if (usdcToken && BigInt(usdcToken.totalBalance) > 0n) {
+        // Parse the balance (it's in smallest unit, divide by 1e6 for USDC)
+        const balance = parseFloat(`${usdcToken.totalBalance}`) / 1e6
+        // Floor to 2 decimals to ensure we never try to send more than we have
+        const flooredBalance = Math.floor(balance * 100) / 100
+        setUsdcBalance(flooredBalance.toFixed(2))
+      } else {
+        setUsdcBalance('0.00')
+      }
+    } catch {
+      setUsdcBalance('0.00')
+    } finally {
+      setIsLoadingBalance(false)
+    }
+  }, [getPosition, getMarkets, getTokenBalances])
+
+  // Function to mint demo USDC
+  const handleMintUSDC = useCallback(async () => {
+    // Early exit if precondition not met
+    if (!isReady()) {
+      return
+    }
+
+    try {
+      setIsLoadingBalance(true)
+      await mintUSDC()
+
+      // Transaction succeeded - optimistically update balance with the minted amount (100 USDC)
+      const currentBalance = parseFloat(usdcBalance)
+      const mintedAmount = 100
+      const newOptimisticBalance = (currentBalance + mintedAmount).toFixed(2)
+      setUsdcBalance(newOptimisticBalance)
+      setIsLoadingBalance(false)
+
+      // Fetch actual balance to verify/correct the optimistic update
+      const balanceResult = await getTokenBalances()
+      const usdcToken = balanceResult.find(
+        (token) => token.symbol === 'USDC_DEMO',
+      )
+
+      if (usdcToken && usdcToken.totalBalance > 0) {
+        const actualBalance = parseFloat(`${usdcToken.totalBalance}`) / 1e6
+        const flooredBalance = Math.floor(actualBalance * 100) / 100
+        const actualBalanceStr = flooredBalance.toFixed(2)
+
+        // Only update if different from optimistic value
+        if (actualBalanceStr !== newOptimisticBalance) {
+          setUsdcBalance(actualBalanceStr)
+        }
+      }
+    } catch (error) {
+      console.error('Error minting USDC:', error)
+      setIsLoadingBalance(false)
+    }
+  }, [mintUSDC, isReady, fetchBalance, usdcBalance, getTokenBalances])
+
+  // Auto-initialize balance on first ready state
+  useEffect(() => {
+    if (!isReady() || hasInitialized.current) {
+      return
+    }
+
+    hasInitialized.current = true
+
+    const initialize = async () => {
+      try {
+        await fetchBalance()
+      } catch (error) {
+        console.error('Error fetching balance:', error)
+        hasInitialized.current = false // Reset on error so it can retry
+      }
+    }
+
+    initialize()
+  }, [isReady, fetchBalance])
+
+  const executePositon = useCallback(
+    async (operation: 'open' | 'close', amount: number) => {
+      if (!isReady() || !marketData) {
+        throw new Error('User or market data not available')
+      }
+      const marketId = marketData.marketId
+      const tokenAddress = marketData.assetAddress
+
+      const asset = SUPPORTED_TOKENS.find(
+        (token) =>
+          token.address[marketId.chainId as SupportedChainId] === tokenAddress,
+      )
+      if (!asset) {
+        const error = `Asset not found for token address: ${tokenAddress}`
+        console.error('[executePosition] ERROR:', error)
+        throw new Error(error)
+      }
+
+      const positionParams = { amount, asset, marketId }
+
+      const result =
+        operation === 'open'
+          ? await openPosition(positionParams)
+          : await closePosition(positionParams)
+
+      const transactionHashes = isEOATransactionReceipt(result)
+        ? [result.transactionHash]
+        : isBatchEOATransactionReceipt(result)
+          ? result.map((receipt) => receipt.transactionHash)
+          : undefined
+
+      const userOpHash = isUserOperationTransactionReceipt(result)
+        ? result.userOpHash
+        : undefined
+
+      const blockExplorerUrls = await getBlockExplorerUrls(
+        marketId.chainId,
+        transactionHashes,
+        userOpHash,
+      )
+
+      const transaction = {
+        transactionHashes,
+        userOpHash,
+        blockExplorerUrls,
+        amount,
+        tokenAddress,
+        marketId,
+      }
+
+      return { transaction }
+    },
+    [isReady, marketData],
+  )
+
+  // Handle transaction (lend or withdraw)
+  const handleTransaction = useCallback(
+    async (mode: 'lend' | 'withdraw', amount: number) => {
+      if (!isReady() || !marketData) {
+        throw new Error('User or market data not available')
+      }
+
+      const result =
+        mode === 'lend'
+          ? await executePositon('open', amount)
+          : await executePositon('close', amount)
+
+      // Get the first transaction hash if available, or use userOpHash for account abstraction
+      const txHash =
+        result.transaction.transactionHashes?.[0] ||
+        result.transaction.userOpHash
+
+      const explorerUrl = result.transaction.blockExplorerUrls?.[0]
+
+      // Refresh position after successful transaction with a small delay to ensure state is updated
+      setTimeout(async () => {
+        if (isReady() && marketData) {
+          try {
+            await fetchPosition()
+          } catch {
+            setDepositedAmount('0.00')
+          }
+        }
+      }, 1000)
+
+      // Also refresh wallet balance
+      if (isReady()) {
+        setTimeout(async () => {
+          await fetchBalance()
+        }, 2000)
+      }
+
+      return {
+        transactionHash: txHash,
+        blockExplorerUrl: explorerUrl,
+      }
+    },
+    [isReady, marketData, fetchBalance],
+  )
+
+  // Fetch market APY and data on mount
+  useEffect(() => {
+    const fetchMarketApy = async () => {
+      // Skip if already initiated (prevents double-fetch in StrictMode)
+      if (hasInitiatedMarketFetch.current) {
+        console.log('[getMarkets] Skipping - already initiated')
+        return
+      }
+
+      hasInitiatedMarketFetch.current = true
+      console.log('[getMarkets] Fetching market data...')
+
+      try {
+        setIsLoadingApy(true)
+        const markets = await getMarkets()
+        const formattedMarkets = markets.map((market) =>
+          formatMarketResponse(market),
+        )
+
+        const market = formattedMarkets.find(
+          (market) =>
+            market.marketId.address === USDCDemoVault.address &&
+            market.marketId.chainId === USDCDemoVault.chainId,
+        )
+
+        if (market) {
+          setApy(market.apy.total)
+
+          // Store market data for transactions
+          const assetAddress = (market.asset.address[market.marketId.chainId] ||
+            Object.values(market.asset.address)[0]) as Address
+
+          setMarketData({
+            marketId: market.marketId,
+            assetAddress,
+          })
+        }
+      } catch {
+        // Error fetching market APY
+      } finally {
+        setIsLoadingApy(false)
+        setIsInitialLoad(false)
+      }
+    }
+
+    fetchMarketApy()
+  }, [hasInitiatedMarketFetch])
+
+  const fetchPosition = useCallback(
+    async (backgroundPolling: boolean = false) => {
+      if (!isReady() || !marketChainId || !marketAddress) return
+
+      const getPosition =
+        backgroundPolling && params.getPositionSilent
+          ? params.getPositionSilent
+          : params.getPosition
+
+      try {
+        if (!backgroundPolling) {
+          setIsLoadingPosition(true)
+        }
+        const position = await getPosition({
+          chainId: marketChainId,
+          address: marketAddress,
+        })
+        setDepositedAmount(position.balanceFormatted)
+      } catch {
+        // Silently fail polling - don't reset to 0.00
+        if (!backgroundPolling) {
+          setDepositedAmount('0.00')
+        }
+      } finally {
+        if (!backgroundPolling) {
+          setIsLoadingPosition(false)
+        }
+      }
+    },
+    [
+      isReady,
+      marketChainId,
+      marketAddress,
+      params.getPosition,
+      params.getPositionSilent,
+    ],
+  )
+
+  // Fetch position when market data is available or user changes
+  useEffect(() => {
+    if (isReady() && marketChainId && marketAddress) {
+      fetchPosition()
+    }
+  }, [isReady, marketChainId, marketAddress, fetchPosition])
+
+  useEffect(() => {
+    if (!isReady() || !marketChainId || !marketAddress) return
+
+    const intervalId = setInterval(() => fetchPosition(true), 5000)
+    return () => clearInterval(intervalId)
+  }, [isReady, marketChainId, marketAddress, fetchPosition])
+
+  return {
+    usdcBalance,
+    isLoadingBalance,
+    handleMintUSDC,
+    isLoadingApy,
+    apy,
+    isInitialLoad,
+    isLoadingPosition,
+    depositedAmount,
+    handleTransaction,
+  }
+}

--- a/packages/demo/frontend/src/types/api.ts
+++ b/packages/demo/frontend/src/types/api.ts
@@ -3,6 +3,7 @@
  * @description Types matching backend API responses with serialized values
  */
 
+import type { Asset, LendMarketId } from '@eth-optimism/actions-sdk'
 import type { Address } from 'viem'
 
 export interface MarketResponse {
@@ -58,4 +59,13 @@ export interface TransactionResponse {
     chainId: number
     address: Address
   }
+}
+
+export interface LendExecutePositionParams {
+  /** Asset to withdraw (optional - will be validated against marketId) */
+  asset: Asset
+  /** Amount to withdraw (in wei) */
+  amount: number
+  /** Market identifier containing address and chainId */
+  marketId: LendMarketId
 }

--- a/packages/demo/frontend/src/util/serialize.ts
+++ b/packages/demo/frontend/src/util/serialize.ts
@@ -1,0 +1,11 @@
+/**
+ * Recursively converts all bigint fields to string
+ * Useful for API responses where bigints are serialized as strings
+ */
+export type Serialized<T> = {
+  [K in keyof T]: T[K] extends bigint
+    ? string
+    : T[K] extends object
+      ? Serialized<T[K]>
+      : T[K]
+}

--- a/packages/demo/frontend/src/utils/blockExplorer.ts
+++ b/packages/demo/frontend/src/utils/blockExplorer.ts
@@ -1,0 +1,32 @@
+import type { SupportedChainId } from '@eth-optimism/actions-sdk'
+import { baseSepolia, chainById, unichain } from '@eth-optimism/viem/chains'
+
+/**
+ * Get block explorer URLs for transaction hashes or user operation hash
+ */
+export async function getBlockExplorerUrls(
+  chainId: SupportedChainId,
+  transactionHashes?: string[],
+  userOpHash?: string,
+): Promise<string[]> {
+  const chain = chainById[chainId]
+  if (!chain) {
+    throw new Error(`Chain not found for chainId: ${chainId}`)
+  }
+
+  let url = `${chain.blockExplorers?.default.url}`
+  if (chain.id === unichain.id) {
+    url = `https://unichain.blockscout.com`
+  }
+  if (chain.id === baseSepolia.id) {
+    url = `https://base-sepolia.blockscout.com`
+  }
+
+  if (userOpHash) {
+    return [`${url}/op/${userOpHash}`]
+  }
+  if (!transactionHashes) {
+    throw new Error('Transaction hashes not found')
+  }
+  return transactionHashes.map((hash) => `${url}/tx/${hash}`)
+}

--- a/packages/demo/frontend/src/utils/formatters.ts
+++ b/packages/demo/frontend/src/utils/formatters.ts
@@ -1,0 +1,22 @@
+import { formatUnits } from 'viem'
+import type { LendMarket } from '@eth-optimism/actions-sdk'
+
+/**
+ * Format a LendMarket response with human-readable values
+ */
+export function formatMarketResponse(market: LendMarket) {
+  return {
+    marketId: market.marketId,
+    name: market.name,
+    asset: market.asset,
+    supply: {
+      totalAssets: formatUnits(
+        market.supply.totalAssets,
+        market.asset.metadata.decimals,
+      ),
+      totalShares: formatUnits(market.supply.totalShares, 18),
+    },
+    apy: market.apy,
+    metadata: market.metadata,
+  }
+}

--- a/packages/demo/frontend/src/utils/receiptTypeGuards.ts
+++ b/packages/demo/frontend/src/utils/receiptTypeGuards.ts
@@ -1,0 +1,32 @@
+import type {
+  EOATransactionReceipt,
+  LendTransactionReceipt,
+  UserOperationTransactionReceipt,
+} from '@eth-optimism/actions-sdk'
+
+/**
+ * Type guard to check if receipt is an EOA transaction receipt
+ */
+export function isEOATransactionReceipt(
+  receipt: LendTransactionReceipt,
+): receipt is EOATransactionReceipt {
+  return !Array.isArray(receipt) && !('userOpHash' in receipt)
+}
+
+/**
+ * Type guard to check if receipt is a batch EOA transaction receipt
+ */
+export function isBatchEOATransactionReceipt(
+  receipt: LendTransactionReceipt,
+): receipt is EOATransactionReceipt[] {
+  return Array.isArray(receipt)
+}
+
+/**
+ * Type guard to check if receipt is a user operation transaction receipt
+ */
+export function isUserOperationTransactionReceipt(
+  receipt: LendTransactionReceipt,
+): receipt is UserOperationTransactionReceipt {
+  return 'userOpHash' in receipt
+}


### PR DESCRIPTION
Part of https://github.com/ethereum-optimism/actions/issues/193

## Changes
There was a lot of duplicate logic between the `EarnWithServerWallet` and `EarnWithFrontendWallet` so consolidated this logic by doing the following:
- created `useBalanceOperations` hook that performs all shared balance operations between the two components
- updated backend endpoints used by the `Earn` component to not perform any formatting and to have same response shape as calling the sdk directly. This makes it easy to abstract rpc calls regardless of whether they are happening directly by calling the sdk (frontend wallets) or by calling the sdk via the backend server (server wallets)
  - to keep this pr small and to not break old code touching these endpoints (Terminal.tsx) I appended v1 to have them under their own routes. In a follow up PR I will kill the terminal app and remove all the old endpoints