### PR TITLE
feat(sdk): skip lend approvals when allowance is sufficient

### DIFF
--- a/packages/sdk/src/actions/lend/core/LendProvider.ts
+++ b/packages/sdk/src/actions/lend/core/LendProvider.ts
@@ -22,7 +22,7 @@ import type {
   LendTransaction,
   TransactionData,
 } from '@/types/lend/index.js'
-import { buildErc20ApprovalTx } from '@/utils/approve.js'
+import { buildApprovalTxIfNeeded } from '@/utils/approve.js'
 import { validateChainSupported } from '@/utils/validation.js'
 
 /**
@@ -273,18 +273,24 @@ export abstract class LendProvider<
   }
 
   /**
-   * Build an ERC20 approval transaction
-   * @param tokenAddress - Address of the token to approve
-   * @param spender - Address to approve spending for
-   * @param amount - Amount to approve
-   * @returns Transaction data for the approval
+   * Build an ERC20 approval transaction only if the on-chain allowance is insufficient.
+   * Reads the current allowance via the chain's public client and approves only the
+   * deficit, returning `undefined` when the existing allowance already covers `amount`.
+   * @param params - Token, owner, spender, required amount, and chainId
+   * @returns Approval transaction for the deficit, or undefined if allowance is sufficient
    */
-  protected buildApprovalTx(
-    tokenAddress: Address,
-    spender: Address,
-    amount: bigint,
-  ): TransactionData {
-    return buildErc20ApprovalTx(tokenAddress, spender, amount)
+  protected buildApprovalTx(params: {
+    chainId: SupportedChainId
+    token: Address
+    owner: Address
+    spender: Address
+    amount: bigint
+  }): Promise<TransactionData | undefined> {
+    const { chainId, ...rest } = params
+    return buildApprovalTxIfNeeded({
+      publicClient: this.chainManager.getPublicClient(chainId),
+      ...rest,
+    })
   }
 
   /**

--- a/packages/sdk/src/actions/lend/providers/aave/AaveLendProvider.ts
+++ b/packages/sdk/src/actions/lend/providers/aave/AaveLendProvider.ts
@@ -279,11 +279,13 @@ export class AaveLendProvider extends LendProvider<LendProviderConfig> {
       marketId: params.marketId.address,
       apy: marketInfo.apy.total,
       transactionData: {
-        approval: this.buildApprovalTx(
-          assetAddress,
-          poolAddress,
-          params.amountWei,
-        ),
+        approval: await this.buildApprovalTx({
+          chainId: params.marketId.chainId,
+          token: assetAddress,
+          owner: params.walletAddress,
+          spender: poolAddress,
+          amount: params.amountWei,
+        }),
         position: {
           to: poolAddress,
           data: supplyCallData,
@@ -335,11 +337,13 @@ export class AaveLendProvider extends LendProvider<LendProviderConfig> {
       marketId: params.marketId.address,
       apy: marketInfo.apy.total,
       transactionData: {
-        approval: this.buildApprovalTx(
-          aWETHAddress,
-          gatewayAddress,
-          params.amount,
-        ),
+        approval: await this.buildApprovalTx({
+          chainId: params.marketId.chainId,
+          token: aWETHAddress,
+          owner: params.walletAddress,
+          spender: gatewayAddress,
+          amount: params.amount,
+        }),
         position: {
           to: gatewayAddress,
           data: withdrawCallData,

--- a/packages/sdk/src/actions/lend/providers/aave/__tests__/AaveLendProvider.test.ts
+++ b/packages/sdk/src/actions/lend/providers/aave/__tests__/AaveLendProvider.test.ts
@@ -1,3 +1,4 @@
+import { encodeFunctionData, erc20Abi } from 'viem'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { MockReceiverAddress } from '@/actions/lend/__mocks__/MockMarkets.js'
@@ -201,6 +202,59 @@ describe('AaveLendProvider', () => {
           walletAddress: MockReceiverAddress,
         }),
       ).rejects.toThrow('Failed to open position')
+    })
+
+    it('should skip approval when existing allowance is sufficient', async () => {
+      const amount = 1000
+      const asset = MockAaveUSDCAsset
+      const marketId = {
+        address: MockAaveUSDCMarket.address,
+        chainId: MockAaveUSDCMarket.chainId,
+      }
+      // Allowance already covers the 1000 USDC (1e9 wei) deposit
+      const client = mockChainManager.getPublicClient(marketId.chainId)
+      vi.mocked(client.readContract).mockResolvedValueOnce(10n ** 18n)
+
+      const lendTransaction = await provider.openPosition({
+        amount,
+        asset,
+        marketId,
+        walletAddress: MockReceiverAddress,
+      })
+
+      expect(lendTransaction.transactionData.approval).toBeUndefined()
+      expect(lendTransaction.transactionData).toHaveProperty('position')
+    })
+
+    it('should approve only the deficit when existing allowance is partial', async () => {
+      const amount = 1000 // 1e9 wei at 6 decimals
+      const asset = MockAaveUSDCAsset
+      const marketId = {
+        address: MockAaveUSDCMarket.address,
+        chainId: MockAaveUSDCMarket.chainId,
+      }
+      // Base Aave V3 Pool
+      const basePoolAddress = '0xA238Dd80C259a72e81d7e4664a9801593F98d1c5'
+      const existingAllowance = 400_000_000n // 400 USDC
+      const expectedDeficit = 600_000_000n // required 1e9 - existing 4e8
+      const client = mockChainManager.getPublicClient(marketId.chainId)
+      vi.mocked(client.readContract).mockResolvedValueOnce(existingAllowance)
+
+      const lendTransaction = await provider.openPosition({
+        amount,
+        asset,
+        marketId,
+        walletAddress: MockReceiverAddress,
+      })
+
+      expect(lendTransaction.transactionData.approval).toBeDefined()
+      expect(lendTransaction.transactionData.approval!.data).toBe(
+        encodeFunctionData({
+          abi: erc20Abi,
+          functionName: 'approve',
+          args: [basePoolAddress, expectedDeficit],
+        }),
+      )
     })
   })
 

--- a/packages/sdk/src/actions/lend/providers/morpho/MorphoLendProvider.ts
+++ b/packages/sdk/src/actions/lend/providers/morpho/MorphoLendProvider.ts
@@ -69,11 +69,13 @@ export class MorphoLendProvider extends LendProvider<LendProviderConfig> {
         marketId: params.marketId.address,
         apy: vaultInfo.apy.total,
         transactionData: {
-          approval: this.buildApprovalTx(
-            assetAddress,
-            params.marketId.address,
-            params.amountWei,
-          ),
+          approval: await this.buildApprovalTx({
+            chainId: params.marketId.chainId,
+            token: assetAddress,
+            owner: params.walletAddress,
+            spender: params.marketId.address,
+            amount: params.amountWei,
+          }),
           position: {
             to: params.marketId.address,
             data: depositCallData,

--- a/packages/sdk/src/actions/lend/providers/morpho/__tests__/MorphoLendProvider.test.ts
+++ b/packages/sdk/src/actions/lend/providers/morpho/__tests__/MorphoLendProvider.test.ts
@@ -1,4 +1,5 @@
 import { fetchAccrualVault } from '@morpho-org/blue-sdk-viem'
+import { encodeFunctionData, erc20Abi } from 'viem'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
@@ -232,6 +233,56 @@ describe('MorphoLendProvider', () => {
           walletAddress: MockReceiverAddress,
         }),
       ).rejects.toThrow('Failed to open position')
+    })
+
+    it('should skip approval when existing allowance is sufficient', async () => {
+      const amount = 1000
+      const asset = MockGauntletUSDCMarket.asset
+      const marketId = {
+        address: MockGauntletUSDCMarket.address,
+        chainId: MockGauntletUSDCMarket.chainId,
+      }
+      const client = mockChainManager.getPublicClient(marketId.chainId)
+      vi.mocked(client.readContract).mockResolvedValueOnce(10n ** 18n)
+
+      const lendTransaction = await provider.openPosition({
+        amount,
+        asset,
+        marketId,
+        walletAddress: MockReceiverAddress,
+      })
+
+      expect(lendTransaction.transactionData.approval).toBeUndefined()
+      expect(lendTransaction.transactionData).toHaveProperty('position')
+    })
+
+    it('should approve only the deficit when existing allowance is partial', async () => {
+      const amount = 1000 // 1e9 wei at 6 decimals
+      const asset = MockGauntletUSDCMarket.asset
+      const marketId = {
+        address: MockGauntletUSDCMarket.address,
+        chainId: MockGauntletUSDCMarket.chainId,
+      }
+      const existingAllowance = 400_000_000n
+      const expectedDeficit = 600_000_000n
+      const client = mockChainManager.getPublicClient(marketId.chainId)
+      vi.mocked(client.readContract).mockResolvedValueOnce(existingAllowance)
+
+      const lendTransaction = await provider.openPosition({
+        amount,
+        asset,
+        marketId,
+        walletAddress: MockReceiverAddress,
+      })
+
+      expect(lendTransaction.transactionData.approval).toBeDefined()
+      expect(lendTransaction.transactionData.approval!.data).toBe(
+        encodeFunctionData({
+          abi: erc20Abi,
+          functionName: 'approve',
+          args: [marketId.address, expectedDeficit],
+        }),
+      )
     })
   })
 


### PR DESCRIPTION
## Summary

Closes #133.

Aave and Morpho lend providers always emit an `approve(amount)` tx alongside every supply/withdraw, even when the user already has enough on-chain allowance. With the 4337 batch path this shows up as an extra UserOperation and wasted gas. Applies the same pattern the Velodrome swap provider already uses (`buildApprovalTxIfNeeded` from `utils/approve.ts`).

- Rework the base `LendProvider.buildApprovalTx` helper from a sync `buildErc20ApprovalTx(...)` wrapper into an async thin wrapper over `buildApprovalTxIfNeeded({ publicClient, token, owner, spender, amount })`.
- Update the three approval sites to pass `{ chainId, token, owner, spender, amount }` and `await` the result:
  - `AaveLendProvider._openERC20Position` (asset → Pool)
  - `AaveLendProvider._closeETHPosition` (aWETH → WETHGateway)
  - `MorphoLendProvider._openPosition` (asset → MetaMorpho vault)

When `allowance >= amount`, `approval` is `undefined`; otherwise it approves only the deficit (`amount - allowance`), matching the swap provider behaviour.

No consumer changes needed: `LendTransaction.transactionData.approval` was already `TransactionData | undefined`, and `WalletLendNamespace.dispatch` already falls through to a single-tx send when `approval` is undefined.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 486 tests pass (4 new)
- [x] `pnpm lint` — no new warnings

New unit tests (per provider):
- approval is `undefined` when on-chain allowance ≥ required amount
- approval encodes the deficit (`amount - existingAllowance`) when allowance is partial

The existing tests that assert `transactionData.approval` is defined still hold: the mock `readContract` defaults to `1_000_000n` (1 USDC), so deposits of 1000 USDC (`1e9` wei) trigger the approval path.