### PR TITLE
ci: fix OIDC claims JSON escaping and context-bind trust entry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,14 @@ jobs:
       - run:
           name: Obtain OIDC token for npm trusted publishing
           command: |
-            echo "export NPM_ID_TOKEN=$(circleci run oidc get --claims '{\"aud\": \"npm:registry.npmjs.org\"}')" >> "$BASH_ENV"
+            set -e
+            NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud":"npm:registry.npmjs.org"}')
+            if [ -z "$NPM_ID_TOKEN" ]; then
+              echo "ERROR: circleci run oidc get returned an empty token" >&2
+              exit 1
+            fi
+            echo "OIDC token fetched (length=${#NPM_ID_TOKEN})"
+            echo "export NPM_ID_TOKEN=$NPM_ID_TOKEN" >> "$BASH_ENV"
 
       - when:
           condition:


### PR DESCRIPTION
This pull request updates the process for obtaining the OIDC token for npm trusted publishing in the `.circleci/config.yml` file. The main improvement is the addition of error handling to ensure the token is successfully fetched before proceeding.

**CI/CD pipeline improvements:**

* Fixed the JSON payload passed to `circleci run oidc get --claims` so it is valid JSON and the CLI returns a non-empty token.
* Added error handling to check if the OIDC token is empty after fetching; the script now exits with an error message if the token is not retrieved, improving reliability of npm publishing.
* Added a debug log to display the length of the fetched OIDC token, aiding troubleshooting without exposing the token value.
