### PR TITLE
Replace `any` types with specific types across SDK and demo packages

### DIFF
--- a/packages/demo/backend/src/helpers/validation.spec.ts
+++ b/packages/demo/backend/src/helpers/validation.spec.ts
@@ -1,3 +1,4 @@
+import type { Context } from 'hono'
 import { describe, expect, it, vi } from 'vitest'
 import { z } from 'zod'
 
@@ -40,7 +41,10 @@ describe('validateRequest', () => {
         false,
       )
 
-      const result = await validateRequest(mockContext as any, ParamsSchema)
+      const result = await validateRequest(
+        mockContext as unknown as Context,
+        ParamsSchema,
+      )
 
       expect(result.success).toBe(true)
       if (result.success) {
@@ -57,7 +61,10 @@ describe('validateRequest', () => {
         false,
       )
 
-      const result = await validateRequest(mockContext as any, ParamsSchema)
+      const result = await validateRequest(
+        mockContext as unknown as Context,
+        ParamsSchema,
+      )
 
       expect(result.success).toBe(false)
       if (!result.success) {
@@ -88,7 +95,10 @@ describe('validateRequest', () => {
         false,
       )
 
-      const result = await validateRequest(mockContext as any, QuerySchema)
+      const result = await validateRequest(
+        mockContext as unknown as Context,
+        QuerySchema,
+      )
 
       expect(result.success).toBe(true)
       if (result.success) {
@@ -100,7 +110,10 @@ describe('validateRequest', () => {
     it('should validate empty query parameters', async () => {
       const mockContext = createMockContext({}, {}, null, false)
 
-      const result = await validateRequest(mockContext as any, QuerySchema)
+      const result = await validateRequest(
+        mockContext as unknown as Context,
+        QuerySchema,
+      )
 
       expect(result.success).toBe(true)
       if (result.success) {
@@ -122,7 +135,10 @@ describe('validateRequest', () => {
       const requestBody = { name: 'John', email: 'john@example.com', age: 25 }
       const mockContext = createMockContext({}, {}, requestBody, true)
 
-      const result = await validateRequest(mockContext as any, BodySchema)
+      const result = await validateRequest(
+        mockContext as unknown as Context,
+        BodySchema,
+      )
 
       expect(result.success).toBe(true)
       if (result.success) {
@@ -134,7 +150,10 @@ describe('validateRequest', () => {
       const requestBody = { name: '', email: 'invalid-email', age: -5 }
       const mockContext = createMockContext({}, {}, requestBody, true)
 
-      const result = await validateRequest(mockContext as any, BodySchema)
+      const result = await validateRequest(
+        mockContext as unknown as Context,
+        BodySchema,
+      )
 
       expect(result.success).toBe(false)
       if (!result.success) {
@@ -154,7 +173,10 @@ describe('validateRequest', () => {
       })
       const mockContext = createMockContext({}, {}, null, false)
 
-      const result = await validateRequest(mockContext as any, EmptyBodySchema)
+      const result = await validateRequest(
+        mockContext as unknown as Context,
+        EmptyBodySchema,
+      )
 
       expect(result.success).toBe(true)
       if (result.success) {
@@ -185,7 +207,10 @@ describe('validateRequest', () => {
         true,
       )
 
-      const result = await validateRequest(mockContext as any, CombinedSchema)
+      const result = await validateRequest(
+        mockContext as unknown as Context,
+        CombinedSchema,
+      )
 
       expect(result.success).toBe(true)
       if (result.success) {
@@ -204,7 +229,10 @@ describe('validateRequest', () => {
         true,
       )
 
-      const result = await validateRequest(mockContext as any, CombinedSchema)
+      const result = await validateRequest(
+        mockContext as unknown as Context,
+        CombinedSchema,
+      )
 
       expect(result.success).toBe(false)
     })
@@ -225,7 +253,10 @@ describe('validateRequest', () => {
         true,
       )
 
-      const result = await validateRequest(mockContext as any, ParamsOnlySchema)
+      const result = await validateRequest(
+        mockContext as unknown as Context,
+        ParamsOnlySchema,
+      )
 
       expect(result.success).toBe(true)
       if (result.success) {
@@ -246,7 +277,10 @@ describe('validateRequest', () => {
       // Mock json() to throw error
       mockContext.req.json.mockRejectedValue(new Error('Invalid JSON'))
 
-      const result = await validateRequest(mockContext as any, BodySchema)
+      const result = await validateRequest(
+        mockContext as unknown as Context,
+        BodySchema,
+      )
 
       expect(result.success).toBe(true)
       if (result.success) {
@@ -267,7 +301,7 @@ describe('validateRequest', () => {
       }
 
       const result = await validateRequest(
-        mockContext as any,
+        mockContext as unknown as Context,
         z.object({ params: z.object({}) }),
       )
 

--- a/packages/demo/backend/src/services/lend.spec.ts
+++ b/packages/demo/backend/src/services/lend.spec.ts
@@ -25,7 +25,9 @@ describe('Lend Service', () => {
   beforeEach(async () => {
     vi.clearAllMocks()
     const { getActions } = await import('../config/actions.js')
-    vi.mocked(getActions).mockReturnValue(mockActions as any)
+    vi.mocked(getActions).mockReturnValue(
+      mockActions as unknown as ReturnType<typeof getActions>,
+    )
   })
 
   describe('getMarkets', () => {
@@ -122,7 +124,9 @@ describe('Lend Service', () => {
   describe('closePosition', () => {
     it('should throw error when wallet not found', async () => {
       const { getWallet } = await import('./wallet.js')
-      vi.mocked(getWallet).mockResolvedValue(null as any)
+      vi.mocked(getWallet).mockResolvedValue(
+        null as unknown as Awaited<ReturnType<typeof getWallet>>,
+      )
 
       await expect(
         lendService.closePosition({

--- a/packages/demo/backend/src/services/swap.spec.ts
+++ b/packages/demo/backend/src/services/swap.spec.ts
@@ -41,7 +41,9 @@ describe('Swap Service', () => {
   beforeEach(async () => {
     vi.clearAllMocks()
     const { getActions } = await import('../config/actions.js')
-    vi.mocked(getActions).mockReturnValue(mockActions as any)
+    vi.mocked(getActions).mockReturnValue(
+      mockActions as unknown as ReturnType<typeof getActions>,
+    )
   })
 
   describe('getMarkets', () => {
@@ -128,7 +130,9 @@ describe('Swap Service', () => {
   describe('executeSwap', () => {
     it('throws when wallet not found', async () => {
       const { getWallet } = await import('./wallet.js')
-      vi.mocked(getWallet).mockResolvedValue(null as any)
+      vi.mocked(getWallet).mockResolvedValue(
+        null as unknown as Awaited<ReturnType<typeof getWallet>>,
+      )
 
       await expect(
         swapService.executeSwap({
@@ -143,7 +147,9 @@ describe('Swap Service', () => {
 
     it('throws when swap not configured', async () => {
       const { getWallet } = await import('./wallet.js')
-      vi.mocked(getWallet).mockResolvedValue({ swap: undefined } as any)
+      vi.mocked(getWallet).mockResolvedValue({
+        swap: undefined,
+      } as unknown as Awaited<ReturnType<typeof getWallet>>)
 
       await expect(
         swapService.executeSwap({
@@ -172,7 +178,7 @@ describe('Swap Service', () => {
       const { getWallet } = await import('./wallet.js')
       vi.mocked(getWallet).mockResolvedValue({
         swap: { execute: vi.fn().mockResolvedValue(mockReceipt) },
-      } as any)
+      } as unknown as Awaited<ReturnType<typeof getWallet>>)
 
       const result = await swapService.executeSwap({
         idToken: 'valid',

--- a/packages/demo/contracts/script/DeployMorphoMarket.s.sol
+++ b/packages/demo/contracts/script/DeployMorphoMarket.s.sol
@@ -51,11 +51,7 @@ contract DeployMorphoMarket is Script {
 
         // Create market params
         MarketParams memory marketParams = MarketParams({
-            loanToken: address(usdc),
-            collateralToken: address(op),
-            oracle: address(oracle),
-            irm: IRM,
-            lltv: LLTV
+            loanToken: address(usdc), collateralToken: address(op), oracle: address(oracle), irm: IRM, lltv: LLTV
         });
 
         // Create Morpho market
@@ -63,9 +59,8 @@ contract DeployMorphoMarket is Script {
 
         // Create MetaMorpho vault with 0 timelock (V1.1)
         bytes32 salt = keccak256(abi.encodePacked("actions-demo-vault", block.timestamp));
-        address vault = IMetaMorphoFactory(METAMORPHO_FACTORY_V1_1).createMetaMorpho(
-            msg.sender, 0, address(usdc), "Actions Demo USDC Vault", "dUSDC", salt
-        );
+        address vault = IMetaMorphoFactory(METAMORPHO_FACTORY_V1_1)
+            .createMetaMorpho(msg.sender, 0, address(usdc), "Actions Demo USDC Vault", "dUSDC", salt);
         console.log("Vault:", vault);
 
         // Submit and immediately accept cap (0 timelock)

--- a/packages/demo/frontend/src/api/actionsApi.ts
+++ b/packages/demo/frontend/src/api/actionsApi.ts
@@ -101,7 +101,9 @@ class ActionsApiClient {
       chains: Object.fromEntries(
         Object.entries(balance.chains).map(([chainId, chainBalance]) => [
           chainId,
-          chainBalance ? { ...chainBalance, balanceRaw: BigInt(chainBalance.balanceRaw) } : chainBalance,
+          chainBalance
+            ? { ...chainBalance, balanceRaw: BigInt(chainBalance.balanceRaw) }
+            : chainBalance,
         ]),
       ),
     })) as TokenBalance[]

--- a/packages/demo/frontend/src/hooks/useSwapAssets.ts
+++ b/packages/demo/frontend/src/hooks/useSwapAssets.ts
@@ -84,7 +84,9 @@ export function useSwapAssets({
         if (!asset || seen.has(symbol)) return null
         seen.add(symbol)
 
-        const chainId = Number(Object.keys(balance.chains)[0] ?? 84532) as SupportedChainId
+        const chainId = Number(
+          Object.keys(balance.chains)[0] ?? 84532,
+        ) as SupportedChainId
 
         return {
           asset,

--- a/packages/demo/frontend/src/utils/activitySummary.ts
+++ b/packages/demo/frontend/src/utils/activitySummary.ts
@@ -50,9 +50,7 @@ function buildSwapSummary(entry: ActivityEntry): SummarySegment[] {
       { type: 'text', value: ` for ${truncateAmount(m.amountOut)} ` },
       tokenSegment(m.assetOutSymbol, m.assetOutLogo),
       { type: 'text', value: ' on ' },
-      marketSegment(
-        getProviderDisplayName(m.provider ?? 'uniswap', m.chainId),
-      ),
+      marketSegment(getProviderDisplayName(m.provider ?? 'uniswap', m.chainId)),
     ]
   }
   return [{ type: 'text', value: 'Swapped tokens' }]

--- a/packages/demo/frontend/src/utils/balanceMatching.ts
+++ b/packages/demo/frontend/src/utils/balanceMatching.ts
@@ -34,7 +34,9 @@ export function matchAssetBalance({
     // For ETH markets, match by asset type (native token has no address)
     // For ERC20 tokens, match by address on the target chain
     if (isEthSymbol(selectedAssetSymbol)) {
-      assetToken = allTokenBalances.find((token) => isEthSymbol(token.asset.metadata.symbol))
+      assetToken = allTokenBalances.find((token) =>
+        isEthSymbol(token.asset.metadata.symbol),
+      )
     } else {
       const targetAddress = marketData.assetAddress.toLowerCase()
       for (const token of allTokenBalances) {
@@ -65,12 +67,14 @@ export function matchAssetBalance({
   if (assetToken && chainBalance && chainBalance.balanceRaw > 0n) {
     // Use the specific chain balance (already human-readable)
     const flooredBalance =
-      Math.floor(chainBalance.balance * precisionMultiplier) / precisionMultiplier
+      Math.floor(chainBalance.balance * precisionMultiplier) /
+      precisionMultiplier
     return flooredBalance.toFixed(displayPrecision)
   } else if (assetToken && assetToken.totalBalanceRaw > 0n) {
     // Fallback to total balance (already human-readable)
     const flooredBalance =
-      Math.floor(assetToken.totalBalance * precisionMultiplier) / precisionMultiplier
+      Math.floor(assetToken.totalBalance * precisionMultiplier) /
+      precisionMultiplier
     return flooredBalance.toFixed(displayPrecision)
   } else {
     return isEth ? '0.0000' : '0.00'

--- a/packages/sdk/src/lend/__mocks__/MockLendProvider.ts
+++ b/packages/sdk/src/lend/__mocks__/MockLendProvider.ts
@@ -141,7 +141,9 @@ export class MockLendProvider extends LendProvider<LendProviderConfig> {
    * Helper method to simulate errors
    */
   simulateError(method: keyof MockLendProvider, error: Error) {
-    const mockMethod = this[method] as MockedFunction<any>
+    const mockMethod = this[method] as MockedFunction<
+      (...args: unknown[]) => unknown
+    >
     if (mockMethod && typeof mockMethod.mockRejectedValue === 'function') {
       mockMethod.mockRejectedValue(error)
     }

--- a/packages/sdk/src/lend/core/__tests__/LendProvider.test.ts
+++ b/packages/sdk/src/lend/core/__tests__/LendProvider.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 
 import { MockUSDCAsset } from '@/__mocks__/MockAssets.js'
 import { MockLendProvider } from '@/lend/__mocks__/MockLendProvider.js'
+import type { Asset } from '@/types/asset.js'
 import type { LendMarketConfig, LendMarketId } from '@/types/lend/index.js'
 import { validateChainSupported } from '@/utils/validation.js'
 
@@ -101,7 +102,7 @@ describe('LendProvider', () => {
       const mockAsset = {
         metadata: { symbol: 'USDC', name: 'USD Coin' },
         address: { 84532: '0x123' as Address },
-      } as any
+      } as unknown as Asset
 
       const markets = await provider.getMarkets({ asset: mockAsset })
       expect(Array.isArray(markets)).toBe(true)

--- a/packages/sdk/src/lend/providers/aave/sdk.ts
+++ b/packages/sdk/src/lend/providers/aave/sdk.ts
@@ -64,7 +64,7 @@ function findMarketInAllowlist(
  * @returns APY breakdown with native APY and rewards
  */
 export function calculateApyBreakdown(reserve: {
-  formattedReserve?: any
+  formattedReserve?: { supplyAPY?: string }
 }): ApyBreakdown {
   // Get supply APY from formatted reserve data
   const supplyApy = reserve.formattedReserve?.supplyAPY

--- a/packages/sdk/src/lend/providers/morpho/__tests__/MorphoLendProvider.test.ts
+++ b/packages/sdk/src/lend/providers/morpho/__tests__/MorphoLendProvider.test.ts
@@ -59,7 +59,9 @@ describe('MorphoLendProvider', () => {
     beforeEach(() => {
       const mockVault = createMockMorphoVault()
 
-      vi.mocked(fetchAccrualVault).mockResolvedValue(mockVault as any)
+      vi.mocked(fetchAccrualVault).mockResolvedValue(
+        mockVault as unknown as Awaited<ReturnType<typeof fetchAccrualVault>>,
+      )
 
       vi.stubGlobal(
         'fetch',
@@ -75,7 +77,7 @@ describe('MorphoLendProvider', () => {
               },
             },
           }),
-        } as any),
+        } as unknown as Response),
       )
     })
 
@@ -114,9 +116,10 @@ describe('MorphoLendProvider', () => {
     })
 
     it('should handle withdrawal errors', async () => {
-      vi.spyOn(provider as any, '_getMarket').mockRejectedValueOnce(
-        new Error('Market fetch failed'),
-      )
+      vi.spyOn(
+        provider as unknown as { _getMarket: () => unknown },
+        '_getMarket',
+      ).mockRejectedValueOnce(new Error('Market fetch failed'))
 
       const amount = 500
       const asset = MockGauntletUSDCMarket.asset
@@ -158,7 +161,9 @@ describe('MorphoLendProvider', () => {
     beforeEach(() => {
       const mockVault = createMockMorphoVault()
 
-      vi.mocked(fetchAccrualVault).mockResolvedValue(mockVault as any)
+      vi.mocked(fetchAccrualVault).mockResolvedValue(
+        mockVault as unknown as Awaited<ReturnType<typeof fetchAccrualVault>>,
+      )
 
       // Mock the fetch API for rewards
       vi.stubGlobal(
@@ -175,7 +180,7 @@ describe('MorphoLendProvider', () => {
               },
             },
           }),
-        } as any),
+        } as unknown as Response),
       )
     })
 
@@ -213,9 +218,10 @@ describe('MorphoLendProvider', () => {
     })
 
     it('should handle lending errors', async () => {
-      vi.spyOn(provider as any, '_getMarket').mockRejectedValueOnce(
-        new Error('Market fetch failed'),
-      )
+      vi.spyOn(
+        provider as unknown as { _getMarket: () => unknown },
+        '_getMarket',
+      ).mockRejectedValueOnce(new Error('Market fetch failed'))
 
       const asset = MockGauntletUSDCMarket.asset
       const amount = 1000

--- a/packages/sdk/src/lend/providers/morpho/__tests__/api.test.ts
+++ b/packages/sdk/src/lend/providers/morpho/__tests__/api.test.ts
@@ -117,10 +117,11 @@ describe('Morpho API Integration', () => {
 
       expect(vaultData).toBeDefined()
       expect(vaultData).not.toBeNull()
-      expect(vaultData.address.toLowerCase()).toBe(
+      if (!vaultData) throw new Error('unreachable')
+      expect(vaultData.address!.toLowerCase()).toBe(
         GAUNTLET_USDC_VAULT.toLowerCase(),
       )
-      expect(vaultData.state.rewards).toHaveLength(2)
+      expect(vaultData.state!.rewards).toHaveLength(2)
     })
 
     it('should return null when vault not found', async () => {
@@ -308,7 +309,8 @@ describe('Morpho API Integration', () => {
 
       expect(vaultData).toBeDefined()
       expect(vaultData).not.toBeNull()
-      expect(vaultData.address.toLowerCase()).toBe(
+      if (!vaultData) throw new Error('unreachable')
+      expect(vaultData.address!.toLowerCase()).toBe(
         GAUNTLET_USDC_VAULT.toLowerCase(),
       )
       expect(vaultData.state).toBeDefined()

--- a/packages/sdk/src/lend/providers/morpho/api.ts
+++ b/packages/sdk/src/lend/providers/morpho/api.ts
@@ -2,6 +2,54 @@ import type { Address } from 'viem'
 
 const MORPHO_API_ENDPOINT = 'https://api.morpho.org/graphql'
 
+/** Asset info returned by Morpho GraphQL rewards query */
+interface MorphoRewardAsset {
+  address?: string
+  name?: string
+  symbol?: string
+  chain?: { id?: number }
+}
+
+/** Individual reward entry from the Morpho GraphQL API */
+interface MorphoReward {
+  asset?: MorphoRewardAsset
+  amountPerSuppliedToken?: string | number
+  supplyApr?: number
+}
+
+/** Market allocation entry from the Morpho GraphQL API */
+interface MorphoMarketAllocation {
+  market?: {
+    id?: string
+    uniqueKey?: string
+    state?: {
+      rewards?: MorphoReward[]
+    }
+  }
+  supplyAssetsUsd?: number
+}
+
+/** Vault state from the Morpho GraphQL API */
+interface MorphoVaultState {
+  rewards?: MorphoReward[]
+  allocation?: MorphoMarketAllocation[]
+}
+
+/** Full vault response from the Morpho GraphQL `vaultByAddress` query */
+export interface MorphoVaultApiResponse {
+  address?: string
+  id?: string
+  state?: MorphoVaultState
+  chain?: { id?: number }
+}
+
+/** Parsed top-level response envelope from Morpho GraphQL */
+interface MorphoGraphQLResponse {
+  data?: {
+    vaultByAddress?: MorphoVaultApiResponse
+  }
+}
+
 export interface RewardsBreakdown {
   /** Reward APR per token, keyed by lowercase token address. 'other' for unrecognized tokens. */
   [tokenAddress: string]: number
@@ -17,7 +65,7 @@ export interface RewardsBreakdown {
 export async function fetchRewards(
   vaultAddress: Address,
   chainId: number,
-): Promise<any | null> {
+): Promise<MorphoVaultApiResponse | null> {
   const vaultQuery = {
     query: `
       query VaultByAddress($address: String!, $chainId: Int) {
@@ -79,8 +127,8 @@ export async function fetchRewards(
       body: JSON.stringify(vaultQuery),
     })
 
-    const vaultData = (await response.json()) as any
-    return vaultData.data?.vaultByAddress || null
+    const vaultData = (await response.json()) as MorphoGraphQLResponse
+    return vaultData.data?.vaultByAddress ?? null
   } catch (apiError) {
     // eslint-disable-next-line no-console
     console.error('Failed to fetch rewards from GraphQL API:', apiError)

--- a/packages/sdk/src/lend/providers/morpho/sdk.ts
+++ b/packages/sdk/src/lend/providers/morpho/sdk.ts
@@ -1,4 +1,4 @@
-import { type AccrualPosition, ChainId } from '@morpho-org/blue-sdk'
+import { ChainId } from '@morpho-org/blue-sdk'
 import {
   adaptiveCurveIrmAbi,
   blueAbi,
@@ -10,6 +10,7 @@ import type { Address, PublicClient } from 'viem'
 import { NATIVELY_SUPPORTED_ASSETS } from '@/constants/assets.js'
 import {
   fetchRewards,
+  type MorphoVaultApiResponse,
   type RewardsBreakdown,
 } from '@/lend/providers/morpho/api.js'
 import { getMorphoContracts } from '@/lend/providers/morpho/contracts.js'
@@ -24,6 +25,25 @@ import type {
   MorphoContracts,
 } from '@/types/lend/index.js'
 import { SECONDS_PER_YEAR } from '@/utils/constants.js'
+
+/** Position data accessed by APY calculations — structural subset of AccrualPosition */
+interface MorphoSdkPosition {
+  supplyShares: bigint
+  supplyAssets: bigint
+  market: { supplyApy?: bigint } | null
+}
+
+/** Single allocation entry from the Morpho SDK vault's allocations Map */
+interface MorphoSdkAllocation {
+  position: MorphoSdkPosition
+}
+
+/** Minimal shape of a Morpho SDK vault used by APY calculation functions */
+interface MorphoSdkVault {
+  totalAssets: bigint
+  fee: bigint
+  allocations: { values(): Iterable<MorphoSdkAllocation> }
+}
 
 /**
  * Fetch and calculate rewards breakdown from Morpho GraphQL API
@@ -71,7 +91,7 @@ function buildEmptyRewards(
  * @param vault - Vault data from Morpho SDK
  * @returns Base APY (before rewards, after fees)
  */
-export function calculateBaseApy(vault: any): number {
+export function calculateBaseApy(vault: MorphoSdkVault): number {
   try {
     if (vault.totalAssets === 0n) {
       return 0
@@ -81,8 +101,8 @@ export function calculateBaseApy(vault: any): number {
     const allocationsArray = Array.from(vault.allocations.values())
 
     const totalWeightedApy = allocationsArray.reduce(
-      (total: bigint, allocation: any) => {
-        const position: AccrualPosition = allocation.position
+      (total: bigint, allocation: MorphoSdkAllocation) => {
+        const position = allocation.position
         const market = position.market
 
         if (market && position.supplyShares > 0n) {
@@ -470,7 +490,7 @@ export async function findBestVaultForAsset(
  * @returns Complete APY breakdown
  */
 export function calculateApyBreakdown(
-  vault: any,
+  vault: MorphoSdkVault,
   rewardsBreakdown: RewardsBreakdown,
 ): ApyBreakdown {
   // 1. Calculate base APY from SDK data (before fees)
@@ -517,7 +537,7 @@ function categorizeRewardAsset(
  * @returns Detailed rewards breakdown
  */
 export function calculateRewardsBreakdown(
-  apiVault: any,
+  apiVault: MorphoVaultApiResponse,
   chainId: number,
   marketAsset?: Asset,
 ): RewardsBreakdown {
@@ -554,7 +574,7 @@ export function calculateRewardsBreakdown(
   // Calculate market-level rewards (weighted by allocation)
   if (apiVault.state?.allocation && apiVault.state.allocation.length > 0) {
     const totalSupplyUsd = apiVault.state.allocation.reduce(
-      (total: number, alloc: any) => {
+      (total: number, alloc: { supplyAssetsUsd?: number }) => {
         return total + (alloc.supplyAssetsUsd || 0)
       },
       0,

--- a/packages/sdk/src/services/__mocks__/MockChainManager.ts
+++ b/packages/sdk/src/services/__mocks__/MockChainManager.ts
@@ -122,7 +122,7 @@ export class MockChainManager {
       getBalance: vi.fn().mockImplementation(() => {
         return Promise.resolve(this.config.defaultBalance)
       }),
-    } as any
+    } as unknown as PublicClient
   }
 
   private createBundlerClient(): BundlerClient {
@@ -130,6 +130,6 @@ export class MockChainManager {
       sendUserOperation: vi.fn(),
       waitForUserOperationReceipt: vi.fn(),
       prepareUserOperation: vi.fn(),
-    } as any
+    } as unknown as BundlerClient
   }
 }

--- a/packages/sdk/src/services/tokenBalance.spec.ts
+++ b/packages/sdk/src/services/tokenBalance.spec.ts
@@ -17,7 +17,7 @@ describe('TokenBalance', () => {
     chainManager = new MockChainManager({
       supportedChains: [unichain.id],
       defaultBalance: 1000000n,
-    }) as any
+    }) as unknown as ChainManager
   })
 
   describe('fetchBalance', () => {
@@ -50,7 +50,7 @@ describe('TokenBalance', () => {
         },
         address: {
           27637: '0xBAa5CC21fd487B8Fcc2F632f3F4E8D37262a0842',
-        } as any,
+        } as unknown as Asset['address'],
         type: 'erc20',
       }
 

--- a/packages/sdk/src/swap/providers/uniswap/__tests__/sdk.test.ts
+++ b/packages/sdk/src/swap/providers/uniswap/__tests__/sdk.test.ts
@@ -131,7 +131,11 @@ describe('getQuote', () => {
     })
 
     const call = vi.mocked(publicClient.simulateContract).mock.calls[0][0]
-    const args = (call as any).args[0]
+    const args = (
+      call as unknown as {
+        args: [{ poolKey: { currency0: string; currency1: string } }]
+      }
+    ).args[0]
     // currency0 should be the lower address
     expect(
       args.poolKey.currency0.toLowerCase() <
@@ -154,7 +158,11 @@ describe('getQuote', () => {
     })
 
     const call = vi.mocked(publicClient.simulateContract).mock.calls[0][0]
-    const args = (call as any).args[0]
+    const args = (
+      call as unknown as {
+        args: [{ poolKey: { currency0: string; currency1: string } }]
+      }
+    ).args[0]
     // Native ETH should be address(0), sorted as currency0 (lowest possible address)
     expect(args.poolKey.currency0).toBe(zeroAddress)
   })
@@ -174,7 +182,11 @@ describe('getQuote', () => {
     })
 
     const call = vi.mocked(publicClient.simulateContract).mock.calls[0][0]
-    const args = (call as any).args[0]
+    const args = (
+      call as unknown as {
+        args: [{ poolKey: { currency0: string; currency1: string } }]
+      }
+    ).args[0]
     // Native ETH should be address(0) regardless of swap direction
     expect(args.poolKey.currency0).toBe(zeroAddress)
   })

--- a/packages/sdk/src/utils/assets.test.ts
+++ b/packages/sdk/src/utils/assets.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { MockUSDCAsset, MockWETHAsset } from '@/__mocks__/MockAssets.js'
+import type { SupportedChainId } from '@/constants/supportedChains.js'
 import { isAssetSupportedOnChain, parseAssetAmount } from '@/utils/assets.js'
 
 describe('Asset Utilities', () => {
@@ -10,7 +11,12 @@ describe('Asset Utilities', () => {
     })
 
     it('should return false for asset on unsupported chain', () => {
-      expect(isAssetSupportedOnChain(MockUSDCAsset, 999 as any)).toBe(false)
+      expect(
+        isAssetSupportedOnChain(
+          MockUSDCAsset,
+          999 as unknown as SupportedChainId,
+        ),
+      ).toBe(false)
     })
 
     it('should return correct metadata for MockUSDCAsset', () => {

--- a/packages/sdk/src/utils/test.ts
+++ b/packages/sdk/src/utils/test.ts
@@ -111,7 +111,7 @@ export async function startSupersim(
 
   // Handle case where supersim command is not found
   supersimProcess.on('error', (error) => {
-    if ((error as any).code === 'ENOENT') {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
       throw new Error(
         'supersim command not found. Please install supersim:\n' +
           '  macOS/Linux: brew install ethereum-optimism/tap/supersim\n' +
@@ -249,7 +249,7 @@ export async function fundWallet(config: FundWalletConfig): Promise<void> {
     account: funderAccount,
     chain,
     transport: http(rpcUrl),
-  }) as any // Type assertion to avoid viem version compatibility issue
+  })
 
   // Send ETH funding transaction
   const fundingTx = await funderClient.sendTransaction({
@@ -273,8 +273,12 @@ export async function fundWallet(config: FundWalletConfig): Promise<void> {
 
       // Impersonate the whale account
       console.log(`Impersonating whale account: ${usdcWhale}`)
-      await publicClient.request({
-        method: 'anvil_impersonateAccount' as any,
+      await (
+        publicClient as unknown as {
+          request: (args: { method: string; params: string[] }) => Promise<void>
+        }
+      ).request({
+        method: 'anvil_impersonateAccount',
         params: [usdcWhale],
       })
 
@@ -320,8 +324,12 @@ export async function fundWallet(config: FundWalletConfig): Promise<void> {
       )
 
       // Stop impersonating the account
-      await publicClient.request({
-        method: 'anvil_stopImpersonatingAccount' as any,
+      await (
+        publicClient as unknown as {
+          request: (args: { method: string; params: string[] }) => Promise<void>
+        }
+      ).request({
+        method: 'anvil_stopImpersonatingAccount',
         params: [usdcWhale],
       })
     } catch (error) {

--- a/packages/sdk/src/wallet/core/wallets/smart/default/__tests__/DefaultSmartWallet.spec.ts
+++ b/packages/sdk/src/wallet/core/wallets/smart/default/__tests__/DefaultSmartWallet.spec.ts
@@ -145,7 +145,7 @@ describe('DefaultSmartWallet', () => {
       client: mockChainManager.getPublicClient(baseSepolia.id),
       owners: [mockSigner],
       nonce: BigInt(0),
-    } as any
+    } as unknown as Awaited<ReturnType<typeof toCoinbaseSmartAccount>>
     vi.mocked(toCoinbaseSmartAccount).mockResolvedValue(mockAccount)
     const bundlerClient = mockChainManager.getBundlerClient(
       chainId,
@@ -219,7 +219,7 @@ describe('DefaultSmartWallet', () => {
       client: mockChainManager.getPublicClient(baseSepolia.id),
       owners: [mockSigner],
       nonce: BigInt(0),
-    } as any
+    } as unknown as Awaited<ReturnType<typeof toCoinbaseSmartAccount>>
     vi.mocked(toCoinbaseSmartAccount).mockResolvedValue(mockAccount)
     const bundlerClient = mockChainManager.getBundlerClient(
       chainId,

--- a/packages/sdk/src/wallet/react/wallets/hosted/dynamic/__tests__/DynamicWallet.spec.ts
+++ b/packages/sdk/src/wallet/react/wallets/hosted/dynamic/__tests__/DynamicWallet.spec.ts
@@ -140,7 +140,7 @@ describe('DynamicWallet', () => {
       })
     } catch (err) {
       expect((err as Error).message).toBe('Failed to initialize wallet')
-      expect((err as any).cause?.message).toBe(
+      expect((err as Error & { cause?: Error }).cause?.message).toBe(
         'Wallet not connected or not EVM compatible',
       )
     }

--- a/packages/sdk/src/wallet/react/wallets/hosted/privy/__tests__/PrivyWallet.spec.ts
+++ b/packages/sdk/src/wallet/react/wallets/hosted/privy/__tests__/PrivyWallet.spec.ts
@@ -50,7 +50,7 @@ describe('PrivyWallet (React)', () => {
       signMessage: vi.fn(),
       signTransaction: vi.fn(),
       signTypedData: vi.fn(),
-    } as any
+    } as unknown as Awaited<ReturnType<typeof toViemAccount>>
     vi.mocked(toViemAccount).mockResolvedValue(mockViemAccount)
     const connectedWallet = {
       __brand: 'privy-connected-wallet',
@@ -82,7 +82,7 @@ describe('PrivyWallet (React)', () => {
       signMessage: vi.fn(),
       signTransaction: vi.fn(),
       signTypedData: vi.fn(),
-    } as any)
+    } as unknown as Awaited<ReturnType<typeof toViemAccount>>)
     const connectedWallet = {
       __brand: 'privy-connected-wallet',
     } as unknown as ConnectedWallet


### PR DESCRIPTION
This change sweeps through 23 files in `packages/sdk`, `packages/demo/backend`, and `packages/demo/frontend` to eliminate every `@typescript-eslint/no-explicit-any` suppression. In the SDK source layer, the biggest wins are in `lend/providers/morpho/api.ts` and `lend/providers/morpho/sdk.ts`: `fetchRewards` now returns a properly typed `MorphoVaultApiResponse` instead of `any`, backed by four new interfaces (`MorphoRewardAsset`, `MorphoReward`, `MorphoMarketAllocation`, `MorphoVaultState`) that model the Morpho GraphQL schema. `calculateBaseApy`, `calculateApyBreakdown`, and `calculateRewardsBreakdown` in `sdk.ts` receive a structural `MorphoSdkVault` interface instead of `any`, and the inline `AccrualPosition` cast is gone — the reducer callback and `allocation.position` are now typed through `MorphoSdkAllocation`/`MorphoSdkPosition`. In `aave/sdk.ts`, `calculateApyBreakdown`'s `formattedReserve` parameter moves from `any` to `{ supplyAPY?: string }`. Over in `utils/test.ts`, the Anvil RPC calls (`anvil_impersonateAccount` / `anvil_stopImpersonatingAccount`) are handled via a structural cast on `publicClient.request` instead of casting the method string to `any`, and the redundant `as any` on `createWalletClient` is simply removed because viem's types already match.

In test files the pattern is consistent: every `as any` mock cast becomes `as unknown as <ConcreteType>`, where `<ConcreteType>` is derived from the function's actual return type — e.g. `ReturnType<typeof getActions>`, `Awaited<ReturnType<typeof fetchAccrualVault>>`, `Context` (from Hono), `PublicClient`, `BundlerClient`, `Asset`, `SupportedChainId`, or `Awaited<ReturnType<typeof toCoinbaseSmartAccount>>`. This two-step cast through `unknown` is the standard TypeScript escape hatch when building partial mocks: it satisfies the compiler while still documenting the intended type at the call site. The Morpho API test (`api.test.ts`) adds narrowing guards (`if (!vaultData) throw new Error('unreachable')`) before property access so the non-null assertions are explicit rather than silently swallowed by `any`. The `DynamicWallet.spec.ts` error-cause access switches from `(err as any).cause` to `(err as Error & { cause?: Error }).cause`, preserving type safety on the chained cause.

The design intent is to make every `any` removal a local, minimal change — introduce the narrowest structural interface that satisfies the call site, prefer `ReturnType`/`Awaited` utility types over hand-rolled duplicates, and avoid pulling in heavy external type packages. The Solidity file `DeployMorphoMarket.s.sol` only has a formatting adjustment that crept in from the linter pass. I ran `pnpm typecheck` and `pnpm lint` across the entire monorepo after the changes, confirming zero type errors and that the `no-explicit-any` warning count drops to zero in all touched files.

Closes https://github.com/ethereum-optimism/actions/issues/337