### PR TITLE
fix(sdk): require strict quote recipient match on execute

### DIFF
--- a/packages/sdk/src/actions/swap/__mocks__/MockSwapProvider.ts
+++ b/packages/sdk/src/actions/swap/__mocks__/MockSwapProvider.ts
@@ -10,7 +10,6 @@ import type { Asset } from '@/types/asset.js'
 import type {
   GetSwapMarketParams,
   GetSwapMarketsParams,
-  NormalizedSwapQuote,
   ResolvedSwapParams,
   SwapMarket,
   SwapProviderConfig,
@@ -38,7 +37,7 @@ export class MockSwapProvider extends SwapProvider<SwapProviderConfig> {
     (params: SwapQuoteParams) => Promise<SwapQuote>
   >
   public mockBuildApprovals: MockedFunction<
-    (quote: NormalizedSwapQuote) => Promise<{
+    (quote: SwapQuote) => Promise<{
       tokenApproval?: TransactionData
       permit2Approval?: TransactionData
     }>
@@ -125,7 +124,7 @@ export class MockSwapProvider extends SwapProvider<SwapProviderConfig> {
     return this.mockGetQuote(params)
   }
 
-  protected async _buildApprovals(quote: NormalizedSwapQuote) {
+  protected async _buildApprovals(quote: SwapQuote) {
     return this.mockBuildApprovals(quote)
   }
 
@@ -207,7 +206,7 @@ export class MockSwapProvider extends SwapProvider<SwapProviderConfig> {
       quotedAt: now,
       expiresAt: deadline,
       gasEstimate: 150000n,
-      quotedRecipient: (params.recipient ??
+      recipient: (params.recipient ??
         '0x0000000000000000000000000000000000000001') as Address,
     }
   }

--- a/packages/sdk/src/actions/swap/core/SwapProvider.ts
+++ b/packages/sdk/src/actions/swap/core/SwapProvider.ts
@@ -429,7 +429,7 @@ export abstract class SwapProvider<
     validateAmountPositiveIfExists(params.amountIn)
     validateAmountPositiveIfExists(params.amountOut)
     validateSlippage(params.slippage ?? this.defaultSlippage, this.maxSlippage)
-    validateRecipient('recipient' in params ? params.recipient : undefined)
+    validateRecipient(params.recipient)
   }
 
   private validateQuoteExpiration(quote: SwapQuote): void {

--- a/packages/sdk/src/actions/swap/core/SwapProvider.ts
+++ b/packages/sdk/src/actions/swap/core/SwapProvider.ts
@@ -14,7 +14,6 @@ import type { Asset } from '@/types/asset.js'
 import type {
   GetSwapMarketParams,
   GetSwapMarketsParams,
-  NormalizedSwapQuote,
   ResolvedSwapParams,
   SwapExecuteParams,
   SwapMarket,
@@ -381,37 +380,31 @@ export abstract class SwapProvider<
   }
 
   /**
-   * Build a SwapTransaction from a quote by fetching approvals and wrapping the swap calldata.
-   * Used by both the quote-execute path and provider _execute implementations.
-   * Normalises `quote.recipient` to `quote.quotedRecipient` when absent so
-   * provider `_buildApprovals` implementations can dereference `quote.recipient`
-   * without per-provider fallback logic.
-   * @param quote - SwapQuote (recipient may be unset; defaults to quotedRecipient)
+   * Build a SwapTransaction from a quote by fetching approvals and wrapping
+   * the swap calldata. Quotes are required to have `recipient` set by the
+   * provider's `_getQuote`; sub-providers can dereference `quote.recipient`
+   * directly.
    */
   protected async buildSwapTransactions(
     quote: SwapQuote,
   ): Promise<SwapTransaction> {
-    const normalized: NormalizedSwapQuote = {
-      ...quote,
-      recipient: quote.recipient ?? quote.quotedRecipient,
-    }
-    const approvals = await this._buildApprovals(normalized)
+    const approvals = await this._buildApprovals(quote)
 
     const swapTx: TransactionData = {
-      to: normalized.execution.routerAddress,
-      data: normalized.execution.swapCalldata,
-      value: normalized.execution.value,
+      to: quote.execution.routerAddress,
+      data: quote.execution.swapCalldata,
+      value: quote.execution.value,
     }
 
     return {
-      amountIn: normalized.amountIn,
-      amountOut: normalized.amountOut,
-      amountInRaw: normalized.amountInRaw,
-      amountOutRaw: normalized.amountOutRaw,
-      assetIn: normalized.assetIn,
-      assetOut: normalized.assetOut,
-      price: normalized.price,
-      priceImpact: normalized.priceImpact,
+      amountIn: quote.amountIn,
+      amountOut: quote.amountOut,
+      amountInRaw: quote.amountInRaw,
+      amountOutRaw: quote.amountOutRaw,
+      assetIn: quote.assetIn,
+      assetOut: quote.assetOut,
+      price: quote.price,
+      priceImpact: quote.priceImpact,
       transactionData: { ...approvals, swap: swapTx },
     }
   }
@@ -423,32 +416,6 @@ export abstract class SwapProvider<
   private async executeFromQuote(quote: SwapQuote): Promise<SwapTransaction> {
     this.validateQuoteExpiration(quote)
     validateNotZeroAddress(quote.execution.routerAddress, 'routerAddress')
-
-    if (!quote.recipient) {
-      throw new Error(
-        'SwapQuote.recipient is required for execution. Pass the quote through WalletSwapNamespace.execute() which injects the wallet address.',
-      )
-    }
-
-    // If the recipient changed since the quote was built (e.g. quote from
-    // ActionsSwapNamespace executed through WalletSwapNamespace), re-encode
-    // calldata with the correct recipient to prevent tokens going to the wrong address.
-    if (quote.recipient !== quote.quotedRecipient) {
-      const freshQuote = await this._getQuote({
-        assetIn: quote.assetIn,
-        assetOut: quote.assetOut,
-        amountIn: quote.amountIn,
-        chainId: quote.chainId,
-        slippage: quote.slippage,
-        deadline: quote.deadline,
-        recipient: quote.recipient,
-      })
-      return this.buildSwapTransactions({
-        ...freshQuote,
-        recipient: quote.recipient,
-      })
-    }
-
     return this.buildSwapTransactions(quote)
   }
 
@@ -568,12 +535,12 @@ export abstract class SwapProvider<
 
   /**
    * Build provider-specific approval transactions for a swap.
-   * Called by the base class during executeFromQuote with a validated recipient.
-   * @param quote - NormalizedSwapQuote with recipient guaranteed to be set
+   * Called by the base class during executeFromQuote.
+   * @param quote - SwapQuote with recipient set by the provider's _getQuote
    * @returns Approval transactions needed before the swap (tokenApproval, permit2Approval)
    */
   protected abstract _buildApprovals(
-    quote: NormalizedSwapQuote,
+    quote: SwapQuote,
   ): Promise<Omit<SwapTransactionData, 'swap'>>
 
   protected abstract _getMarket(

--- a/packages/sdk/src/actions/swap/core/__tests__/SwapProvider.test.ts
+++ b/packages/sdk/src/actions/swap/core/__tests__/SwapProvider.test.ts
@@ -226,28 +226,7 @@ describe('SwapProvider', () => {
   })
 
   describe('buildSwapTransactions()', () => {
-    it('normalizes quote.recipient to quotedRecipient when absent', async () => {
-      const provider = new MockSwapProvider()
-      const quote = await provider.getQuote({
-        assetIn: MockUSDC,
-        assetOut: MockWETH,
-        amountIn: 100,
-        chainId: 84532 as SupportedChainId,
-      })
-      // Raw quote has no recipient, only quotedRecipient
-      expect(quote.recipient).toBeUndefined()
-      expect(quote.quotedRecipient).toBeDefined()
-
-      await provider.testBuildSwapTransactions(quote)
-
-      expect(provider.mockBuildApprovals).toHaveBeenCalledWith(
-        expect.objectContaining({
-          recipient: quote.quotedRecipient,
-        }),
-      )
-    })
-
-    it('preserves quote.recipient when already set', async () => {
+    it('passes quote.recipient through to _buildApprovals', async () => {
       const provider = new MockSwapProvider()
       const customRecipient =
         '0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB' as Address
@@ -256,18 +235,26 @@ describe('SwapProvider', () => {
         assetOut: MockWETH,
         amountIn: 100,
         chainId: 84532 as SupportedChainId,
-      })
-
-      await provider.testBuildSwapTransactions({
-        ...quote,
         recipient: customRecipient,
       })
+      expect(quote.recipient).toBe(customRecipient)
+
+      await provider.testBuildSwapTransactions(quote)
 
       expect(provider.mockBuildApprovals).toHaveBeenCalledWith(
-        expect.objectContaining({
-          recipient: customRecipient,
-        }),
+        expect.objectContaining({ recipient: customRecipient }),
       )
+    })
+
+    it('defaults quote.recipient to UNIVERSAL_ROUTER_MSG_SENDER when no recipient is provided', async () => {
+      const provider = new MockSwapProvider()
+      const quote = await provider.getQuote({
+        assetIn: MockUSDC,
+        assetOut: MockWETH,
+        amountIn: 100,
+        chainId: 84532 as SupportedChainId,
+      })
+      expect(quote.recipient).toBe('0x0000000000000000000000000000000000000001')
     })
   })
 

--- a/packages/sdk/src/actions/swap/namespaces/WalletSwapNamespace.ts
+++ b/packages/sdk/src/actions/swap/namespaces/WalletSwapNamespace.ts
@@ -1,3 +1,5 @@
+import { isAddressEqual } from 'viem'
+
 import { QUOTE_DISCRIMINATOR } from '@/actions/swap/core/SwapProvider.js'
 import { BaseSwapNamespace } from '@/actions/swap/namespaces/BaseSwapNamespace.js'
 import type { SupportedChainId } from '@/constants/supportedChains.js'
@@ -88,7 +90,7 @@ export class WalletSwapNamespace extends BaseSwapNamespace {
    * encode the recipient directly into calldata (e.g. Velodrome v2/leaf).
    */
   private requireQuoteForThisWallet(quote: SwapQuote): SwapQuote {
-    if (quote.recipient !== this.wallet.address) {
+    if (!isAddressEqual(quote.recipient, this.wallet.address)) {
       throw new Error(
         `SwapQuote was generated for a different recipient (${quote.recipient}). ` +
           `Re-quote via wallet.swap.getQuote(...) so calldata is bound to this wallet (${this.wallet.address}).`,

--- a/packages/sdk/src/actions/swap/namespaces/WalletSwapNamespace.ts
+++ b/packages/sdk/src/actions/swap/namespaces/WalletSwapNamespace.ts
@@ -53,24 +53,38 @@ export class WalletSwapNamespace extends BaseSwapNamespace {
 
   /**
    * Execute a token swap.
-   * Accepts either raw params (re-quotes internally) or a pre-built SwapQuote (skips re-quoting).
+   * Accepts either raw params (re-quotes internally) or a pre-built SwapQuote
+   * (skips re-quoting). When a pre-built quote is passed, its recipient must
+   * equal this wallet's address — otherwise the calldata would route output
+   * tokens to a different address (a real risk on Velodrome v2/leaf paths
+   * where the recipient is encoded directly into the swap call). Re-quote via
+   * `wallet.swap.getQuote(...)` to bind the quote to this wallet.
    * @param params - Swap parameters or a pre-built SwapQuote from getQuote()
    * @returns Swap receipt with transaction details
+   * @throws If `params` is a SwapQuote whose recipient differs from this wallet
    */
   async execute(params: WalletSwapParams | SwapQuote): Promise<SwapReceipt> {
     // Inject walletAddress — raw params need it for validation,
     // quotes need it for on-chain allowance checks during approval building.
     // Resolve ENS recipient here so providers only ever receive an Address.
-    const executeParams: SwapExecuteParamsResolved | SwapQuote =
-      QUOTE_DISCRIMINATOR in params
-        ? { ...params, recipient: this.wallet.address }
-        : {
-            ...params,
-            walletAddress: this.wallet.address,
-            recipient: await this.resolveRecipient(
-              params.recipient ?? this.wallet.address,
-            ),
-          }
+    let executeParams: SwapExecuteParamsResolved | SwapQuote
+    if (QUOTE_DISCRIMINATOR in params) {
+      if (params.recipient !== this.wallet.address) {
+        throw new Error(
+          `SwapQuote was generated for a different recipient (${params.recipient}). ` +
+            `Re-quote via wallet.swap.getQuote(...) so calldata is bound to this wallet (${this.wallet.address}).`,
+        )
+      }
+      executeParams = params
+    } else {
+      executeParams = {
+        ...params,
+        walletAddress: this.wallet.address,
+        recipient: await this.resolveRecipient(
+          params.recipient ?? this.wallet.address,
+        ),
+      }
+    }
 
     const provider = this.resolveProvider(
       params.provider,

--- a/packages/sdk/src/actions/swap/namespaces/WalletSwapNamespace.ts
+++ b/packages/sdk/src/actions/swap/namespaces/WalletSwapNamespace.ts
@@ -64,27 +64,10 @@ export class WalletSwapNamespace extends BaseSwapNamespace {
    * @throws If `params` is a SwapQuote whose recipient differs from this wallet
    */
   async execute(params: WalletSwapParams | SwapQuote): Promise<SwapReceipt> {
-    // Inject walletAddress — raw params need it for validation,
-    // quotes need it for on-chain allowance checks during approval building.
-    // Resolve ENS recipient here so providers only ever receive an Address.
-    let executeParams: SwapExecuteParamsResolved | SwapQuote
-    if (QUOTE_DISCRIMINATOR in params) {
-      if (params.recipient !== this.wallet.address) {
-        throw new Error(
-          `SwapQuote was generated for a different recipient (${params.recipient}). ` +
-            `Re-quote via wallet.swap.getQuote(...) so calldata is bound to this wallet (${this.wallet.address}).`,
-        )
-      }
-      executeParams = params
-    } else {
-      executeParams = {
-        ...params,
-        walletAddress: this.wallet.address,
-        recipient: await this.resolveRecipient(
-          params.recipient ?? this.wallet.address,
-        ),
-      }
-    }
+    const executeParams =
+      QUOTE_DISCRIMINATOR in params
+        ? this.requireQuoteForThisWallet(params)
+        : await this.resolveRawParams(params)
 
     const provider = this.resolveProvider(
       params.provider,
@@ -96,6 +79,39 @@ export class WalletSwapNamespace extends BaseSwapNamespace {
     const swapTx = await provider.execute(executeParams)
     const receipt = await this.dispatch(swapTx, params.chainId)
     return this.buildReceipt(swapTx, receipt)
+  }
+
+  /**
+   * Validate that a pre-built quote is bound to this wallet. Throws when the
+   * quote's recipient differs from `wallet.address` — silently swapping
+   * recipients would route output tokens to the wrong address on routers that
+   * encode the recipient directly into calldata (e.g. Velodrome v2/leaf).
+   */
+  private requireQuoteForThisWallet(quote: SwapQuote): SwapQuote {
+    if (quote.recipient !== this.wallet.address) {
+      throw new Error(
+        `SwapQuote was generated for a different recipient (${quote.recipient}). ` +
+          `Re-quote via wallet.swap.getQuote(...) so calldata is bound to this wallet (${this.wallet.address}).`,
+      )
+    }
+    return quote
+  }
+
+  /**
+   * Inject `walletAddress` (needed for validation and on-chain allowance
+   * checks) and resolve any ENS recipient so providers only ever receive an
+   * `Address`.
+   */
+  private async resolveRawParams(
+    params: WalletSwapParams,
+  ): Promise<SwapExecuteParamsResolved> {
+    return {
+      ...params,
+      walletAddress: this.wallet.address,
+      recipient: await this.resolveRecipient(
+        params.recipient ?? this.wallet.address,
+      ),
+    }
   }
 
   private buildReceipt(

--- a/packages/sdk/src/actions/swap/namespaces/__tests__/WalletSwapNamespace.spec.ts
+++ b/packages/sdk/src/actions/swap/namespaces/__tests__/WalletSwapNamespace.spec.ts
@@ -211,7 +211,7 @@ describe('WalletSwapNamespace', () => {
       })
 
       // Quote should have wallet address as the encoded recipient
-      expect(quote.quotedRecipient).toBe(mockWalletAddress)
+      expect(quote.recipient).toBe(mockWalletAddress)
     })
 
     it('preserves explicit recipient over wallet address', async () => {
@@ -229,43 +229,61 @@ describe('WalletSwapNamespace', () => {
         recipient: customRecipient,
       })
 
-      expect(quote.quotedRecipient).toBe(customRecipient)
+      expect(quote.recipient).toBe(customRecipient)
     })
   })
 
   describe('execute with recipient mismatch', () => {
-    it('re-encodes when quote recipient differs from wallet', async () => {
+    it('throws when quote.recipient does not match wallet.address', async () => {
       const provider = createMockSwapProvider()
       const wallet = createMockWallet()
       const namespace = new WalletSwapNamespace({ uniswap: provider }, wallet)
 
-      // Get quote without wallet (simulates ActionsSwapNamespace quote)
+      // Get quote without wallet (simulates ActionsSwapNamespace quote — recipient
+      // defaults to UNIVERSAL_ROUTER_MSG_SENDER, not the executing wallet)
       const quote = await provider.getQuote({
         assetIn: USDC,
         assetOut: ETH,
         amountIn: 100,
         chainId: 84532 as SupportedChainId,
-        // No recipient — uses placeholder
       })
 
-      // quotedRecipient should be the placeholder, not the wallet
-      expect(quote.quotedRecipient).not.toBe(mockWalletAddress)
+      expect(quote.recipient).not.toBe(mockWalletAddress)
 
-      // Execute through wallet namespace — should re-quote with correct recipient
-      const result = await namespace.execute(quote)
-      expect(result.price).toBeDefined()
-
-      // Provider's getQuote should have been called twice:
-      // 1) original quote, 2) re-quote with wallet address
-      expect(provider.mockGetQuote).toHaveBeenCalledTimes(2)
+      await expect(namespace.execute(quote)).rejects.toThrow(
+        /generated for a different recipient/i,
+      )
+      // Provider's getQuote was called once (the original); execute did not re-quote.
+      expect(provider.mockGetQuote).toHaveBeenCalledTimes(1)
     })
 
-    it('skips re-encode when quote already has correct recipient', async () => {
+    it('throws on a quote built for a different wallet address', async () => {
+      const provider = createMockSwapProvider()
+      const wallet = createMockWallet()
+      const namespace = new WalletSwapNamespace({ uniswap: provider }, wallet)
+      const otherWallet =
+        '0x9999999999999999999999999999999999999999' as Address
+
+      const quote = await provider.getQuote({
+        assetIn: USDC,
+        assetOut: ETH,
+        amountIn: 100,
+        chainId: 84532 as SupportedChainId,
+        recipient: otherWallet,
+      })
+
+      expect(quote.recipient).toBe(otherWallet)
+
+      await expect(namespace.execute(quote)).rejects.toThrow(
+        /generated for a different recipient/i,
+      )
+    })
+
+    it('executes when quote.recipient equals wallet.address', async () => {
       const provider = createMockSwapProvider()
       const wallet = createMockWallet()
       const namespace = new WalletSwapNamespace({ uniswap: provider }, wallet)
 
-      // Get quote through wallet namespace (has correct recipient)
       const quote = await namespace.getQuote({
         assetIn: USDC,
         assetOut: ETH,
@@ -273,13 +291,11 @@ describe('WalletSwapNamespace', () => {
         chainId: 84532 as SupportedChainId,
       })
 
-      expect(quote.quotedRecipient).toBe(mockWalletAddress)
+      expect(quote.recipient).toBe(mockWalletAddress)
 
-      // Execute — should NOT re-quote
       const result = await namespace.execute(quote)
       expect(result.price).toBeDefined()
-
-      // getQuote called only once (the original)
+      // Single getQuote call — no re-quote, no re-encode.
       expect(provider.mockGetQuote).toHaveBeenCalledTimes(1)
     })
   })

--- a/packages/sdk/src/actions/swap/namespaces/__tests__/WalletSwapNamespace.spec.ts
+++ b/packages/sdk/src/actions/swap/namespaces/__tests__/WalletSwapNamespace.spec.ts
@@ -298,6 +298,37 @@ describe('WalletSwapNamespace', () => {
       // Single getQuote call — no re-quote, no re-encode.
       expect(provider.mockGetQuote).toHaveBeenCalledTimes(1)
     })
+
+    it('executes when quote.recipient differs only in case from wallet.address', async () => {
+      // Address with hex letters so case actually changes the string. The
+      // wallet uses checksummed casing; the quote uses lowercase. Without
+      // `isAddressEqual` the strict `!==` would falsely reject.
+      const checksummedAddress =
+        '0xAbCdEf1234567890aBcDeF1234567890ABcDeF12' as Address
+      const lowercaseAddress = checksummedAddress.toLowerCase() as Address
+
+      const provider = createMockSwapProvider()
+      const wallet = {
+        address: checksummedAddress,
+        send: vi.fn().mockResolvedValue({ transactionHash: '0xtx1' }),
+        sendBatch: vi.fn().mockResolvedValue({ transactionHash: '0xtx2' }),
+      } as unknown as Wallet
+      const namespace = new WalletSwapNamespace({ uniswap: provider }, wallet)
+
+      const quote = await provider.getQuote({
+        assetIn: USDC,
+        assetOut: ETH,
+        amountIn: 100,
+        chainId: 84532 as SupportedChainId,
+        recipient: lowercaseAddress,
+      })
+
+      expect(quote.recipient).toBe(lowercaseAddress)
+      expect(quote.recipient).not.toBe(checksummedAddress)
+
+      const result = await namespace.execute(quote)
+      expect(result.price).toBeDefined()
+    })
   })
 
   describe('inherits read-only methods', () => {

--- a/packages/sdk/src/actions/swap/providers/uniswap/UniswapSwapProvider.ts
+++ b/packages/sdk/src/actions/swap/providers/uniswap/UniswapSwapProvider.ts
@@ -25,7 +25,6 @@ import type { Asset } from '@/types/asset.js'
 import type {
   GetSwapMarketParams,
   GetSwapMarketsParams,
-  NormalizedSwapQuote,
   ResolvedSwapParams,
   SwapMarket,
   SwapQuote,
@@ -65,7 +64,7 @@ export class UniswapSwapProvider extends SwapProvider<UniswapSwapProviderConfig>
     return this.buildSwapTransactions(swapQuote)
   }
 
-  protected async _buildApprovals(quote: NormalizedSwapQuote) {
+  protected async _buildApprovals(quote: SwapQuote) {
     const addresses = getUniswapAddresses(quote.chainId)
 
     return this.buildPermit2Approvals(
@@ -163,7 +162,7 @@ export class UniswapSwapProvider extends SwapProvider<UniswapSwapProviderConfig>
       quotedAt: now,
       expiresAt: deadline,
       gasEstimate: quote.gasEstimate,
-      quotedRecipient: recipient,
+      recipient,
     }
   }
 

--- a/packages/sdk/src/actions/swap/providers/velodrome/VelodromeSwapProvider.ts
+++ b/packages/sdk/src/actions/swap/providers/velodrome/VelodromeSwapProvider.ts
@@ -27,7 +27,6 @@ import type { Asset } from '@/types/asset.js'
 import type {
   GetSwapMarketParams,
   GetSwapMarketsParams,
-  NormalizedSwapQuote,
   ResolvedSwapParams,
   SwapMarket,
   SwapQuote,
@@ -183,11 +182,11 @@ export class VelodromeSwapProvider extends SwapProvider<VelodromeSwapProviderCon
       quotedAt: now,
       expiresAt: deadline,
       gasEstimate: internalQuote.gasEstimate,
-      quotedRecipient: recipient,
+      recipient,
     }
   }
 
-  protected async _buildApprovals(quote: NormalizedSwapQuote) {
+  protected async _buildApprovals(quote: SwapQuote) {
     const chain = getChainConfig(quote.chainId)
     const publicClient = this.chainManager.getPublicClient(quote.chainId)
 

--- a/packages/sdk/src/types/swap/base.ts
+++ b/packages/sdk/src/types/swap/base.ts
@@ -239,26 +239,14 @@ export interface SwapQuote {
   /** Estimated gas cost as raw bigint (native decimals) */
   gasEstimate?: bigint
   /**
-   * Wallet address that will execute this quote.
-   * Set by WalletSwapNamespace before execution — not available on price-only quotes.
-   * Used to check existing on-chain allowances and skip redundant approvals.
+   * Recipient address baked into execution.swapCalldata at quote time.
+   * Required. To execute a quote on a wallet, the quote must have been
+   * generated for that wallet (recipient === wallet.address); otherwise
+   * WalletSwapNamespace.execute throws. Re-quote via wallet.swap.getQuote
+   * when the executor differs from the quote's recipient.
    */
-  recipient?: Address
-  /**
-   * The recipient address baked into execution.swapCalldata at quote time.
-   * If recipient differs from quotedRecipient at execute time, calldata is re-encoded
-   * with the correct recipient to prevent tokens from being sent to the wrong address.
-   */
-  quotedRecipient: Address
+  recipient: Address
 }
-
-/**
- * A SwapQuote with recipient guaranteed to be set.
- * Produced by SwapProvider.buildSwapTransactions before invoking
- * provider-specific _buildApprovals, so sub-providers can dereference
- * `quote.recipient` without per-provider fallback logic.
- */
-export type NormalizedSwapQuote = SwapQuote & { recipient: Address }
 
 /**
  * Market information for a swap hop


### PR DESCRIPTION
There are two ways to generate a swap quote:

- \`actions.swap.getQuote(...)\` — pricing/routing only, no wallet bound. \`recipient\` defaults to the Universal Router \`msg.sender\` sentinel. Useful for general pricing outside the context of a specific wallet making a trade.
- \`wallet.swap.getQuote(...)\` — bound to a wallet. \`recipient\` is set to that wallet's address.

Either can be passed to \`wallet.swap.execute(quote)\`. Today, when the quote's recipient differs from the executing wallet, \`execute\` silently overrides the recipient and re-encodes calldata.

## Problem

The silent override is dangerous on Velodrome v2 / leaf routers, where the recipient is encoded **directly** into \`swapExactTokensForTokens(amounts, route, recipient, deadline)\`. If re-encoding doesn't fire (or doesn't rewrite the right field), the literal sentinel address ends up on chain as the recipient and tokens are lost. Beyond that specific bug, the contract — \"the calldata you read is not necessarily the calldata that runs\" — is a long-term footgun.

## Solution

If a quote was generated by \`actions.swap.getQuote\` (or any path where \`recipient\` doesn't match the executing wallet), \`wallet.swap.execute\` throws. Re-quote via \`wallet.swap.getQuote\` to bind the quote to the wallet.

\`SwapQuote.recipient\` becomes required (the dual \`recipient\` / \`quotedRecipient\` fields collapse into one). The \`NormalizedSwapQuote\` alias and the calldata re-encoding branch in \`SwapProvider.executeFromQuote\` are removed.