### PR TITLE
Decouple walletAddress from quote.recipient in _buildApprovals

### DIFF
--- a/.changeset/swap-allowance-owner.md
+++ b/.changeset/swap-allowance-owner.md
@@ -1,0 +1,14 @@
+---
+'@eth-optimism/actions-sdk': minor
+---
+
+Decouple the swap allowance owner from the quote recipient.
+
+`SwapQuote` now carries an explicit `walletAddress` (the executing wallet whose
+ERC-20 / Permit2 allowances are read when building approvals), distinct from
+`recipient` (who receives the output tokens). `UniswapSwapProvider` and
+`VelodromeSwapProvider` `_buildApprovals` now read allowances against
+`quote.walletAddress` instead of reusing `quote.recipient`. This fixes a latent
+bug where a raw swap with a custom `recipient` checked allowances against the
+recipient rather than the executing wallet; for EOAs and current smart-wallet
+implementations the two coincide, so behavior is unchanged there.

--- a/packages/sdk/src/actions/swap/__mocks__/MockSwapProvider.ts
+++ b/packages/sdk/src/actions/swap/__mocks__/MockSwapProvider.ts
@@ -15,7 +15,6 @@ import type {
   SwapMarket,
   SwapProviderConfig,
   SwapQuote,
-  SwapQuoteParams,
   SwapTransaction,
 } from '@/types/swap/index.js'
 import type { TransactionData } from '@/types/transaction.js'
@@ -35,7 +34,7 @@ export class MockSwapProvider extends SwapProvider<SwapProviderConfig> {
     (params: ResolvedSwapParams) => Promise<SwapTransaction>
   >
   public mockGetQuote: MockedFunction<
-    (params: SwapQuoteParams) => Promise<SwapQuote>
+    (params: SwapQuoteParamsResolved) => Promise<SwapQuote>
   >
   public mockBuildApprovals: MockedFunction<
     (quote: SwapQuote) => Promise<{
@@ -121,7 +120,9 @@ export class MockSwapProvider extends SwapProvider<SwapProviderConfig> {
     return this.mockExecute(params)
   }
 
-  protected async _getQuote(params: SwapQuoteParams): Promise<SwapQuote> {
+  protected async _getQuote(
+    params: SwapQuoteParamsResolved,
+  ): Promise<SwapQuote> {
     return this.mockGetQuote(params)
   }
 
@@ -164,7 +165,7 @@ export class MockSwapProvider extends SwapProvider<SwapProviderConfig> {
     }
   }
 
-  private createMockQuote(params: SwapQuoteParams): SwapQuote {
+  private createMockQuote(params: SwapQuoteParamsResolved): SwapQuote {
     const now = Math.floor(Date.now() / 1000)
     const deadline = params.deadline ?? now + 60
     const slippage = params.slippage ?? 0.005
@@ -209,7 +210,7 @@ export class MockSwapProvider extends SwapProvider<SwapProviderConfig> {
       gasEstimate: 150000n,
       recipient: (params.recipient ??
         '0x0000000000000000000000000000000000000001') as Address,
-      walletAddress: ((params as SwapQuoteParamsResolved).walletAddress ??
+      walletAddress: (params.walletAddress ??
         params.recipient ??
         '0x0000000000000000000000000000000000000001') as Address,
     }

--- a/packages/sdk/src/actions/swap/__mocks__/MockSwapProvider.ts
+++ b/packages/sdk/src/actions/swap/__mocks__/MockSwapProvider.ts
@@ -5,6 +5,7 @@ import { SwapProvider } from '@/actions/swap/core/SwapProvider.js'
 import type { SupportedChainId } from '@/constants/supportedChains.js'
 import { MockChainManager } from '@/services/__mocks__/MockChainManager.js'
 import type { ChainManager } from '@/services/ChainManager.js'
+import type { SwapQuoteParamsResolved } from '@/services/nameservices/ens/types.js'
 import type { SwapSettings } from '@/types/actions.js'
 import type { Asset } from '@/types/asset.js'
 import type {
@@ -207,6 +208,9 @@ export class MockSwapProvider extends SwapProvider<SwapProviderConfig> {
       expiresAt: deadline,
       gasEstimate: 150000n,
       recipient: (params.recipient ??
+        '0x0000000000000000000000000000000000000001') as Address,
+      walletAddress: ((params as SwapQuoteParamsResolved).walletAddress ??
+        params.recipient ??
         '0x0000000000000000000000000000000000000001') as Address,
     }
   }

--- a/packages/sdk/src/actions/swap/core/SwapProvider.ts
+++ b/packages/sdk/src/actions/swap/core/SwapProvider.ts
@@ -265,15 +265,19 @@ export abstract class SwapProvider<
   /**
    * Resolve common quote parameters with provider defaults.
    * @param params - Raw quote params from the user
-   * @returns Resolved slippage, deadline, recipient, amountInRaw, and current timestamp
+   * @returns Resolved slippage, deadline, recipient, walletAddress, amountInRaw, and current timestamp
    */
   protected resolveQuoteDefaults(params: SwapQuoteParamsResolved) {
     const slippage = params.slippage ?? this.defaultSlippage
     const now = Math.floor(Date.now() / 1000)
     const deadline = params.deadline ?? now + this.quoteExpirationSeconds
     const recipient = params.recipient ?? UNIVERSAL_ROUTER_MSG_SENDER
+    // Allowance owner is the executing wallet, independent of recipient. Only
+    // the raw execute path threads `walletAddress` through; read-only quotes
+    // (no wallet) fall back to recipient and never run allowance checks.
+    const walletAddress = params.walletAddress ?? recipient
     const amountInRaw = parseAssetAmount(params.assetIn, params.amountIn ?? 1)
-    return { slippage, now, deadline, recipient, amountInRaw }
+    return { slippage, now, deadline, recipient, walletAddress, amountInRaw }
   }
 
   /**

--- a/packages/sdk/src/actions/swap/providers/uniswap/UniswapSwapProvider.ts
+++ b/packages/sdk/src/actions/swap/providers/uniswap/UniswapSwapProvider.ts
@@ -72,6 +72,7 @@ export class UniswapSwapProvider extends SwapProvider<UniswapSwapProviderConfig>
       slippage: params.slippage,
       deadline: params.deadline,
       recipient: params.recipient,
+      walletAddress: params.walletAddress,
     })
     return this.buildSwapTransactions({
       ...swapQuote,
@@ -89,7 +90,7 @@ export class UniswapSwapProvider extends SwapProvider<UniswapSwapProviderConfig>
         slippage: quote.slippage,
         deadline: quote.deadline,
         recipient: quote.recipient,
-        walletAddress: quote.recipient,
+        walletAddress: quote.walletAddress,
         chainId: quote.chainId,
         amountInRaw: quote.amountInRaw,
         approvalMode: resolveApprovalMode(
@@ -112,7 +113,7 @@ export class UniswapSwapProvider extends SwapProvider<UniswapSwapProviderConfig>
     const publicClient = this.chainManager.getPublicClient(chainId)
     const marketConfig = this.resolveUniswapConfig(assetIn, assetOut, chainId)
 
-    const { slippage, now, deadline, recipient, amountInRaw } =
+    const { slippage, now, deadline, recipient, walletAddress, amountInRaw } =
       this.resolveQuoteDefaults(params)
     const amountOutRaw = parseAssetAmount(assetOut, params.amountOut)
 
@@ -183,6 +184,7 @@ export class UniswapSwapProvider extends SwapProvider<UniswapSwapProviderConfig>
       expiresAt: deadline,
       gasEstimate: quote.gasEstimate,
       recipient,
+      walletAddress,
     }
   }
 

--- a/packages/sdk/src/actions/swap/providers/uniswap/__tests__/UniswapSwapProvider.test.ts
+++ b/packages/sdk/src/actions/swap/providers/uniswap/__tests__/UniswapSwapProvider.test.ts
@@ -216,6 +216,40 @@ describe('UniswapSwapProvider', () => {
       // 1 USDC = 1000000 (6 decimals)
       expect(quote.amountInRaw).toBe(1000000n)
     })
+
+    it('threads walletAddress onto the quote when provided', async () => {
+      const provider = createProvider()
+      const wallet = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as Address
+      const recipient = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' as Address
+      const quote = await provider.getQuote({
+        assetIn: USDC,
+        assetOut: OP,
+        amountIn: 100,
+        chainId: CHAIN_ID,
+        recipient,
+        walletAddress: wallet,
+      })
+
+      // Allowance owner is decoupled from the output recipient.
+      expect(quote.walletAddress).toBe(wallet)
+      expect(quote.recipient).toBe(recipient)
+    })
+
+    it('falls back walletAddress to recipient for read-only quotes', async () => {
+      const provider = createProvider()
+      const recipient = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' as Address
+      const quote = await provider.getQuote({
+        assetIn: USDC,
+        assetOut: OP,
+        amountIn: 100,
+        chainId: CHAIN_ID,
+        recipient,
+      })
+
+      // No wallet context (read-only): owner falls back to recipient and is
+      // never used for an allowance check.
+      expect(quote.walletAddress).toBe(recipient)
+    })
   })
 
   describe('getMarkets', () => {

--- a/packages/sdk/src/actions/swap/providers/uniswap/__tests__/UniswapSwapProvider.test.ts
+++ b/packages/sdk/src/actions/swap/providers/uniswap/__tests__/UniswapSwapProvider.test.ts
@@ -125,6 +125,67 @@ describe('UniswapSwapProvider', () => {
         }),
       ).rejects.toThrow('fee and tickSpacing must be configured')
     })
+
+    it('reads Permit2/ERC-20 allowances against walletAddress, not recipient', async () => {
+      const wallet = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as Address
+      const recipient = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' as Address
+      const owners: string[] = []
+      const mockPublicClient = {
+        simulateContract: vi.fn().mockResolvedValue({
+          result: [500000000000000000n, 150000n],
+        }),
+        readContract: vi
+          .fn()
+          .mockImplementation(
+            ({
+              functionName,
+              args,
+            }: {
+              functionName: string
+              args: unknown[]
+            }) => {
+              if (functionName === 'extsload')
+                return Promise.resolve(`0x${'0'.repeat(64)}`)
+              if (functionName === 'allowance') {
+                owners.push((args[0] as string).toLowerCase())
+                // Permit2 allowance has 3 args; ERC-20 allowance has 2
+                return Promise.resolve(args.length === 3 ? [0n, 0, 0] : 0n)
+              }
+              return Promise.resolve(0n)
+            },
+          ),
+      } as unknown as PublicClient
+      const chainManager = {
+        getPublicClient: vi.fn().mockReturnValue(mockPublicClient),
+        getSupportedChains: vi.fn().mockReturnValue([CHAIN_ID]),
+      } as unknown as ChainManager
+      const provider = new UniswapSwapProvider(
+        {
+          defaultSlippage: 0.005,
+          marketAllowlist: [
+            { assets: [USDC, OP], fee: 100, tickSpacing: 2, chainId: CHAIN_ID },
+          ],
+        },
+        chainManager,
+      )
+
+      await provider.execute({
+        amountIn: 100,
+        assetIn: USDC,
+        assetOut: OP,
+        chainId: CHAIN_ID,
+        walletAddress: wallet,
+        recipient,
+      })
+
+      // Both the ERC-20→Permit2 and Permit2→router allowance reads must use the
+      // executing wallet as owner, never the (distinct) output recipient.
+      expect(owners.length).toBeGreaterThan(0)
+      expect(owners).not.toContain(recipient.toLowerCase())
+      for (const owner of owners) {
+        expect(owner).toBe(wallet.toLowerCase())
+      }
+    })
   })
 
   describe('getQuote', () => {

--- a/packages/sdk/src/actions/swap/providers/velodrome/VelodromeSwapProvider.ts
+++ b/packages/sdk/src/actions/swap/providers/velodrome/VelodromeSwapProvider.ts
@@ -89,6 +89,7 @@ export class VelodromeSwapProvider extends SwapProvider<VelodromeSwapProviderCon
       slippage: params.slippage,
       deadline: params.deadline,
       recipient: params.recipient,
+      walletAddress: params.walletAddress,
     })
     return this.buildSwapTransactions({
       ...swapQuote,
@@ -149,7 +150,7 @@ export class VelodromeSwapProvider extends SwapProvider<VelodromeSwapProviderCon
       assetOut,
       chainId,
     )
-    const { slippage, now, deadline, recipient, amountInRaw } =
+    const { slippage, now, deadline, recipient, walletAddress, amountInRaw } =
       this.resolveQuoteDefaults(params)
 
     const { internalQuote, providerContext } = await fetchPoolQuote(
@@ -201,6 +202,7 @@ export class VelodromeSwapProvider extends SwapProvider<VelodromeSwapProviderCon
       expiresAt: deadline,
       gasEstimate: internalQuote.gasEstimate,
       recipient,
+      walletAddress,
     }
   }
 
@@ -218,7 +220,7 @@ export class VelodromeSwapProvider extends SwapProvider<VelodromeSwapProviderCon
     const allowance = await checkTokenAllowance({
       publicClient,
       token,
-      owner: quote.recipient,
+      owner: quote.walletAddress,
       spender,
     })
 

--- a/packages/sdk/src/actions/swap/providers/velodrome/__tests__/VelodromeSwapProvider.test.ts
+++ b/packages/sdk/src/actions/swap/providers/velodrome/__tests__/VelodromeSwapProvider.test.ts
@@ -227,6 +227,71 @@ describe('VelodromeSwapProvider', () => {
         expect(owner).toBe(MOCK_WALLET.toLowerCase())
       }
     })
+
+    it('reads allowance against the quote walletAddress on the pre-built quote path', async () => {
+      const recipient = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' as Address
+      const owners: string[] = []
+      const mockPublicClient = {
+        readContract: vi
+          .fn()
+          .mockImplementation(
+            ({
+              functionName,
+              args,
+            }: {
+              functionName: string
+              args: unknown[]
+            }) => {
+              if (functionName === 'getAmountsOut')
+                return Promise.resolve([100000000n, 500000000000000000n])
+              if (functionName === 'allowance') {
+                owners.push((args[0] as string).toLowerCase())
+                return Promise.resolve(0n)
+              }
+              if (functionName === 'getPool')
+                return Promise.resolve(
+                  '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+                )
+              return Promise.resolve(0n)
+            },
+          ),
+      } as unknown as PublicClient
+      const chainManager = {
+        getPublicClient: vi.fn().mockReturnValue(mockPublicClient),
+        tryGetPublicClient: vi.fn().mockReturnValue(undefined),
+        getSupportedChains: vi.fn().mockReturnValue([CHAIN_ID]),
+      } as unknown as ChainManager
+      const provider = new VelodromeSwapProvider(
+        {
+          defaultSlippage: 0.005,
+          marketAllowlist: [
+            { assets: [USDC, OP], stable: false, chainId: CHAIN_ID },
+          ],
+        },
+        chainManager,
+      )
+
+      // Build a quote whose allowance owner (walletAddress) differs from its
+      // output recipient, then execute it via the pre-built-quote path.
+      const quote = await provider.getQuote({
+        assetIn: USDC,
+        assetOut: OP,
+        amountIn: 100,
+        chainId: CHAIN_ID,
+        recipient,
+        walletAddress: MOCK_WALLET,
+      })
+      expect(quote.walletAddress).toBe(MOCK_WALLET)
+      expect(quote.recipient).toBe(recipient)
+
+      await provider.execute(quote)
+
+      expect(owners.length).toBeGreaterThan(0)
+      expect(owners).not.toContain(recipient.toLowerCase())
+      for (const owner of owners) {
+        expect(owner).toBe(MOCK_WALLET.toLowerCase())
+      }
+    })
   })
 
   describe('getQuote', () => {

--- a/packages/sdk/src/actions/swap/providers/velodrome/__tests__/VelodromeSwapProvider.test.ts
+++ b/packages/sdk/src/actions/swap/providers/velodrome/__tests__/VelodromeSwapProvider.test.ts
@@ -168,6 +168,65 @@ describe('VelodromeSwapProvider', () => {
         'Either stable (v2 AMM) or tickSpacing (CL) must be configured',
       )
     })
+
+    it('reads token allowance against walletAddress, not recipient', async () => {
+      const recipient = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' as Address
+      const owners: string[] = []
+      const mockPublicClient = {
+        readContract: vi
+          .fn()
+          .mockImplementation(
+            ({
+              functionName,
+              args,
+            }: {
+              functionName: string
+              args: unknown[]
+            }) => {
+              if (functionName === 'getAmountsOut')
+                return Promise.resolve([100000000n, 500000000000000000n])
+              if (functionName === 'allowance') {
+                owners.push((args[0] as string).toLowerCase())
+                return Promise.resolve(0n)
+              }
+              if (functionName === 'getPool')
+                return Promise.resolve(
+                  '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+                )
+              return Promise.resolve(0n)
+            },
+          ),
+      } as unknown as PublicClient
+      const chainManager = {
+        getPublicClient: vi.fn().mockReturnValue(mockPublicClient),
+        tryGetPublicClient: vi.fn().mockReturnValue(undefined),
+        getSupportedChains: vi.fn().mockReturnValue([CHAIN_ID]),
+      } as unknown as ChainManager
+      const provider = new VelodromeSwapProvider(
+        {
+          defaultSlippage: 0.005,
+          marketAllowlist: [
+            { assets: [USDC, OP], stable: false, chainId: CHAIN_ID },
+          ],
+        },
+        chainManager,
+      )
+
+      await provider.execute({
+        amountIn: 100,
+        assetIn: USDC,
+        assetOut: OP,
+        chainId: CHAIN_ID,
+        walletAddress: MOCK_WALLET,
+        recipient,
+      })
+
+      expect(owners.length).toBeGreaterThan(0)
+      expect(owners).not.toContain(recipient.toLowerCase())
+      for (const owner of owners) {
+        expect(owner).toBe(MOCK_WALLET.toLowerCase())
+      }
+    })
   })
 
   describe('getQuote', () => {

--- a/packages/sdk/src/services/nameservices/ens/types.ts
+++ b/packages/sdk/src/services/nameservices/ens/types.ts
@@ -59,6 +59,12 @@ export type SwapExecuteParamsResolved = Omit<SwapExecuteParams, 'recipient'> & {
 /** SwapQuoteParams with recipient narrowed to Address after ENS resolution */
 export type SwapQuoteParamsResolved = Omit<SwapQuoteParams, 'recipient'> & {
   recipient?: Address
+  /**
+   * Allowance owner (executing wallet) threaded through from the raw execute
+   * path so the quote's `walletAddress` is decoupled from `recipient`. Absent
+   * for read-only quotes, where it falls back to `recipient`.
+   */
+  walletAddress?: Address
 }
 
 /**

--- a/packages/sdk/src/types/swap/base.ts
+++ b/packages/sdk/src/types/swap/base.ts
@@ -256,6 +256,17 @@ export interface SwapQuote {
    */
   recipient: Address
   /**
+   * Allowance owner: the address whose ERC-20 / Permit2 allowances are read
+   * when building swap approvals. This is the executing wallet (signer / EOA),
+   * which is conceptually distinct from `recipient` (who receives the output
+   * tokens). For EOAs and current smart-wallet implementations the two always
+   * coincide, but they are decoupled here so allowance reads never depend on
+   * the recipient — see the discriminated execute paths in `SwapProvider`.
+   * Populated by the provider's `_getQuote`; for read-only quotes with no
+   * wallet context it falls back to `recipient`.
+   */
+  walletAddress: Address
+  /**
    * Per-call override for the approval-amount strategy. When set, the provider
    * uses this for the swap's approvals instead of the wallet-level config
    * default. When unset, the provider falls back to the wallet's


### PR DESCRIPTION
Closes #436

Mirror of ethereum-optimism/actions#436; surfaced during review of #434.

## Problem

`UniswapSwapProvider._buildApprovals` and `VelodromeSwapProvider._buildApprovals` reused `quote.recipient` as the `walletAddress` (allowance owner) for Permit2 / ERC-20 allowance reads. That conflated two distinct concepts — *who receives the output* (`recipient`) vs *whose allowances we check* (the executing wallet) — and was only safe because #434's strict check guarantees `quote.recipient === wallet.address` on the pre-built-quote path.

It also left a latent bug on the **raw execute path**: a swap with a custom `recipient` (output sent elsewhere) read allowances against the recipient instead of the executing wallet, since `walletAddress` was dropped when the internal quote was built.

## Change

- Added an explicit `walletAddress: Address` to `SwapQuote` — the allowance owner, decoupled from `recipient`.
- `SwapProvider.resolveQuoteDefaults` now resolves `walletAddress` (`params.walletAddress ?? recipient`). The fallback to `recipient` only applies to read-only quotes with no wallet context, which never run allowance checks; every execute path sources the real wallet.
- Both providers thread `params.walletAddress` into `_getQuote` (raw path) and emit `walletAddress` on the quote.
- Both `_buildApprovals` now read allowances against `quote.walletAddress`.

For EOAs and current smart-wallet implementations `recipient` and `walletAddress` coincide, so existing behavior is unchanged. The decoupling matters for future session-key / relayer flows and removes the implicit dependency on the strict-recipient invariant.

## Tests

- New per-provider tests assert allowance reads use `walletAddress`, not a divergent `recipient`, on the raw execute path (Uniswap: ERC-20→Permit2 and Permit2→router reads; Velodrome: ERC-20→router read).
- Full SDK unit suite green (666 passing), typecheck, lint, and build clean.
