### PR TITLE
fix(sdk): correct V4 SWAP_EXACT_OUT_SINGLE action byte

### DIFF
--- a/packages/sdk/src/actions/swap/providers/uniswap/__tests__/sdk.test.ts
+++ b/packages/sdk/src/actions/swap/providers/uniswap/__tests__/sdk.test.ts
@@ -1,6 +1,13 @@
-import { type Address, type PublicClient, zeroAddress } from 'viem'
+import {
+  type Address,
+  decodeAbiParameters,
+  decodeFunctionData,
+  type PublicClient,
+  zeroAddress,
+} from 'viem'
 import { describe, expect, it, vi } from 'vitest'
 
+import { UNIVERSAL_ROUTER_ABI } from '@/actions/swap/providers/uniswap/abis.js'
 import {
   calculatePriceImpact,
   encodeUniversalRouterSwap,
@@ -300,6 +307,61 @@ describe('encodeUniversalRouterSwap', () => {
 
     expect(calldata).toMatch(/^0x/)
     expect(calldata.length).toBeGreaterThan(10)
+  })
+
+  it('tags V4 action bytes per Uniswap v4-periphery Actions.sol', () => {
+    // Regression: SWAP_EXACT_OUT_SINGLE was previously encoded as 0x07, which
+    // V4Router treats as multi-hop SWAP_EXACT_IN. The router decoded our
+    // single-hop EXACT_OUTPUT_SINGLE_PARAMS struct as a PathKey[] path and
+    // bare-reverted on pool lookup. Correct codes:
+    //   0x06 SWAP_EXACT_IN_SINGLE
+    //   0x08 SWAP_EXACT_OUT_SINGLE
+    const decodeActions = (calldata: `0x${string}`): `0x${string}` => {
+      const { args } = decodeFunctionData({
+        abi: UNIVERSAL_ROUTER_ABI,
+        data: calldata,
+      })
+      const [, inputs] = args as readonly [
+        `0x${string}`,
+        ReadonlyArray<`0x${string}`>,
+        bigint,
+      ]
+      const [actions] = decodeAbiParameters(
+        [{ type: 'bytes' }, { type: 'bytes[]' }],
+        inputs[0]!,
+      )
+      return actions as `0x${string}`
+    }
+
+    const exactIn = encodeUniversalRouterSwap({
+      amountInRaw: 100000000n,
+      assetIn: USDC,
+      assetOut: WETH,
+      slippage: 0.005,
+      deadline: 1700000000,
+      recipient: '0xrecipient' as Address,
+      chainId: CHAIN_ID,
+      quote: baseQuote,
+      universalRouterAddress: '0xrouter' as Address,
+      fee: FEE,
+      tickSpacing: TICK_SPACING,
+    })
+    expect(decodeActions(exactIn)).toBe('0x060c0f')
+
+    const exactOut = encodeUniversalRouterSwap({
+      amountOutRaw: 500000000000000000n,
+      assetIn: USDC,
+      assetOut: WETH,
+      slippage: 0.005,
+      deadline: 1700000000,
+      recipient: '0xrecipient' as Address,
+      chainId: CHAIN_ID,
+      quote: baseQuote,
+      universalRouterAddress: '0xrouter' as Address,
+      fee: FEE,
+      tickSpacing: TICK_SPACING,
+    })
+    expect(decodeActions(exactOut)).toBe('0x080c0f')
   })
 
   it('produces different calldata for exact-in vs exact-out', () => {

--- a/packages/sdk/src/actions/swap/providers/uniswap/encoding.ts
+++ b/packages/sdk/src/actions/swap/providers/uniswap/encoding.ts
@@ -213,7 +213,7 @@ const V4_SWAP = 0x10
 
 // V4 action types
 const SWAP_EXACT_IN_SINGLE = 0x06
-const SWAP_EXACT_OUT_SINGLE = 0x07
+const SWAP_EXACT_OUT_SINGLE = 0x08
 const SETTLE_ALL = 0x0c
 const TAKE_ALL = 0x0f
 


### PR DESCRIPTION
Closes #439.

## Summary

Uniswap supports two swap modes: **exact-input** ("sell exactly X tokens, accept whatever you receive") and **exact-output** ("receive exactly Y tokens, willing to pay up to Z"). Currently, every exact-output swap routed through the Uniswap provider reverts onchain with no decoded error. Exact-input swaps work. Same wallet, same pool, same router — only the direction differs.

Root cause: every action the V4 Universal Router performs is tagged by a single-byte action code. The codes for swaps are:

| Code | Action |
|---|---|
| `0x06` | single-pool, exact input |
| `0x07` | multi-pool path, exact input |
| `0x08` | single-pool, exact output |
| `0x09` | multi-pool path, exact output |

The SDK was tagging single-pool exact-output swaps with `0x07`, which the router treats as a multi-pool exact-input. The struct of parameters we were sending (`{poolKey, zeroForOne, amountOut, amountInMaximum, hookData}`) is a single-pool shape, so the router decoded it as a multi-pool path, found garbage where the path data should be, and bare-reverted on pool lookup with no error message.

Source of truth: [Uniswap v4-periphery `Actions.sol#L28-L31`](https://github.com/Uniswap/v4-periphery/blob/9dafaaecc1e2e1e824eda9d941085f96517d827b/src/libraries/Actions.sol#L28-L31).

Fix is a single byte:

```diff
-const SWAP_EXACT_OUT_SINGLE = 0x07
+const SWAP_EXACT_OUT_SINGLE = 0x08
```

`packages/sdk/src/actions/swap/providers/uniswap/encoding.ts:216`.

This wasn't caught earlier because the demo's `/swap/execute` endpoint and service strip `amountOut` end-to-end, so the buggy path was only reachable via the new CLI's `--amount-out` flag.

## Verification

Replayed the failing calldata on Base Sepolia against the live Universal Router (`0x492e6456…184104`) via `cast call`. Re-ran the same calldata with only that one byte patched (`0x07` → `0x08`):

| Calldata | Outcome |
|---|---|
| Original (action `0x07`) | `unlockCallback → [Revert]` (empty revert data) |
| Patched (action `0x08`, single byte change) | ✅ pool delivered exactly 1 USDC for ~5.500 OP, transaction success, gas 121,364 |

## Test plan

Added a regression test in `packages/sdk/src/actions/swap/providers/uniswap/__tests__/sdk.test.ts` that decodes the calldata produced by `encodeUniversalRouterSwap` and asserts the actions array is `0x060c0f` for exact-input and `0x080c0f` for exact-output. Without the fix this test fails with `0x070c0f`.

- [x] `pnpm -C packages/sdk typecheck`
- [x] `pnpm -C packages/sdk test` — 487 passed, 10 skipped, 0 failed
- [x] `pnpm -C packages/sdk lint` — 0 errors