### PR TITLE
ignore *.local.md per-developer config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ npm-debug.log*
 
 # deployment output files
 latest-faucet-deployment.json
+
+# compound-engineering local config (per-developer)
+compound-engineering.local.md

--- a/.gitignore
+++ b/.gitignore
@@ -55,5 +55,5 @@ npm-debug.log*
 # deployment output files
 latest-faucet-deployment.json
 
-# compound-engineering local config (per-developer)
-compound-engineering.local.md
+# per-developer local config (e.g., compound-engineering.local.md)
+*.local.md


### PR DESCRIPTION
## Summary
- Ignore `*.local.md` files. The `.local` suffix mirrors the `.env.local` convention already in this `.gitignore` for per-developer config that shouldn't be shared. For example, `/compound-engineering:setup` writes `compound-engineering.local.md`; this pattern covers it and any other tool following the same naming.

## Test plan
- [x] After this lands, files matching `*.local.md` no longer show up under `git status`.