### PR TITLE
CI: remove rollup check, simplify foundry install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,28 +154,13 @@ jobs:
       - image: cimg/node:20.11
     resource_class: large
     steps:
-      - attach_workspace:
-          at: .
-      - run:
-          name: Install Foundry
-          command: |
-            mkdir -p ~/.foundry/bin
-            curl -sSf -L https://raw.githubusercontent.com/foundry-rs/foundry/master/foundryup/foundryup -o ~/.foundry/bin/foundryup
-            chmod +x ~/.foundry/bin/foundryup
-            ~/.foundry/bin/foundryup
+      - setup
       - run:
           name: Build Contracts
-          command: export PATH="$HOME/.foundry/bin:$PATH" && cd packages/demo/contracts && pnpm build
+          command: cd packages/demo/contracts && pnpm build
       - run:
           name: Test Contracts
-          command: export PATH="$HOME/.foundry/bin:$PATH" && cd packages/demo/contracts && pnpm test
-
-  # Rollup job to satisfy branch protection expecting "check"
-  check:
-    docker:
-      - image: cimg/node:20.11
-    steps:
-      - run: echo "All checks passed"
+          command: cd packages/demo/contracts && pnpm test
 
 workflows:
   release:
@@ -220,13 +205,5 @@ workflows:
           context:
             - circleci-repo-readonly-authenticated-github-token
       - check-contracts:
-          requires:
-            - install-and-build
           context:
             - circleci-repo-readonly-authenticated-github-token
-      - check:
-          requires:
-            - check-sdk
-            - check-backend
-            - check-frontend
-            - check-contracts


### PR DESCRIPTION
Follow-up to #372.

## Changes
- **Remove rollup `check` job.** Branch protection will be updated in the same window to require the four per-package checks (`check-sdk`, `check-backend`, `check-frontend`, `check-contracts`) directly, which also restores granular failure visibility in the GitHub UI.
- **`check-contracts` uses shared `setup`.** Drops the curl/foundryup install and `attach_workspace`. Foundry now comes from `mise.toml` like every other job, so version is pinned instead of floating nightly.

## Coordination
Branch protection on `main` needs to switch from requiring `ci/circleci: check` to requiring the four per-package checks. I'll flip that immediately after this lands (or just before, to avoid a briefly-blocked state on this PR itself).

Other open PRs will need to rebase onto main to pick up the new job names — same requirement introduced by #372.