### PR TITLE
fix: move Lent Balances table under Actions card

### DIFF
--- a/packages/demo/frontend/src/components/Earn.tsx
+++ b/packages/demo/frontend/src/components/Earn.tsx
@@ -138,13 +138,6 @@ function Earn({
             </div>
 
             <div className="space-y-6">
-              <LentBalance
-                depositedAmount={depositedAmount}
-                apy={apy}
-                isLoadingPosition={isLoadingPosition}
-                isLoadingApy={isLoadingApy}
-                isInitialLoad={isInitialLoad}
-              />
               <Action
                 usdcBalance={usdcBalance}
                 isLoadingBalance={isLoadingBalance}
@@ -153,6 +146,13 @@ function Earn({
                 depositedAmount={depositedAmount}
                 onMintUSDC={onMintUSDC}
                 onTransaction={onTransaction}
+              />
+              <LentBalance
+                depositedAmount={depositedAmount}
+                apy={apy}
+                isLoadingPosition={isLoadingPosition}
+                isLoadingApy={isLoadingApy}
+                isInitialLoad={isInitialLoad}
               />
 
               {/* Activity Log - Mobile Card */}

--- a/packages/demo/frontend/src/components/LentBalance.tsx
+++ b/packages/demo/frontend/src/components/LentBalance.tsx
@@ -16,6 +16,7 @@ function LentBalance({
   isLoadingApy,
   isInitialLoad = false,
 }: LentBalanceProps) {
+  const isEmpty = !isLoadingPosition && !isLoadingApy && depositedAmount === '0'
   // Format deposited amount to 4 decimals and return parts
   const formatDepositedAmount = (amount: string) => {
     const num = parseFloat(amount)
@@ -49,208 +50,243 @@ function LentBalance({
         >
           Lent Balance
         </h2>
-
-        {/* Table */}
-        <div style={{ overflow: 'auto' }}>
-          <table style={{ width: '100%', borderCollapse: 'collapse' }}>
-            {/* Header */}
-            <thead>
-              <tr style={{ borderBottom: '1px solid #E0E2EB' }}>
-                <th
-                  style={{
-                    textAlign: 'left',
-                    padding: '12px 8px',
-                    color: '#9195A6',
-                    fontSize: '12px',
-                    fontWeight: 500,
-                    fontFamily: 'Inter',
-                    minWidth: '120px',
-                  }}
-                >
-                  Market
-                </th>
-                <th
-                  style={{
-                    textAlign: 'left',
-                    padding: '12px 8px',
-                    color: '#9195A6',
-                    fontSize: '12px',
-                    fontWeight: 500,
-                    fontFamily: 'Inter',
-                    minWidth: '130px',
-                  }}
-                >
-                  Network
-                </th>
-                <th
-                  style={{
-                    textAlign: 'left',
-                    padding: '12px 8px',
-                    color: '#9195A6',
-                    fontSize: '12px',
-                    fontWeight: 500,
-                    fontFamily: 'Inter',
-                    minWidth: '80px',
-                  }}
-                >
-                  Asset
-                </th>
-                <th
-                  style={{
-                    textAlign: 'right',
-                    padding: '12px 8px',
-                    color: '#9195A6',
-                    fontSize: '12px',
-                    fontWeight: 500,
-                    fontFamily: 'Inter',
-                    minWidth: '70px',
-                  }}
-                >
-                  APY
-                </th>
-                <th
-                  style={{
-                    textAlign: 'right',
-                    padding: '12px 8px',
-                    color: '#9195A6',
-                    fontSize: '12px',
-                    fontWeight: 500,
-                    fontFamily: 'Inter',
-                    minWidth: '100px',
-                  }}
-                >
-                  Value
-                </th>
-              </tr>
-            </thead>
-
-            {/* Body */}
-            <tbody>
-              <tr>
-                <td style={{ padding: '16px 8px' }}>
-                  {isInitialLoad ? (
-                    <Shimmer width="120px" height="20px" borderRadius="4px" />
-                  ) : (
-                    <div className="flex items-center gap-2">
-                      <img
-                        src={morphoLogo}
-                        alt="Morpho"
-                        style={{ width: '20px', height: '20px' }}
-                      />
-                      <span
-                        style={{
-                          color: '#1a1b1e',
-                          fontSize: '14px',
-                          fontWeight: 400,
-                          fontFamily: 'Inter',
-                        }}
-                      >
-                        Gauntlet
-                      </span>
-                    </div>
-                  )}
-                </td>
-                <td style={{ padding: '16px 8px' }}>
-                  {isInitialLoad ? (
-                    <Shimmer width="110px" height="20px" borderRadius="4px" />
-                  ) : (
-                    <div className="flex items-center gap-2">
-                      <img
-                        src="/base-logo.svg"
-                        alt="Base"
-                        style={{ width: '20px', height: '20px' }}
-                      />
-                      <span
-                        style={{
-                          color: '#1a1b1e',
-                          fontSize: '14px',
-                          fontWeight: 400,
-                          fontFamily: 'Inter',
-                        }}
-                      >
-                        Base Sepolia
-                      </span>
-                    </div>
-                  )}
-                </td>
-                <td style={{ padding: '16px 8px' }}>
-                  {isInitialLoad ? (
-                    <Shimmer width="60px" height="20px" borderRadius="4px" />
-                  ) : (
-                    <div className="flex items-center gap-2">
-                      <img
-                        src="/usd-coin-usdc-logo.svg"
-                        alt="USDC"
-                        style={{ width: '20px', height: '20px' }}
-                      />
-                      <span
-                        style={{
-                          color: '#1a1b1e',
-                          fontSize: '14px',
-                          fontWeight: 400,
-                          fontFamily: 'Inter',
-                        }}
-                      >
-                        USDC
-                      </span>
-                    </div>
-                  )}
-                </td>
-                <td style={{ padding: '16px 8px', textAlign: 'right' }}>
-                  {isInitialLoad || isLoadingApy ? (
-                    <div
-                      style={{ display: 'flex', justifyContent: 'flex-end' }}
-                    >
-                      <Shimmer width="50px" height="20px" borderRadius="4px" />
-                    </div>
-                  ) : (
-                    <span
+        {isEmpty ? (
+          <div className="flex items-start font-normal text-sm leading-5 text-secondary">
+            No active markets yet. Lend to see your balances here.
+          </div>
+        ) : (
+          <>
+            {/* Table */}
+            <div style={{ overflow: 'auto' }}>
+              <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+                {/* Header */}
+                <thead>
+                  <tr style={{ borderBottom: '1px solid #E0E2EB' }}>
+                    <th
                       style={{
-                        color: '#1a1b1e',
-                        fontSize: '14px',
-                        fontWeight: 400,
-                        fontFamily: 'Inter',
-                      }}
-                    >
-                      {apy !== null ? `${(apy * 100).toFixed(2)}%` : '0.00%'}
-                    </span>
-                  )}
-                </td>
-                <td style={{ padding: '16px 8px', textAlign: 'right' }}>
-                  {isInitialLoad || isLoadingPosition ? (
-                    <div
-                      style={{ display: 'flex', justifyContent: 'flex-end' }}
-                    >
-                      <Shimmer width="70px" height="20px" borderRadius="4px" />
-                    </div>
-                  ) : (
-                    <span
-                      style={{
-                        color: '#1a1b1e',
-                        fontSize: '14px',
+                        textAlign: 'left',
+                        padding: '12px 8px',
+                        color: '#9195A6',
+                        fontSize: '12px',
                         fontWeight: 500,
                         fontFamily: 'Inter',
+                        minWidth: '120px',
                       }}
                     >
-                      ${formatDepositedAmount(depositedAmount || '0').main}
-                      <span
-                        style={{
-                          color: '#9195A6',
-                          fontSize: '12px',
-                        }}
-                      >
-                        {
-                          formatDepositedAmount(depositedAmount || '0')
-                            .secondary
-                        }
-                      </span>
-                    </span>
-                  )}
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
+                      Market
+                    </th>
+                    <th
+                      style={{
+                        textAlign: 'left',
+                        padding: '12px 8px',
+                        color: '#9195A6',
+                        fontSize: '12px',
+                        fontWeight: 500,
+                        fontFamily: 'Inter',
+                        minWidth: '130px',
+                      }}
+                    >
+                      Network
+                    </th>
+                    <th
+                      style={{
+                        textAlign: 'left',
+                        padding: '12px 8px',
+                        color: '#9195A6',
+                        fontSize: '12px',
+                        fontWeight: 500,
+                        fontFamily: 'Inter',
+                        minWidth: '80px',
+                      }}
+                    >
+                      Asset
+                    </th>
+                    <th
+                      style={{
+                        textAlign: 'right',
+                        padding: '12px 8px',
+                        color: '#9195A6',
+                        fontSize: '12px',
+                        fontWeight: 500,
+                        fontFamily: 'Inter',
+                        minWidth: '70px',
+                      }}
+                    >
+                      APY
+                    </th>
+                    <th
+                      style={{
+                        textAlign: 'right',
+                        padding: '12px 8px',
+                        color: '#9195A6',
+                        fontSize: '12px',
+                        fontWeight: 500,
+                        fontFamily: 'Inter',
+                        minWidth: '100px',
+                      }}
+                    >
+                      Value
+                    </th>
+                  </tr>
+                </thead>
+
+                {/* Body */}
+                <tbody>
+                  <tr>
+                    <td style={{ padding: '16px 8px' }}>
+                      {isInitialLoad ? (
+                        <Shimmer
+                          width="120px"
+                          height="20px"
+                          borderRadius="4px"
+                        />
+                      ) : (
+                        <div className="flex items-center gap-2">
+                          <img
+                            src={morphoLogo}
+                            alt="Morpho"
+                            style={{ width: '20px', height: '20px' }}
+                          />
+                          <span
+                            style={{
+                              color: '#1a1b1e',
+                              fontSize: '14px',
+                              fontWeight: 400,
+                              fontFamily: 'Inter',
+                            }}
+                          >
+                            Gauntlet
+                          </span>
+                        </div>
+                      )}
+                    </td>
+                    <td style={{ padding: '16px 8px' }}>
+                      {isInitialLoad ? (
+                        <Shimmer
+                          width="110px"
+                          height="20px"
+                          borderRadius="4px"
+                        />
+                      ) : (
+                        <div className="flex items-center gap-2">
+                          <img
+                            src="/base-logo.svg"
+                            alt="Base"
+                            style={{ width: '20px', height: '20px' }}
+                          />
+                          <span
+                            style={{
+                              color: '#1a1b1e',
+                              fontSize: '14px',
+                              fontWeight: 400,
+                              fontFamily: 'Inter',
+                            }}
+                          >
+                            Base Sepolia
+                          </span>
+                        </div>
+                      )}
+                    </td>
+                    <td style={{ padding: '16px 8px' }}>
+                      {isInitialLoad ? (
+                        <Shimmer
+                          width="60px"
+                          height="20px"
+                          borderRadius="4px"
+                        />
+                      ) : (
+                        <div className="flex items-center gap-2">
+                          <img
+                            src="/usd-coin-usdc-logo.svg"
+                            alt="USDC"
+                            style={{ width: '20px', height: '20px' }}
+                          />
+                          <span
+                            style={{
+                              color: '#1a1b1e',
+                              fontSize: '14px',
+                              fontWeight: 400,
+                              fontFamily: 'Inter',
+                            }}
+                          >
+                            USDC
+                          </span>
+                        </div>
+                      )}
+                    </td>
+                    <td style={{ padding: '16px 8px', textAlign: 'right' }}>
+                      {isInitialLoad || isLoadingApy ? (
+                        <div
+                          style={{
+                            display: 'flex',
+                            justifyContent: 'flex-end',
+                          }}
+                        >
+                          <Shimmer
+                            width="50px"
+                            height="20px"
+                            borderRadius="4px"
+                          />
+                        </div>
+                      ) : (
+                        <span
+                          style={{
+                            color: '#1a1b1e',
+                            fontSize: '14px',
+                            fontWeight: 400,
+                            fontFamily: 'Inter',
+                          }}
+                        >
+                          {apy !== null
+                            ? `${(apy * 100).toFixed(2)}%`
+                            : '0.00%'}
+                        </span>
+                      )}
+                    </td>
+                    <td style={{ padding: '16px 8px', textAlign: 'right' }}>
+                      {isInitialLoad || isLoadingPosition ? (
+                        <div
+                          style={{
+                            display: 'flex',
+                            justifyContent: 'flex-end',
+                          }}
+                        >
+                          <Shimmer
+                            width="70px"
+                            height="20px"
+                            borderRadius="4px"
+                          />
+                        </div>
+                      ) : (
+                        <span
+                          style={{
+                            color: '#1a1b1e',
+                            fontSize: '14px',
+                            fontWeight: 500,
+                            fontFamily: 'Inter',
+                          }}
+                        >
+                          ${formatDepositedAmount(depositedAmount || '0').main}
+                          <span
+                            style={{
+                              color: '#9195A6',
+                              fontSize: '12px',
+                            }}
+                          >
+                            {
+                              formatDepositedAmount(depositedAmount || '0')
+                                .secondary
+                            }
+                          </span>
+                        </span>
+                      )}
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </>
+        )}
       </div>
     </div>
   )

--- a/packages/demo/frontend/tailwind.config.js
+++ b/packages/demo/frontend/tailwind.config.js
@@ -15,6 +15,7 @@ export default {
         blue: '#83a598',
         indigo: '#d3869b',
         purple: '#d3869b',
+        secondary: '#404454',
         terminal: {
           bg: '#1d2021',
           secondary: '#282828',


### PR DESCRIPTION
## Changes
- Move the Lent Balances table underneath the lend/withdraw card (this is how it is designed in [Figma](https://www.figma.com/design/YkHMtXKgZ9FghCpv9tVUV0/Verbs-Demo?node-id=196-4018&m=dev))
- Add an empty state to the Lent Balances table