### PR TITLE
Document executor vs recipient invariant in WalletSwapNamespace strict check

### DIFF
--- a/packages/sdk/src/actions/swap/namespaces/WalletSwapNamespace.ts
+++ b/packages/sdk/src/actions/swap/namespaces/WalletSwapNamespace.ts
@@ -89,6 +89,23 @@ export class WalletSwapNamespace extends BaseSwapNamespace {
    * quote's recipient differs from `wallet.address`; silently swapping
    * recipients would route output tokens to the wrong address on routers that
    * encode the recipient directly into calldata (e.g. Velodrome v2/leaf).
+   *
+   * Invariant: `wallet.address` is the *receiving* address, not the signer.
+   *
+   * Recipient is who receives the output tokens. For a smart wallet that is the
+   * smart-wallet contract address; for an EOA wallet it is the EOA. In both
+   * cases it equals `wallet.address`, which is exactly what a quote built via
+   * `getQuote()` encodes as its recipient.
+   *
+   * Executor is who signs and submits the transaction (an EOA key, a
+   * smart-wallet owner, or a session-key holder). The executor's address can
+   * differ from `wallet.address` — e.g. a session-key signer authoring a
+   * UserOperation for a smart wallet (see #403).
+   *
+   * The comparison is therefore `recipient === wallet.address`, never
+   * `recipient === signer`. It stays correct regardless of who actually signed,
+   * because the check asserts the quote was built to pay *this* wallet, not
+   * anything about the executor's identity.
    */
   private requireQuoteForThisWallet(quote: SwapQuote): SwapQuote {
     if (!isAddressEqual(quote.recipient, this.wallet.address)) {


### PR DESCRIPTION
Closes #437

## Summary

Documents the executor-vs-recipient invariant on
`WalletSwapNamespace.requireQuoteForThisWallet` (Path 1 from the issue, the
preferred path). No behavior change — the strict
`isAddressEqual(quote.recipient, wallet.address)` check is unchanged.

The added JSDoc makes explicit that `wallet.address` is the *receiving* address
(smart-wallet contract for AA, EOA for externals), not the signer/executor, and
that the comparison is `recipient === wallet.address` (never `recipient === signer`).
This stays correct regardless of who signs — including future session-key signers
(#403) authoring UserOps for a smart wallet, where the executor and recipient are
genuinely different addresses.

## Why Path 1 over Path 2

Path 2 proposed a `wallet.intendedRecipient()` accessor. Today it would return
`this.address` for every wallet type (EOA + smart) — pure indirection with no
behavioral differentiation, i.e. a speculative abstraction. Documenting the
invariant achieves the issue's goal (clarity + forward-compatibility framing for
session keys) with zero new surface area. The extension point can be added later
if/when a wallet type actually decouples recipient from `address`.

## Validation

- `eslint` + `prettier --check` on the changed file: pass (jsdoc rules included)
- `tsc --noEmit`: pass
- `vitest` WalletSwapNamespace.spec.ts: 14/14 pass (behavior unchanged)
