### PR TITLE
feat: make the earn demo responsive and mobile-friendly

### DIFF
--- a/packages/demo/frontend/src/components/ActivityLog.tsx
+++ b/packages/demo/frontend/src/components/ActivityLog.tsx
@@ -1,9 +1,12 @@
-import ActivityLogItem from './ActivityLogItem'
-import Info from './Info'
+import { useState } from 'react'
 import { useActivityLog } from '../hooks/useActivityLog'
+import ActivityLogCard from './ActivityLogCard'
+import ActivityLogSidebar from './ActivityLogSidebar'
+import ActivityLogPanel from './ActivityLogPanel'
 
 function ActivityLog() {
   const { activities } = useActivityLog()
+  const [isFullLogOpen, setIsFullLogOpen] = useState(false)
 
   // Helper function to format timestamp
   const formatTimestamp = (isoString: string) => {
@@ -21,97 +24,36 @@ function ActivityLog() {
     return `${diffDays} day${diffDays > 1 ? 's' : ''} ago`
   }
 
+  const hasMoreActivities = activities.length > 3
+
   return (
-    <div
-      className="h-full flex flex-col"
-      style={{
-        backgroundColor: '#FFFFFF',
-        borderLeft: '1px solid #E0E2EB',
-        fontFamily: 'Inter, system-ui, -apple-system, sans-serif',
-      }}
-    >
-      <div className="p-6 pb-0">
-        <div className="flex items-center gap-2 mb-4">
-          <svg
-            width="20"
-            height="20"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="#1a1b1e"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
-            <line x1="8" y1="6" x2="21" y2="6" />
-            <line x1="8" y1="12" x2="21" y2="12" />
-            <line x1="8" y1="18" x2="21" y2="18" />
-            <line x1="3" y1="6" x2="3.01" y2="6" />
-            <line x1="3" y1="12" x2="3.01" y2="12" />
-            <line x1="3" y1="18" x2="3.01" y2="18" />
-          </svg>
-          <h2 className="text-lg font-semibold" style={{ color: '#1a1b1e' }}>
-            Under the Hood
-          </h2>
-        </div>
+    <>
+      {/* Mobile Card */}
+      <div className="lg:hidden">
+        <ActivityLogCard
+          activities={activities}
+          formatTimestamp={formatTimestamp}
+          hasMoreActivities={hasMoreActivities}
+          onViewFullLog={() => setIsFullLogOpen(true)}
+        />
       </div>
 
-      <div
-        className="flex-1 overflow-y-auto"
-        style={{
-          scrollbarWidth: 'thin',
-          scrollbarColor: '#D1D5DB #F3F4F6',
-        }}
-      >
-        <style>{`
-          .activity-log-scroll::-webkit-scrollbar {
-            width: 8px;
-          }
-          .activity-log-scroll::-webkit-scrollbar-track {
-            background: #F3F4F6;
-          }
-          .activity-log-scroll::-webkit-scrollbar-thumb {
-            background: #D1D5DB;
-            border-radius: 4px;
-          }
-          .activity-log-scroll::-webkit-scrollbar-thumb:hover {
-            background: #9CA3AF;
-          }
-        `}</style>
-        <div className="activity-log-scroll">
-          {activities.length > 0 ? (
-            activities.map((activity) => (
-              <ActivityLogItem
-                key={activity.id}
-                type={activity.type}
-                action={activity.action}
-                timestamp={formatTimestamp(activity.timestamp)}
-                status={activity.status}
-                blockExplorerUrl={activity.blockExplorerUrl}
-                isFromPreviousSession={activity.isFromPreviousSession}
-              />
-            ))
-          ) : (
-            <div
-              style={{
-                color: '#9CA3AF',
-                textAlign: 'center',
-                padding: '2rem',
-              }}
-            >
-              No activity yet
-            </div>
-          )}
-        </div>
+      {/* Desktop Sidebar */}
+      <div className="hidden lg:block h-full">
+        <ActivityLogSidebar
+          activities={activities}
+          formatTimestamp={formatTimestamp}
+        />
       </div>
 
-      {/* Info section at bottom */}
-      <div className="mt-auto">
-        <div style={{ borderTop: '1px solid #E0E2EB' }} />
-        <div className="p-6 pt-6">
-          <Info />
-        </div>
-      </div>
-    </div>
+      {/* Mobile Full Log Panel */}
+      <ActivityLogPanel
+        activities={activities}
+        formatTimestamp={formatTimestamp}
+        isOpen={isFullLogOpen}
+        onClose={() => setIsFullLogOpen(false)}
+      />
+    </>
   )
 }
 

--- a/packages/demo/frontend/src/components/ActivityLogCard.tsx
+++ b/packages/demo/frontend/src/components/ActivityLogCard.tsx
@@ -1,0 +1,90 @@
+import ActivityLogItem from './ActivityLogItem'
+import ActivityLogIcon from './icons/ActivityLogIcon'
+import type { ActivityEntry } from '../providers/ActivityLogProvider'
+
+interface ActivityLogCardProps {
+  activities: ActivityEntry[]
+  formatTimestamp: (timestamp: string) => string
+  hasMoreActivities: boolean
+  onViewFullLog: () => void
+}
+
+function ActivityLogCard({
+  activities,
+  formatTimestamp,
+  hasMoreActivities,
+  onViewFullLog,
+}: ActivityLogCardProps) {
+  const displayedActivities = activities.slice(0, 3)
+
+  return (
+    <div
+      style={{
+        backgroundColor: '#FFFFFF',
+        border: '1px solid #E0E2EB',
+        borderRadius: '24px',
+        fontFamily: 'Inter, system-ui, -apple-system, sans-serif',
+      }}
+    >
+      <div className="p-6 pb-0">
+        <div className="flex items-center gap-2 mb-4">
+          <ActivityLogIcon />
+          <h2 className="text-lg font-semibold" style={{ color: '#1a1b1e' }}>
+            Under the Hood
+          </h2>
+        </div>
+      </div>
+
+      <div
+        className="overflow-y-auto max-h-96"
+        style={{
+          scrollbarWidth: 'thin',
+          scrollbarColor: '#D1D5DB #F3F4F6',
+        }}
+      >
+        {activities.length > 0 ? (
+          displayedActivities.map((activity) => (
+            <ActivityLogItem
+              key={activity.id}
+              type={activity.type}
+              action={activity.action}
+              timestamp={formatTimestamp(activity.timestamp)}
+              status={activity.status}
+              blockExplorerUrl={activity.blockExplorerUrl}
+              isFromPreviousSession={activity.isFromPreviousSession}
+            />
+          ))
+        ) : (
+          <div
+            style={{
+              color: '#9CA3AF',
+              textAlign: 'center',
+              padding: '2rem',
+            }}
+          >
+            No activity yet
+          </div>
+        )}
+      </div>
+
+      {hasMoreActivities && (
+        <div className="p-4 pt-0">
+          <button
+            onClick={onViewFullLog}
+            className="w-full py-3 text-center font-medium transition-colors"
+            style={{
+              color: '#1a1b1e',
+              backgroundColor: 'transparent',
+              border: 'none',
+              cursor: 'pointer',
+            }}
+          >
+            View Full Log
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default ActivityLogCard

--- a/packages/demo/frontend/src/components/ActivityLogPanel.tsx
+++ b/packages/demo/frontend/src/components/ActivityLogPanel.tsx
@@ -1,0 +1,91 @@
+import ActivityLogItem from './ActivityLogItem'
+import ActivityLogIcon from './icons/ActivityLogIcon'
+import CloseIcon from './icons/CloseIcon'
+import type { ActivityEntry } from '../providers/ActivityLogProvider'
+
+interface ActivityLogPanelProps {
+  activities: ActivityEntry[]
+  formatTimestamp: (timestamp: string) => string
+  isOpen: boolean
+  onClose: () => void
+}
+
+function ActivityLogPanel({
+  activities,
+  formatTimestamp,
+  isOpen,
+  onClose,
+}: ActivityLogPanelProps) {
+  if (!isOpen) return null
+
+  return (
+    <div
+      className="lg:hidden fixed inset-0 z-50"
+      style={{
+        backgroundColor: '#FFFFFF',
+        animation: 'slideInRight 0.3s ease-out',
+      }}
+    >
+      <style>{`
+        @keyframes slideInRight {
+          from {
+            transform: translateX(100%);
+          }
+          to {
+            transform: translateX(0);
+          }
+        }
+      `}</style>
+
+      {/* Header */}
+      <div
+        className="flex items-center justify-between p-4"
+        style={{
+          borderBottom: '1px solid #E0E2EB',
+        }}
+      >
+        <div className="flex items-center gap-2">
+          <ActivityLogIcon />
+          <h2 className="text-lg font-semibold" style={{ color: '#1a1b1e' }}>
+            Activity Log
+          </h2>
+        </div>
+        <button
+          onClick={onClose}
+          className="p-2"
+          style={{
+            background: 'none',
+            border: 'none',
+            cursor: 'pointer',
+          }}
+        >
+          <CloseIcon />
+        </button>
+      </div>
+
+      {/* Full Activity List */}
+      <div
+        className="overflow-y-auto"
+        style={{
+          height: 'calc(100vh - 65px)',
+          scrollbarWidth: 'thin',
+          scrollbarColor: '#D1D5DB #F3F4F6',
+        }}
+      >
+        {activities.map((activity) => (
+          <ActivityLogItem
+            key={activity.id}
+            type={activity.type}
+            action={activity.action}
+            timestamp={formatTimestamp(activity.timestamp)}
+            status={activity.status}
+            blockExplorerUrl={activity.blockExplorerUrl}
+            isFromPreviousSession={activity.isFromPreviousSession}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default ActivityLogPanel

--- a/packages/demo/frontend/src/components/ActivityLogSidebar.tsx
+++ b/packages/demo/frontend/src/components/ActivityLogSidebar.tsx
@@ -1,0 +1,76 @@
+import ActivityLogItem from './ActivityLogItem'
+import ActivityLogIcon from './icons/ActivityLogIcon'
+import Info from './Info'
+import type { ActivityEntry } from '../providers/ActivityLogProvider'
+
+interface ActivityLogSidebarProps {
+  activities: ActivityEntry[]
+  formatTimestamp: (timestamp: string) => string
+}
+
+function ActivityLogSidebar({
+  activities,
+  formatTimestamp,
+}: ActivityLogSidebarProps) {
+  return (
+    <div
+      className="flex flex-col h-full"
+      style={{
+        backgroundColor: '#FFFFFF',
+        borderLeft: '1px solid #E0E2EB',
+        fontFamily: 'Inter, system-ui, -apple-system, sans-serif',
+      }}
+    >
+      <div className="p-6 pb-0">
+        <div className="flex items-center gap-2 mb-4">
+          <ActivityLogIcon />
+          <h2 className="text-lg font-semibold" style={{ color: '#1a1b1e' }}>
+            Under the Hood
+          </h2>
+        </div>
+      </div>
+
+      <div
+        className="flex-1 overflow-y-auto"
+        style={{
+          scrollbarWidth: 'thin',
+          scrollbarColor: '#D1D5DB #F3F4F6',
+          minHeight: 0,
+        }}
+      >
+        {activities.length > 0 ? (
+          activities.map((activity) => (
+            <ActivityLogItem
+              key={activity.id}
+              type={activity.type}
+              action={activity.action}
+              timestamp={formatTimestamp(activity.timestamp)}
+              status={activity.status}
+              blockExplorerUrl={activity.blockExplorerUrl}
+              isFromPreviousSession={activity.isFromPreviousSession}
+            />
+          ))
+        ) : (
+          <div
+            style={{
+              color: '#9CA3AF',
+              textAlign: 'center',
+              padding: '2rem',
+            }}
+          >
+            No activity yet
+          </div>
+        )}
+      </div>
+
+      <div className="mt-auto">
+        <div style={{ borderTop: '1px solid #E0E2EB' }} />
+        <div className="p-6 pt-6">
+          <Info />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default ActivityLogSidebar

--- a/packages/demo/frontend/src/components/Earn.tsx
+++ b/packages/demo/frontend/src/components/Earn.tsx
@@ -1,6 +1,7 @@
 import { Action } from './Action'
 import LentBalance from './LentBalance'
 import ActivityLog from './ActivityLog'
+import Info from './Info'
 import { WalletProviderDropdown } from './WalletProviderDropdown'
 import type { WalletProviderConfig } from '@/constants/walletProviders'
 export interface EarnContentProps {
@@ -95,12 +96,9 @@ function Earn({
         </div>
       </header>
 
-      <main className="flex" style={{ height: 'calc(100vh - 65px)' }}>
+      <main className="flex flex-col lg:flex-row min-h-[calc(100vh-65px)]">
         {/* Left Content Area */}
-        <div
-          className="flex-1 flex flex-col items-center p-8 overflow-y-auto"
-          style={{ maxWidth: 'calc(100% - 436px)' }}
-        >
+        <div className="flex-1 flex flex-col items-center p-8 overflow-y-auto">
           <div className="w-full max-w-2xl">
             {/* Title Section */}
             <div className="mb-8 text-left">
@@ -112,6 +110,7 @@ function Earn({
                     fontStyle: 'normal',
                     fontWeight: 600,
                   }}
+                  className="sm:text-2xl"
                 >
                   Actions Demo
                 </h1>
@@ -132,6 +131,7 @@ function Earn({
                   color: '#666666',
                   fontSize: '16px',
                 }}
+                className="sm:text-base"
               >
                 Earn interest by lending USDC
               </p>
@@ -154,12 +154,31 @@ function Earn({
                 onMintUSDC={onMintUSDC}
                 onTransaction={onTransaction}
               />
+
+              {/* Activity Log - Mobile Card */}
+              <div className="lg:hidden">
+                <ActivityLog />
+              </div>
+
+              {/* Info - Mobile Card */}
+              <div className="lg:hidden">
+                <div
+                  className="p-6"
+                  style={{
+                    border: '1px solid #E0E2EB',
+                    borderRadius: '24px',
+                    backgroundColor: '#FFFFFF',
+                  }}
+                >
+                  <Info />
+                </div>
+              </div>
             </div>
           </div>
         </div>
 
-        {/* Activity Log - Right Side */}
-        <div style={{ width: '436px' }}>
+        {/* Activity Log - Desktop Sidebar */}
+        <div className="hidden lg:h-[calc(100vh-65px)] lg:block lg:w-[436px]">
           <ActivityLog />
         </div>
       </main>

--- a/packages/demo/frontend/src/components/LentBalance.tsx
+++ b/packages/demo/frontend/src/components/LentBalance.tsx
@@ -64,6 +64,7 @@ function LentBalance({
                     fontSize: '12px',
                     fontWeight: 500,
                     fontFamily: 'Inter',
+                    minWidth: '120px',
                   }}
                 >
                   Market
@@ -76,6 +77,7 @@ function LentBalance({
                     fontSize: '12px',
                     fontWeight: 500,
                     fontFamily: 'Inter',
+                    minWidth: '130px',
                   }}
                 >
                   Network
@@ -88,6 +90,7 @@ function LentBalance({
                     fontSize: '12px',
                     fontWeight: 500,
                     fontFamily: 'Inter',
+                    minWidth: '80px',
                   }}
                 >
                   Asset
@@ -100,6 +103,7 @@ function LentBalance({
                     fontSize: '12px',
                     fontWeight: 500,
                     fontFamily: 'Inter',
+                    minWidth: '70px',
                   }}
                 >
                   APY

--- a/packages/demo/frontend/src/components/WalletProviderDropdown.tsx
+++ b/packages/demo/frontend/src/components/WalletProviderDropdown.tsx
@@ -108,6 +108,7 @@ export function WalletProviderDropdown({
             border: '1px solid #E5E5E5',
             zIndex: 50,
             width: '400px',
+            maxWidth: 'calc(100vw - 32px)',
           }}
         >
           <div className="p-6">

--- a/packages/demo/frontend/src/components/icons/ActivityLogIcon.tsx
+++ b/packages/demo/frontend/src/components/icons/ActivityLogIcon.tsx
@@ -1,0 +1,33 @@
+interface ActivityLogIconProps {
+  width?: number
+  height?: number
+  color?: string
+}
+
+function ActivityLogIcon({
+  width = 20,
+  height = 20,
+  color = '#1a1b1e',
+}: ActivityLogIconProps) {
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke={color}
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <line x1="8" y1="6" x2="21" y2="6" />
+      <line x1="8" y1="12" x2="21" y2="12" />
+      <line x1="8" y1="18" x2="21" y2="18" />
+      <line x1="3" y1="6" x2="3.01" y2="6" />
+      <line x1="3" y1="12" x2="3.01" y2="12" />
+      <line x1="3" y1="18" x2="3.01" y2="18" />
+    </svg>
+  )
+}
+
+export default ActivityLogIcon

--- a/packages/demo/frontend/src/components/icons/CloseIcon.tsx
+++ b/packages/demo/frontend/src/components/icons/CloseIcon.tsx
@@ -1,0 +1,29 @@
+interface CloseIconProps {
+  width?: number
+  height?: number
+  color?: string
+}
+
+function CloseIcon({
+  width = 24,
+  height = 24,
+  color = '#1a1b1e',
+}: CloseIconProps) {
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke={color}
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <line x1="18" y1="6" x2="6" y2="18" />
+      <line x1="6" y1="6" x2="18" y2="18" />
+    </svg>
+  )
+}
+
+export default CloseIcon


### PR DESCRIPTION
Closes https://github.com/ethereum-optimism/actions/issues/220

Creates a mobile friendly view of the earn page based on this mock:
<img width="323" height="999" alt="Screenshot 2025-10-28 at 5 31 30 PM" src="https://github.com/user-attachments/assets/72a7cd95-12bf-42cb-b616-1d32a74292e0" />
