### PR TITLE
fix: rename WalletNamespace#hostedWalletToActionsWallet to WalletNamespace#toActionsWallet

### DIFF
--- a/.changeset/dry-tires-study.md
+++ b/.changeset/dry-tires-study.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/actions-sdk': patch
+---
+
+rename actions.wallet.hostedWalletToActionsWallet to actions.wallet.toActionsWallet

--- a/packages/demo/backend/src/app.integration.spec.ts
+++ b/packages/demo/backend/src/app.integration.spec.ts
@@ -61,7 +61,7 @@ vi.mock('./config/actions.js', () => ({
           deployments: [{ chainId: 1, receipt: undefined, success: true }],
         }),
       ),
-      hostedWalletToActionsWallet: vi.fn(
+      toActionsWallet: vi.fn(
         async ({ address }: { walletId: string; address: string }) => {
           return {
             address: address,

--- a/packages/demo/backend/src/services/wallet.spec.ts
+++ b/packages/demo/backend/src/services/wallet.spec.ts
@@ -14,7 +14,7 @@ const mockActions = {
     },
     getSmartWallet: vi.fn(),
     createSmartWallet: vi.fn(),
-    hostedWalletToActionsWallet: vi.fn(({ address }: { address: string }) => ({
+    toActionsWallet: vi.fn(({ address }: { address: string }) => ({
       address,
       signer: {
         address,

--- a/packages/demo/frontend/src/components/home/ConfigureWalletsSection.tsx
+++ b/packages/demo/frontend/src/components/home/ConfigureWalletsSection.tsx
@@ -31,7 +31,7 @@ const embeddedWallet = wallets.find(
 )
 
 // ACTIONS: Let wallet make onchain Actions
-const wallet = await actions.wallet.hostedWalletToActionsWallet({
+const wallet = await actions.wallet.toActionsWallet({
   connectedWallet: embeddedWallet,
 })`
 
@@ -46,7 +46,7 @@ const privyWallet = await privyClient.walletApi.createWallet({
 })
 
 // ACTIONS: Let wallet make onchain Actions
-const wallet = await actions.wallet.hostedWalletToActionsWallet({
+const wallet = await actions.wallet.toActionsWallet({
   walletId: privyWallet.id,
   address: privyWallet.address,
 })`
@@ -77,7 +77,7 @@ const embeddedWallet = await createWallet({
 const walletAddress = embeddedWallet.accounts[0].address
 
 // ACTIONS: Let wallet make onchain Actions
-const wallet = await actions.wallet.hostedWalletToActionsWallet({
+const wallet = await actions.wallet.toActionsWallet({
   client: httpClient,
   organizationId: session.organizationId,
   signWith: walletAddress,
@@ -106,7 +106,7 @@ const turnkeyWallet = await turnkeyClient.apiClient().createWallet({
 })
 
 // ACTIONS: Let wallet make onchain Actions
-const wallet = await actions.wallet.hostedWalletToActionsWallet({
+const wallet = await actions.wallet.toActionsWallet({
   organizationId: turnkeyWallet.activity.organizationId,
   signWith: turnkeyWallet.addresses[0],
 })`

--- a/packages/demo/frontend/src/components/home/HostedWalletsSection.tsx
+++ b/packages/demo/frontend/src/components/home/HostedWalletsSection.tsx
@@ -30,7 +30,7 @@ const embeddedWallet = wallets.find(
 )
 
 // ACTIONS: Let wallet make onchain Actions
-const actionsWallet = await actions.wallet.hostedWalletToActionsWallet({
+const actionsWallet = await actions.wallet.toActionsWallet({
   connectedWallet: embeddedWallet,
 })`
 
@@ -45,7 +45,7 @@ const privyWallet = await privyClient.walletApi.createWallet({
 })
 
 // ACTIONS: Let wallet make onchain Actions
-const wallet = await actions.wallet.hostedWalletToActionsWallet({
+const wallet = await actions.wallet.toActionsWallet({
   walletId: privyWallet.id,
   address: privyWallet.address,
 })`
@@ -75,7 +75,7 @@ const wallet = await createWallet({
 const walletAddress = wallet.accounts[0].address
 
 // ACTIONS: Let wallet make onchain Actions
-const actionsWallet = await actions.wallet.hostedWalletToActionsWallet({
+const actionsWallet = await actions.wallet.toActionsWallet({
   client: httpClient,
   organizationId: session.organizationId,
   signWith: walletAddress,
@@ -104,7 +104,7 @@ const turnkeyWallet = await turnkeyClient.apiClient().createWallet({
 })
 
 // ACTIONS: Let wallet make onchain Actions
-const wallet = await actions.wallet.hostedWalletToActionsWallet({
+const wallet = await actions.wallet.toActionsWallet({
   organizationId: turnkeyWallet.activity.organizationId,
   signWith: turnkeyWallet.addresses[0],
 })`

--- a/packages/sdk/src/wallet/core/namespace/WalletNamespace.ts
+++ b/packages/sdk/src/wallet/core/namespace/WalletNamespace.ts
@@ -98,7 +98,7 @@ export class WalletNamespace<
    * @param params.address - Ethereum address of the hosted wallet
    * @returns Promise resolving to the Actions wallet instance
    */
-  async hostedWalletToActionsWallet(
+  async toActionsWallet(
     params: TToActionsMap[THostedProviderType],
   ): Promise<Wallet> {
     return this.provider.hostedWalletToActionsWallet(params)

--- a/packages/sdk/src/wallet/core/namespace/__tests__/WalletNamespace.spec.ts
+++ b/packages/sdk/src/wallet/core/namespace/__tests__/WalletNamespace.spec.ts
@@ -284,7 +284,7 @@ describe('WalletNamespace', () => {
     })
   })
 
-  describe('hostedWalletToActionsWallet', () => {
+  describe('toActionsWallet', () => {
     it('should convert a hosted wallet to an Actions wallet', async () => {
       const hostedWalletProvider = new PrivyHostedWalletProvider(
         mockPrivyClient,
@@ -313,7 +313,7 @@ describe('WalletNamespace', () => {
         'toActionsWallet',
       )
 
-      const actionsWallet = await walletNamespace.hostedWalletToActionsWallet({
+      const actionsWallet = await walletNamespace.toActionsWallet({
         walletId: privyWallet.id,
         address: privyWallet.address,
       })


### PR DESCRIPTION
Closes https://github.com/ethereum-optimism/actions/issues/218

Just renamed the function exposed externally through the `WalletNamespace` and leaving the name as-is for all internal functions.