### PR TITLE
Optimization: Reduce bundle size

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -11,6 +11,7 @@
   },
   "type": "module",
   "sideEffects": false,
+  "sideEffects": false,
   "version": "0.3.0",
   "description": "TypeScript SDK for Actions",
   "main": "dist/index.js",

--- a/packages/sdk/src/actions.ts
+++ b/packages/sdk/src/actions.ts
@@ -57,8 +57,6 @@ export class Actions<
     uniswap?: SwapProvider<SwapProviderConfig>
   } = {}
   private _assetsConfig?: AssetsConfig
-  private hostedWalletProvider!: THostedWalletProvidersSchema['providerInstances'][THostedWalletProviderType]
-  private smartWalletProvider!: SmartWalletProvider
   private hostedWalletProviderRegistry: HostedWalletProviderRegistry<
     THostedWalletProvidersSchema['providerInstances'],
     THostedWalletProvidersSchema['providerConfigs'],
@@ -198,16 +196,18 @@ export class Actions<
    * @param config - Wallet configuration
    * @returns WalletProvider instance
    */
-  private createWalletProvider(
+  private async createWalletProvider(
     config: ActionsConfig<
       THostedWalletProviderType,
       THostedWalletProvidersSchema['providerConfigs']
     >['wallet'],
-  ): WalletProvider<
-    THostedWalletProviderType,
-    THostedWalletProvidersSchema['providerToActionsOptions'],
-    THostedWalletProvidersSchema['providerInstances'][THostedWalletProviderType],
-    SmartWalletProvider
+  ): Promise<
+    WalletProvider<
+      THostedWalletProviderType,
+      THostedWalletProvidersSchema['providerToActionsOptions'],
+      THostedWalletProvidersSchema['providerInstances'][THostedWalletProviderType],
+      SmartWalletProvider
+    >
   > {
     const hostedWalletProviderConfig = config.hostedWalletConfig.provider
     const factory = this.hostedWalletProviderRegistry.getFactory(
@@ -223,7 +223,7 @@ export class Actions<
         `Invalid options for hosted wallet provider: ${hostedWalletProviderConfig.type}`,
       )
     }
-    this.hostedWalletProvider = factory.create(
+    const hostedWalletProvider = await factory.create(
       {
         chainManager: this.chainManager,
         lendProviders: this._lendProviders,
@@ -233,11 +233,12 @@ export class Actions<
       options,
     )
 
+    let smartWalletProvider: SmartWalletProvider
     if (
       !config.smartWalletConfig ||
       config.smartWalletConfig.provider.type === 'default'
     ) {
-      this.smartWalletProvider = new DefaultSmartWalletProvider(
+      smartWalletProvider = new DefaultSmartWalletProvider(
         this.chainManager,
         this._lendProviders,
         this._swapProviders,
@@ -250,16 +251,13 @@ export class Actions<
       )
     }
 
-    const walletProvider = new WalletProvider(
-      this.hostedWalletProvider,
-      this.smartWalletProvider,
-    )
-
-    return walletProvider
+    return new WalletProvider(hostedWalletProvider, smartWalletProvider)
   }
 
   /**
    * Create the wallet namespace instance
+   * @description Creates a WalletNamespace with lazy provider initialization.
+   * The wallet provider is not created until the first wallet method is called.
    * @param config - Wallet configuration
    * @returns WalletNamespace instance
    */
@@ -269,12 +267,12 @@ export class Actions<
       THostedWalletProvidersSchema['providerConfigs']
     >['wallet'],
   ) {
-    const walletProvider = this.createWalletProvider(config)
+    const providerFactory = () => this.createWalletProvider(config)
     return new WalletNamespace<
       THostedWalletProviderType,
       THostedWalletProvidersSchema['providerToActionsOptions'],
       THostedWalletProvidersSchema['providerInstances'][THostedWalletProviderType],
       SmartWalletProvider
-    >(walletProvider)
+    >(providerFactory)
   }
 }

--- a/packages/sdk/src/wallet/core/namespace/WalletNamespace.ts
+++ b/packages/sdk/src/wallet/core/namespace/WalletNamespace.ts
@@ -12,8 +12,20 @@ import type { Wallet } from '@/wallet/core/wallets/abstract/Wallet.js'
 import type { SmartWallet } from '@/wallet/core/wallets/smart/abstract/SmartWallet.js'
 
 /**
+ * Provider factory function for lazy initialization
+ */
+type WalletProviderFactory<
+  THostedProviderType extends string,
+  TToActionsMap extends Record<THostedProviderType, unknown>,
+  H extends HostedWalletProvider<THostedProviderType, TToActionsMap>,
+  S extends SmartWalletProvider,
+> = () => Promise<WalletProvider<THostedProviderType, TToActionsMap, H, S>>
+
+/**
  * Wallet namespace that provides unified wallet operations
- * @description Provides access to wallet functionality through a single provider interface
+ * @description Provides access to wallet functionality through a single provider interface.
+ * Supports lazy initialization — the wallet provider is created on first method call,
+ * enabling tree-shaking of unused wallet provider dependencies.
  */
 export class WalletNamespace<
   THostedProviderType extends string,
@@ -22,32 +34,70 @@ export class WalletNamespace<
     HostedWalletProvider<THostedProviderType, TToActionsMap>,
   S extends SmartWalletProvider = SmartWalletProvider,
 > {
-  private provider: WalletProvider<THostedProviderType, TToActionsMap, H, S>
+  private _provider: WalletProvider<
+    THostedProviderType,
+    TToActionsMap,
+    H,
+    S
+  > | null = null
+  private _providerFactory: WalletProviderFactory<
+    THostedProviderType,
+    TToActionsMap,
+    H,
+    S
+  >
+  private _initPromise: Promise<
+    WalletProvider<THostedProviderType, TToActionsMap, H, S>
+  > | null = null
 
   constructor(
-    provider: WalletProvider<THostedProviderType, TToActionsMap, H, S>,
+    providerOrFactory:
+      | WalletProvider<THostedProviderType, TToActionsMap, H, S>
+      | WalletProviderFactory<THostedProviderType, TToActionsMap, H, S>,
   ) {
-    this.provider = provider
+    if (typeof providerOrFactory === 'function') {
+      this._providerFactory = providerOrFactory
+    } else {
+      this._provider = providerOrFactory
+      this._providerFactory = () => Promise.resolve(providerOrFactory)
+    }
+  }
+
+  private resolveProvider(): Promise<
+    WalletProvider<THostedProviderType, TToActionsMap, H, S>
+  > {
+    if (this._provider) return Promise.resolve(this._provider)
+    if (!this._initPromise) {
+      this._initPromise = this._providerFactory().then((provider) => {
+        this._provider = provider
+        return provider
+      })
+    }
+    return this._initPromise
   }
 
   /**
    * Get direct access to the hosted wallet provider
    * @description Provides direct access to the underlying hosted wallet provider when
-   * advanced functionality beyond the unified interface is needed
-   * @returns The configured hosted wallet provider instance
+   * advanced functionality beyond the unified interface is needed.
+   * Lazily initializes the provider if not yet created.
+   * @returns Promise resolving to the configured hosted wallet provider instance
    */
-  get hostedWalletProvider(): H {
-    return this.provider.hostedWalletProvider
+  async hostedWalletProvider(): Promise<H> {
+    const provider = await this.resolveProvider()
+    return provider.hostedWalletProvider
   }
 
   /**
    * Get direct access to the smart wallet provider
    * @description Provides direct access to the underlying smart wallet provider when
-   * advanced functionality beyond the unified interface is needed
-   * @returns The configured smart wallet provider instance
+   * advanced functionality beyond the unified interface is needed.
+   * Lazily initializes the provider if not yet created.
+   * @returns Promise resolving to the configured smart wallet provider instance
    */
-  get smartWalletProvider(): S {
-    return this.provider.smartWalletProvider
+  async smartWalletProvider(): Promise<S> {
+    const provider = await this.resolveProvider()
+    return provider.smartWalletProvider
   }
 
   /**
@@ -70,7 +120,8 @@ export class WalletNamespace<
   async createSmartWallet(
     params: CreateSmartWalletOptions,
   ): Promise<SmartWalletCreationResult<SmartWallet>> {
-    return this.provider.createSmartWallet(params)
+    const provider = await this.resolveProvider()
+    return provider.createSmartWallet(params)
   }
 
   /**
@@ -85,7 +136,8 @@ export class WalletNamespace<
   async createSigner(
     params: TToActionsMap[THostedProviderType],
   ): Promise<LocalAccount> {
-    return this.provider.createSigner(params)
+    const provider = await this.resolveProvider()
+    return provider.createSigner(params)
   }
 
   /**
@@ -99,7 +151,8 @@ export class WalletNamespace<
   async toActionsWallet(
     params: TToActionsMap[THostedProviderType],
   ): Promise<Wallet> {
-    return this.provider.hostedWalletToActionsWallet(params)
+    const provider = await this.resolveProvider()
+    return provider.hostedWalletToActionsWallet(params)
   }
 
   /**
@@ -118,6 +171,7 @@ export class WalletNamespace<
    * @throws Error if neither walletAddress nor deploymentSigners provided
    */
   async getSmartWallet(params: GetSmartWalletOptions) {
-    return this.provider.getSmartWallet(params)
+    const provider = await this.resolveProvider()
+    return provider.getSmartWallet(params)
   }
 }

--- a/packages/sdk/src/wallet/core/namespace/__tests__/WalletNamespace.spec.ts
+++ b/packages/sdk/src/wallet/core/namespace/__tests__/WalletNamespace.spec.ts
@@ -38,7 +38,7 @@ describe('WalletNamespace', () => {
   })
 
   describe('hostedWalletProvider', () => {
-    it('should provide access to hosted wallet provider', () => {
+    it('should provide access to hosted wallet provider', async () => {
       const hostedWalletProvider = new PrivyHostedWalletProvider({
         privyClient: mockPrivyClient,
         chainManager: mockChainManager,
@@ -54,12 +54,14 @@ describe('WalletNamespace', () => {
       )
       const walletNamespace = new WalletNamespace(walletProvider)
 
-      expect(walletNamespace.hostedWalletProvider).toBe(hostedWalletProvider)
+      expect(await walletNamespace.hostedWalletProvider()).toBe(
+        hostedWalletProvider,
+      )
     })
   })
 
   describe('smartWalletProvider', () => {
-    it('should provide access to smart wallet provider', () => {
+    it('should provide access to smart wallet provider', async () => {
       const mockPrivyClient = createMockPrivyClient(
         'test-app-id',
         'test-app-secret',
@@ -79,7 +81,9 @@ describe('WalletNamespace', () => {
       )
       const walletNamespace = new WalletNamespace(walletProvider)
 
-      expect(walletNamespace.smartWalletProvider).toBe(smartWalletProvider)
+      expect(await walletNamespace.smartWalletProvider()).toBe(
+        smartWalletProvider,
+      )
     })
   })
 

--- a/packages/sdk/src/wallet/core/providers/hosted/types/index.ts
+++ b/packages/sdk/src/wallet/core/providers/hosted/types/index.ts
@@ -56,7 +56,10 @@ export interface HostedProviderFactory<
 > {
   type: TType
   validateOptions(options: unknown): options is TOptions
-  create(deps: HostedProviderDeps, options: TOptions): TInstance
+  create(
+    deps: HostedProviderDeps,
+    options: TOptions,
+  ): TInstance | Promise<TInstance>
 }
 
 /**

--- a/packages/sdk/src/wallet/node/providers/hosted/registry/NodeHostedWalletProviderRegistry.ts
+++ b/packages/sdk/src/wallet/node/providers/hosted/registry/NodeHostedWalletProviderRegistry.ts
@@ -1,6 +1,4 @@
 import { HostedWalletProviderRegistry } from '@/wallet/core/providers/hosted/registry/HostedWalletProviderRegistry.js'
-import { PrivyHostedWalletProvider } from '@/wallet/node/providers/hosted/privy/PrivyHostedWalletProvider.js'
-import { TurnkeyHostedWalletProvider } from '@/wallet/node/providers/hosted/turnkey/TurnkeyHostedWalletProvider.js'
 import type {
   NodeHostedProviderInstanceMap,
   NodeOptionsMap,
@@ -11,10 +9,8 @@ import type {
  * Node hosted wallet provider registry
  * @description
  * Environment-scoped registry that binds Node/server provider keys to their
- * factory implementations. This ensures browser-only hosted providers are
- * discoverable at runtime without importing Node-only code. The registry
- * pre-registers 'privy' and 'turnkey' providers and can be extended with
- * additional providers via `register`.
+ * factory implementations. Provider code is loaded lazily via dynamic import()
+ * so that unused wallet SDKs are not included in the bundle.
  */
 export class NodeHostedWalletProviderRegistry extends HostedWalletProviderRegistry<
   NodeHostedProviderInstanceMap,
@@ -28,10 +24,12 @@ export class NodeHostedWalletProviderRegistry extends HostedWalletProviderRegist
       validateOptions(options): options is NodeOptionsMap['privy'] {
         return Boolean((options as NodeOptionsMap['privy'])?.privyClient)
       },
-      create(
+      async create(
         { chainManager, lendProviders, swapProviders, supportedAssets },
         options,
       ) {
+        const { PrivyHostedWalletProvider } =
+          await import('@/wallet/node/providers/hosted/privy/PrivyHostedWalletProvider.js')
         return new PrivyHostedWalletProvider({
           privyClient: options.privyClient,
           chainManager,
@@ -49,10 +47,12 @@ export class NodeHostedWalletProviderRegistry extends HostedWalletProviderRegist
         const o = options as NodeOptionsMap['turnkey']
         return Boolean(o?.client)
       },
-      create(
+      async create(
         { chainManager, lendProviders, swapProviders, supportedAssets },
         options,
       ) {
+        const { TurnkeyHostedWalletProvider } =
+          await import('@/wallet/node/providers/hosted/turnkey/TurnkeyHostedWalletProvider.js')
         return new TurnkeyHostedWalletProvider(
           options.client,
           chainManager,

--- a/packages/sdk/src/wallet/node/providers/hosted/registry/__tests__/NodeHostedWalletProviderRegistry.spec.ts
+++ b/packages/sdk/src/wallet/node/providers/hosted/registry/__tests__/NodeHostedWalletProviderRegistry.spec.ts
@@ -54,11 +54,11 @@ describe('NodeHostedWalletProviderRegistry', () => {
     ).toBe(false)
   })
 
-  it('creates a PrivyHostedWalletProvider instance', () => {
+  it('creates a PrivyHostedWalletProvider instance', async () => {
     const registry = new NodeHostedWalletProviderRegistry()
     const factory = registry.getFactory('privy')
 
-    const provider = factory.create({ chainManager: mockChainManager }, {
+    const provider = await factory.create({ chainManager: mockChainManager }, {
       privyClient: mockPrivyClient,
       authorizationContext: getMockAuthorizationContext(),
     } as NodeOptionsMap['privy'])
@@ -80,11 +80,11 @@ describe('NodeHostedWalletProviderRegistry', () => {
     expect(factory.validateOptions?.({})).toBe(false)
   })
 
-  it('creates a TurnkeyHostedWalletProvider instance', () => {
+  it('creates a TurnkeyHostedWalletProvider instance', async () => {
     const registry = new NodeHostedWalletProviderRegistry()
     const factory = registry.getFactory('turnkey')
 
-    const provider = factory.create(
+    const provider = await factory.create(
       { chainManager: mockChainManager },
       {
         client: mockTurnkeyClient,

--- a/packages/sdk/src/wallet/react/providers/registry/ReactHostedWalletProviderRegistry.ts
+++ b/packages/sdk/src/wallet/react/providers/registry/ReactHostedWalletProviderRegistry.ts
@@ -1,7 +1,4 @@
 import { HostedWalletProviderRegistry } from '@/wallet/core/providers/hosted/registry/HostedWalletProviderRegistry.js'
-import { DynamicHostedWalletProvider } from '@/wallet/react/providers/hosted/dynamic/DynamicHostedWalletProvider.js'
-import { PrivyHostedWalletProvider } from '@/wallet/react/providers/hosted/privy/PrivyHostedWalletProvider.js'
-import { TurnkeyHostedWalletProvider } from '@/wallet/react/providers/hosted/turnkey/TurnkeyHostedWalletProvider.js'
 import type {
   ReactHostedProviderInstanceMap,
   ReactOptionsMap,
@@ -12,10 +9,8 @@ import type {
  * React hosted wallet provider registry
  * @description
  * Environment-scoped registry that binds React/browser provider keys to their
- * factory implementations. This ensures browser-only hosted providers are
- * discoverable at runtime without importing Node-only code. The registry
- * pre-registers 'dynamic' and 'privy' providers and can be extended with
- * additional providers via `register`.
+ * factory implementations. Provider code is loaded lazily via dynamic import()
+ * so that unused wallet SDKs are not included in the bundle.
  */
 export class ReactHostedWalletProviderRegistry extends HostedWalletProviderRegistry<
   ReactHostedProviderInstanceMap,
@@ -29,10 +24,12 @@ export class ReactHostedWalletProviderRegistry extends HostedWalletProviderRegis
       validateOptions(_options): _options is ReactOptionsMap['dynamic'] {
         return true
       },
-      create(
+      async create(
         { chainManager, lendProviders, swapProviders, supportedAssets },
         _options,
       ) {
+        const { DynamicHostedWalletProvider } =
+          await import('@/wallet/react/providers/hosted/dynamic/DynamicHostedWalletProvider.js')
         return new DynamicHostedWalletProvider(
           chainManager,
           lendProviders,
@@ -47,10 +44,12 @@ export class ReactHostedWalletProviderRegistry extends HostedWalletProviderRegis
       validateOptions(_options): _options is ReactOptionsMap['privy'] {
         return true
       },
-      create(
+      async create(
         { chainManager, lendProviders, swapProviders, supportedAssets },
         _options,
       ) {
+        const { PrivyHostedWalletProvider } =
+          await import('@/wallet/react/providers/hosted/privy/PrivyHostedWalletProvider.js')
         return new PrivyHostedWalletProvider(
           chainManager,
           lendProviders,
@@ -65,10 +64,12 @@ export class ReactHostedWalletProviderRegistry extends HostedWalletProviderRegis
       validateOptions(_options): _options is ReactOptionsMap['turnkey'] {
         return true
       },
-      create(
+      async create(
         { chainManager, lendProviders, swapProviders, supportedAssets },
         _options,
       ) {
+        const { TurnkeyHostedWalletProvider } =
+          await import('@/wallet/react/providers/hosted/turnkey/TurnkeyHostedWalletProvider.js')
         return new TurnkeyHostedWalletProvider(
           chainManager,
           lendProviders,

--- a/packages/sdk/src/wallet/react/providers/registry/__tests__/ReactHostedWalletProviderRegistry.spec.ts
+++ b/packages/sdk/src/wallet/react/providers/registry/__tests__/ReactHostedWalletProviderRegistry.spec.ts
@@ -49,11 +49,11 @@ describe('ReactHostedWalletProviderRegistry', () => {
     ).toBe(true)
   })
 
-  it('creates a DynamicHostedWalletProvider instance', () => {
+  it('creates a DynamicHostedWalletProvider instance', async () => {
     const registry = new ReactHostedWalletProviderRegistry()
     const factory = registry.getFactory('dynamic')
 
-    const provider = factory.create(
+    const provider = await factory.create(
       { chainManager: mockChainManager },
       undefined as ReactOptionsMap['dynamic'],
     )
@@ -71,11 +71,11 @@ describe('ReactHostedWalletProviderRegistry', () => {
     ).toBe(true)
   })
 
-  it('creates a PrivyHostedWalletProvider instance', () => {
+  it('creates a PrivyHostedWalletProvider instance', async () => {
     const registry = new ReactHostedWalletProviderRegistry()
     const factory = registry.getFactory('privy')
 
-    const provider = factory.create(
+    const provider = await factory.create(
       { chainManager: mockChainManager },
       undefined as ReactOptionsMap['privy'],
     )
@@ -93,11 +93,11 @@ describe('ReactHostedWalletProviderRegistry', () => {
     ).toBe(true)
   })
 
-  it('creates a TurnkeyHostedWalletProvider instance', () => {
+  it('creates a TurnkeyHostedWalletProvider instance', async () => {
     const registry = new ReactHostedWalletProviderRegistry()
     const factory = registry.getFactory('turnkey')
 
-    const provider = factory.create(
+    const provider = await factory.create(
       { chainManager: mockChainManager },
       undefined as ReactOptionsMap['turnkey'],
     )


### PR DESCRIPTION
## Problem

Frontend builds produce warnings:

```
(!) Some chunks are larger than 500 kB after minification.
```

The largest offenders exceed 2MB:

```
actionsApi-Bo6U1spp.js                 2,022.80 kB
privy-provider-BG8GtKO6-Kdn9sR6B.js   1,385.64 kB
DynamicProvider-Bv6AxASU.js            1,290.75 kB
```

The root cause is that `createActions` statically imports all wallet provider SDKs (Dynamic, Privy, Turnkey) via the `ReactHostedWalletProviderRegistry`, regardless of which provider the developer configured.

## Solution

### 1. `sideEffects: false` on SDK package.json

Tells bundlers (Vite/Rollup/esbuild) that the SDK's modules have no side effects, enabling them to drop unused barrel re-exports. Reduced the `actionsApi` chunk from **2,022 kB → 110 kB**.

### 2. Lazy wallet provider initialization with dynamic imports

The wallet provider registries previously used static imports for all wallet providers at the top of the file. Now:

- Each registry factory uses `await import()` to load provider code on demand
- `WalletNamespace` lazily initializes the wallet provider on first method call (all wallet methods are already async)
- `createActions` **remains synchronous** — no consumer API change
- `ActionsConfig` shape is unchanged

The only interface change is that `actions.wallet.hostedWalletProvider` and `actions.wallet.smartWalletProvider` on `WalletNamespace` are now async methods instead of sync getters. These are advanced escape hatches not used in typical integrations.

**Result:** `EarnWithFrontendWallet` chunk dropped from **2,189 kB → 1,550 kB** (~30% reduction). Wallet providers now code-split into their own chunks (e.g. `DynamicHostedWalletProvider` at 611 kB).

Further tree-shaking research is tracked in [#292](https://github.com/ethereum-optimism/actions/pull/292).

## Test plan

- [x] All 364 SDK tests pass
- [x] Full NX build passes (SDK + frontend + backend)
- [x] Typecheck clean
- [x] Lint clean