### PR TITLE
Split price quote from swap quote

### DIFF
--- a/.changeset/split-price-quote-from-swap-quote.md
+++ b/.changeset/split-price-quote-from-swap-quote.md
@@ -1,0 +1,22 @@
+---
+'@eth-optimism/actions-sdk': minor
+---
+
+Split price quotes from executable quotes so `actions.swap.getQuote` no longer leaks the Universal Router `msg.sender` sentinel.
+
+- New `PriceQuote` type: pricing, amounts, route, and metadata only — no
+  `recipient` and no `execution` data. It is structurally un-executable.
+- `actions.swap.getQuote` / `getQuotes` (no wallet bound) now return
+  `PriceQuote` instead of `SwapQuote`. Previously these carried
+  `recipient = 0x..01` (the Universal Router `msg.sender` sentinel) when no
+  recipient was supplied — a value the `recipient: Address` type implied was a
+  real, executable address.
+- `wallet.swap.getQuote` / `getQuotes` still return the full `SwapQuote`
+  (recipient bound to the wallet, `execution` present); `wallet.swap.execute`
+  is unchanged.
+- **Breaking (types):** consumers reading `recipient` / `execution` off the
+  result of `actions.swap.getQuote` must re-quote via `wallet.swap.getQuote` to
+  obtain an executable `SwapQuote`. The dropped fields were either the sentinel
+  or, post strict-recipient-match, un-executable.
+
+Resolves the type/value mismatch flagged in #8.

--- a/docs/plans/2026-06-16-001-refactor-split-price-quote-from-swap-quote-plan.md
+++ b/docs/plans/2026-06-16-001-refactor-split-price-quote-from-swap-quote-plan.md
@@ -1,0 +1,197 @@
+---
+title: "refactor: Split PriceQuote from SwapQuote (sentinel recipient leak)"
+type: refactor
+status: active
+created: 2026-06-16
+issue: its-applekid/actions#8
+---
+
+# refactor: Split PriceQuote from SwapQuote
+
+## Summary
+
+`actions.swap.getQuote(...)` (no wallet bound) returns a `SwapQuote` whose
+`recipient: Address` field is the Universal Router `msg.sender` sentinel
+(`0x0000000000000000000000000000000000000001`) when no recipient is supplied.
+The type says "ready to execute" but the value is un-executable and, worse,
+a footgun for any consumer that reads `quote.recipient` for display,
+accounting, or analytics.
+
+This plan implements **Option B** from the issue: split the return type.
+`actions.swap.getQuote` returns a new **`PriceQuote`** (pricing, amounts,
+route, metadata — **no** `recipient`, **no** `execution`, **no**
+`approvalMode`), making it structurally un-executable. `wallet.swap.getQuote`
+keeps returning the full `SwapQuote` (recipient required, execution present).
+`wallet.swap.execute` already only accepts `SwapQuote`.
+
+**Approach chosen:** B over A/C. The issue recommends B long-term and it best
+serves the stated motivation (price-display consumers get a smaller, honest
+surface). Validated against consumers: the demo's `executeSwap` re-quotes from
+raw params via `wallet.swap.execute` and never executes an actions-level quote,
+so the `execution` data on price quotes is already dead weight. Dropping it
+breaks no execution path.
+
+---
+
+## Problem Frame
+
+- **Root cause:** `SwapProvider.resolveQuoteDefaults` (`packages/sdk/src/actions/swap/core/SwapProvider.ts:274`) defaults `recipient` to `UNIVERSAL_ROUTER_MSG_SENDER` when none is supplied. The provider bakes this into `execution.swapCalldata` and returns it as `SwapQuote.recipient`.
+- **Only the no-wallet path is affected:** `SwapQuoteParams` is shared by both namespaces, but `WalletSwapNamespace.getQuote` injects `wallet.address` before delegating, so a provider only ever sees an empty recipient on the `actions.swap.getQuote` path.
+- **Post-#434 reality:** an actions-level quote already throws at `wallet.swap.execute` (recipient mismatch via `QuoteRecipientMismatchError`), so its `execution`/`recipient` fields are a trap, not a feature.
+
+---
+
+## Scope Boundaries
+
+In scope:
+- New `PriceQuote` type and the `SwapQuote = PriceQuote & {...}` relationship.
+- Namespace return-type split (actions → `PriceQuote`, wallet → `SwapQuote`).
+- Updating SDK consumers (CLI, demo backend/frontend) and tests.
+- Public export of `PriceQuote` from the SDK barrel.
+
+### Deferred to Follow-Up Work
+- **Encoder defense-in-depth guard** (refuse the sentinel on Velodrome v2/leaf encoders). The issue notes this "follows naturally from B/A" but is a separate hardening change; keep this PR focused on the type split. File as a follow-up if not already tracked.
+
+Out of scope / non-goals:
+- Changing how providers internally encode calldata (sentinel stays valid Universal Router encoding internally).
+- Touching `borrow`/`lend` quote types.
+
+---
+
+## Key Technical Decisions
+
+1. **`SwapQuote` extends `PriceQuote`.** Define `PriceQuote` as the display/pricing subset; define `SwapQuote = PriceQuote & { recipient: Address; execution: SwapQuoteExecution; approvalMode?: ApprovalMode }`. This keeps a single source of truth for the shared fields and makes `SwapQuote` assignable to `PriceQuote` (wallet quotes satisfy price-quote consumers for free).
+
+2. **Strip at the namespace boundary, not in providers.** Providers keep returning full internal `SwapQuote`s (they need a recipient to encode calldata; sentinel default stays as an internal encoding detail). `ActionsSwapNamespace` maps results through a `toPriceQuote()` stripper. Minimal, surgical — no provider/encoding changes, no `_getQuote` restructuring.
+
+3. **Make base routing methods protected.** `BaseSwapNamespace.getQuote/getQuotes` become `protected resolveQuote/resolveQuotes` returning `SwapQuote`. Each namespace exposes its own public method with the correct return type. Required because a covariant override cannot widen the return type from `SwapQuote` to `PriceQuote`.
+
+4. **`PriceQuote` → `execute` fails at runtime, not compile time.** `PriceQuote` is structurally assignable to `WalletSwapParams` (it has the required `assetIn`/`assetOut`/`chainId`), so `execute(params: WalletSwapParams | SwapQuote)` accepts it at compile time as raw params. But a `PriceQuote` carries the `quotedAt` discriminator, so `execute` routes it down the pre-built-quote path, where the missing `recipient` makes `requireQuoteForThisWallet` throw. The protection is therefore runtime (fail-loud), covered by a regression test — not a type error.
+
+---
+
+## Implementation Units
+
+### U1. Define `PriceQuote` and re-base `SwapQuote`
+
+**Goal:** Introduce the honest price-only type and express `SwapQuote` in terms of it.
+
+**Files:**
+- `packages/sdk/src/types/swap/base.ts` (modify)
+- `packages/sdk/src/index.ts` (export `PriceQuote`)
+
+**Approach:**
+- Extract the shared pricing/amount/route/metadata fields of the current `SwapQuote` into `interface PriceQuote` — i.e. everything except `recipient`, `execution`, `approvalMode`.
+- Redefine `SwapQuote` as `PriceQuote & { recipient: Address; execution: SwapQuoteExecution; approvalMode?: ApprovalMode }` (or an `interface SwapQuote extends PriceQuote` with those three added).
+- Carry over the precision JSDoc note onto `PriceQuote`. Document on `PriceQuote` that it is intentionally un-executable; re-quote via `wallet.swap.getQuote` to execute.
+- Export `PriceQuote` from the SDK barrel alongside `SwapQuote`.
+
+**Patterns to follow:** existing `SwapQuote`/`SwapQuoteExecution` JSDoc style in `base.ts`; export ordering in `index.ts`.
+
+**Test scenarios:** Test expectation: none — pure type definition. Coverage comes from the type-level consumers in U2–U4 compiling and from existing namespace specs.
+
+---
+
+### U2. Split namespace return types
+
+**Goal:** `actions.swap.getQuote/getQuotes` return `PriceQuote`; `wallet.swap` keeps `SwapQuote`.
+
+**Dependencies:** U1
+
+**Files:**
+- `packages/sdk/src/actions/swap/namespaces/BaseSwapNamespace.ts` (modify)
+- `packages/sdk/src/actions/swap/namespaces/ActionsSwapNamespace.ts` (modify)
+- `packages/sdk/src/actions/swap/namespaces/WalletSwapNamespace.ts` (modify)
+- `packages/sdk/src/actions/swap/namespaces/__tests__/BaseSwapNamespace.spec.ts` (modify)
+- `packages/sdk/src/actions/swap/namespaces/__tests__/WalletSwapNamespace.spec.ts` (modify)
+
+**Approach:**
+- In `BaseSwapNamespace`, rename public `getQuote`→`protected resolveQuote` and `getQuotes`→`protected resolveQuotes` (return `SwapQuote`/`SwapQuote[]`). Internal routing helpers (`getBestQuote`, `fetchAllQuotes`) stay on `SwapQuote`.
+- Add a small `toPriceQuote(quote: SwapQuote): PriceQuote` mapper (destructure-and-drop `recipient`/`execution`/`approvalMode`). Place it where both can't accidentally leak — a module-local helper near `ActionsSwapNamespace` or a `swap` util; prefer the namespace file unless a shared util already fits.
+- `ActionsSwapNamespace`: add public `getQuote(params): Promise<PriceQuote>` and `getQuotes(params): Promise<PriceQuote[]>` that call `resolveQuote`/`resolveQuotes` and map through `toPriceQuote`.
+- `WalletSwapNamespace`: change `getQuote`/`getQuotes` overrides to call `resolveQuote`/`resolveQuotes` (instead of `super.getQuote`), still injecting `recipient ?? wallet.address`. Return type stays `SwapQuote`.
+
+**Patterns to follow:** existing override pattern in `WalletSwapNamespace`; `BaseNamespace` visibility conventions.
+
+**Test scenarios:**
+- `actions.swap.getQuote` result has no `recipient`/`execution`/`approvalMode` keys (assert absence) and carries price/amount/route fields. Covers the core leak fix.
+- `actions.swap.getQuotes` returns an array of stripped `PriceQuote`s, still sorted by `amountOutRaw` desc.
+- With `routing: 'price'`, `actions.swap.getQuote` still returns the best-priced quote (stripped).
+- `wallet.swap.getQuote` still returns a `SwapQuote` with `recipient === wallet.address` and `execution` present.
+- `wallet.swap.getQuote` with an explicit `recipient` keeps that recipient.
+- Type-level: passing an `actions.swap.getQuote` result to `wallet.swap.execute` is a compile error (document via a `// @ts-expect-error` assertion test or a type-only test).
+
+---
+
+### U3. Update CLI consumers
+
+**Goal:** CLI compiles and prints price quotes without referencing dropped fields.
+
+**Dependencies:** U1, U2
+
+**Files:**
+- `packages/cli/src/output/printOutput.ts` (modify — `formatSwapQuote` and the `SwapQuote` typing at lines ~116, ~312–327)
+- `packages/cli/src/commands/actions/swap/quote.ts` (modify)
+- `packages/cli/src/commands/actions/swap/quotes.ts` (modify)
+- `packages/cli/src/commands/actions/swap/util.ts` (review — param-building comment about `SwapQuoteParams`)
+- `packages/cli/src/commands/__tests__/swapQuote.test.ts` (modify)
+
+**Approach:**
+- The `actions swap quote`/`quotes` commands print results — retype those code paths to `PriceQuote`. Either loosen `formatSwapQuote` to accept `PriceQuote` (wallet `SwapQuote` is assignable to it) and guard any `recipient`/`execution` printing, or add a dedicated `formatPriceQuote`. Prefer loosening to `PriceQuote` if the formatter doesn't print execution/recipient; add a `formatPriceQuote` only if it does and the fields are wanted for the wallet path.
+- Verify the wallet swap quote command path still receives `SwapQuote` and prints recipient as before.
+
+**Patterns to follow:** existing `printOutput.ts` formatter registry and per-type formatters.
+
+**Test scenarios:**
+- `runSwapQuote`/`runSwapQuotes` still call `actions.swap.getQuote(s)` with built params and print without error on a `PriceQuote`-shaped object.
+- If a `formatPriceQuote` is added: it renders price/amounts/route and does not print a `recipient` line.
+
+---
+
+### U4. Update demo consumers
+
+**Goal:** Demo backend/frontend compile against the split types.
+
+**Dependencies:** U1, U2
+
+**Files:**
+- `packages/demo/backend/src/services/swap.ts` (modify — `getQuote` return type `SwapQuote`→`PriceQuote` at line 45; import)
+- `packages/demo/frontend/src/hooks/useSwap.ts` (modify — quote display typing)
+- `packages/demo/frontend/src/api/actionsApi.ts` (review/modify)
+- `packages/demo/frontend/src/components/earn/SwapAction.tsx` (review)
+- `packages/demo/frontend/src/components/earn/frontendWalletOperations.ts` / `serverWalletOperations.ts` (review)
+- `packages/demo/backend/src/utils/serializers.ts` (review — if it serializes a swap quote, ensure dropped fields aren't required)
+
+**Approach:**
+- Backend `getQuote` (price path) returns `PriceQuote`. `executeSwap` is unaffected (it re-quotes from raw params via `wallet.swap.execute`).
+- Frontend: the price-quote display type becomes `PriceQuote`. Confirm the execute flow uses raw params (server/frontend wallet operations), not the displayed quote object — adjust types accordingly. If any frontend code currently reads `quote.recipient`/`quote.execution` from the price path, remove that usage (it was reading the sentinel / dead data).
+
+**Patterns to follow:** existing demo serializer/formatter patterns; keep raw-param execute flow intact.
+
+**Test scenarios:**
+- `packages/demo/frontend/src/components/earn/EarnWithFrontendWallet.spec.ts` and any swap-quote test still pass with the stripped price-quote shape.
+- Test expectation for pure type-narrowing edits with no behavior change: none — covered by typecheck + existing specs.
+
+---
+
+## System-Wide Impact
+
+- **Public API change:** `actions.swap.getQuote(s)` return type narrows from `SwapQuote` to `PriceQuote`. This is a breaking type change for SDK consumers who relied on `recipient`/`execution` from the no-wallet path — but those fields were either the sentinel (un-trustworthy) or un-executable post-#434. A changeset entry should call this out.
+- **Affected packages:** `sdk`, `cli`, `demo`. Three of three workspace packages compile against the change.
+- **No runtime behavior change** for execution: wallet execute paths re-quote or require a wallet-bound `SwapQuote` exactly as before.
+
+---
+
+## Verification
+
+- `pnpm typecheck && pnpm lint && pnpm test` green from repo root (zero new warnings/errors per AGENTS.md baseline rule).
+- A changeset added describing the breaking type change (`pnpm changeset` convention — check `.changeset/` for format).
+- Manual CLI exercise: run `actions swap quote` (price path — confirm output has no recipient/sentinel) and a `wallet swap quote` (confirm recipient present), per AGENTS.md "Manual CLI verification before opening a PR".
+
+---
+
+## Deferred / Open Questions (execution-time)
+
+- Exact placement of `toPriceQuote` (namespace-local vs shared `swap` util) — decide when touching the files; prefer namespace-local unless a shared util already exists.
+- Whether `formatSwapQuote` is loosened in place or a `formatPriceQuote` is added — depends on whether the formatter prints `recipient`/`execution` (inspect at implementation time).
+- Whether a follow-up issue for the encoder defense-in-depth guard already exists in the tracker; file one if not.

--- a/packages/cli/src/output/printOutput.ts
+++ b/packages/cli/src/output/printOutput.ts
@@ -9,9 +9,9 @@ import type {
   LendMarket,
   LendMarketPosition,
   LendProviderName,
+  PriceQuote,
   SupportedChainId,
   SwapMarket,
-  SwapQuote,
   TokenBalance,
 } from '@eth-optimism/actions-sdk'
 import type { Address } from 'viem'
@@ -113,8 +113,8 @@ interface Printers {
   borrowPosition: BorrowMarketPosition
   swapMarkets: readonly SwapMarket[]
   swapMarket: SwapMarket
-  swapQuote: SwapQuote
-  swapQuotes: readonly SwapQuote[]
+  swapQuote: PriceQuote
+  swapQuotes: readonly PriceQuote[]
   swapExecute: SwapExecuteDoc
 }
 
@@ -309,7 +309,7 @@ function formatSwapMarkets(markets: readonly SwapMarket[]): void {
   for (const m of markets) formatSwapMarket(m)
 }
 
-function formatSwapQuote(q: SwapQuote): void {
+function formatSwapQuote(q: PriceQuote): void {
   writeLine(
     `${q.amountIn} ${q.assetIn.metadata.symbol} -> ${q.amountOut} ${q.assetOut.metadata.symbol} (provider=${q.provider}, chain=${q.chainId})`,
   )
@@ -319,7 +319,7 @@ function formatSwapQuote(q: SwapQuote): void {
   writeLine(`  amountOutMin=${q.amountOutMin} expiresAt=${q.expiresAt}`)
 }
 
-function formatSwapQuotes(quotes: readonly SwapQuote[]): void {
+function formatSwapQuotes(quotes: readonly PriceQuote[]): void {
   if (quotes.length === 0) {
     writeLine('(no quotes)')
     return

--- a/packages/demo/backend/src/services/swap.ts
+++ b/packages/demo/backend/src/services/swap.ts
@@ -1,8 +1,8 @@
 import type {
+  PriceQuote,
   SupportedChainId,
   SwapMarket,
   SwapProviderName,
-  SwapQuote,
   SwapReceipt,
 } from '@eth-optimism/actions-sdk'
 import type { Address } from 'viem'
@@ -42,7 +42,7 @@ export async function getMarkets(
   return await actions.swap.getMarkets(chainId ? { chainId } : {})
 }
 
-export async function getQuote(params: PriceParams): Promise<SwapQuote> {
+export async function getQuote(params: PriceParams): Promise<PriceQuote> {
   const {
     tokenInAddress,
     tokenOutAddress,

--- a/packages/demo/frontend/src/api/actionsApi.ts
+++ b/packages/demo/frontend/src/api/actionsApi.ts
@@ -1,9 +1,9 @@
 import type {
   Asset,
   LendMarketPosition,
+  PriceQuote,
   SupportedChainId,
   SwapMarket,
-  SwapQuote,
   TokenBalance,
   LendMarket,
   LendTransactionReceipt,
@@ -217,7 +217,7 @@ class ActionsApiClient extends BaseApiClient {
     }
 
     const { result } = await this.request<{
-      result: Serialized<SwapQuote>
+      result: Serialized<PriceQuote>
     }>(`/swap/quote?${params}`, {
       method: 'GET',
       headers,

--- a/packages/demo/frontend/src/components/earn/SwapAction.tsx
+++ b/packages/demo/frontend/src/components/earn/SwapAction.tsx
@@ -1,9 +1,9 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { createPortal } from 'react-dom'
 import type {
+  PriceQuote,
   SupportedChainId,
   SwapMarket,
-  SwapQuote,
 } from '@eth-optimism/actions-sdk/react'
 import type { Address } from 'viem'
 
@@ -31,7 +31,7 @@ import ArrowDownIcon from '@/components/icons/ArrowDownIcon'
 interface SwapActionProps {
   assets: SwapAsset[]
   isLoadingBalances: boolean
-  onSwap: (quote: SwapQuote) => Promise<{
+  onSwap: (quote: PriceQuote) => Promise<{
     blockExplorerUrl?: string
   }>
   onGetQuote: (params: {
@@ -40,7 +40,7 @@ interface SwapActionProps {
     chainId: SupportedChainId
     amountIn?: number
     amountOut?: number
-  }) => Promise<SwapQuote | null>
+  }) => Promise<PriceQuote | null>
   isExecuting: boolean
   selectedProvider?: string | null
   swapMarkets?: SwapMarket[]
@@ -234,7 +234,7 @@ export function SwapAction({
   const [amountIn, setAmountIn] = useState('')
   const [amountOut, setAmountOut] = useState('')
   const [editDirection, setEditDirection] = useState<'in' | 'out'>('in')
-  const [quote, setQuote] = useState<SwapQuote | null>(null)
+  const [quote, setQuote] = useState<PriceQuote | null>(null)
   const [isLoadingPrice, setIsLoadingPrice] = useState(false)
 
   // Modal states

--- a/packages/demo/frontend/src/components/earn/frontendWalletOperations.ts
+++ b/packages/demo/frontend/src/components/earn/frontendWalletOperations.ts
@@ -89,6 +89,10 @@ export function buildFrontendWalletOperations(
     openPosition: async (params) => wallet.lend!.openPosition(params),
     closePosition: async (params) => wallet.lend!.closePosition(params),
     executeSwap: async (quote) => {
+      // `quote` is typed `PriceQuote` by the shared EarnOperations interface,
+      // but this path requires the executable `SwapQuote` returned by this
+      // operations' own `getSwapQuote` (which calls `wallet.swap.getQuote`).
+      // Passing an arbitrary price-only quote would throw at execute().
       const receipt = await wallet.swap!.execute(quote)
       const txReceipt = receipt.receipt
       const blockExplorerUrl = getBlockExplorerUrl(

--- a/packages/demo/frontend/src/hooks/useLendProvider.ts
+++ b/packages/demo/frontend/src/hooks/useLendProvider.ts
@@ -10,9 +10,9 @@ import type {
   LendMarketId,
   LendMarketPosition,
   LendTransactionReceipt,
+  PriceQuote,
   SupportedChainId,
   SwapMarket,
-  SwapQuote,
   Asset,
 } from '@eth-optimism/actions-sdk/react'
 import { useQueryClient } from '@tanstack/react-query'
@@ -40,7 +40,7 @@ export interface EarnOperations {
   closePosition: (
     params: LendExecutePositionParams,
   ) => Promise<LendTransactionReceipt>
-  executeSwap: (quote: SwapQuote) => Promise<{ blockExplorerUrl?: string }>
+  executeSwap: (quote: PriceQuote) => Promise<{ blockExplorerUrl?: string }>
   getConfiguredAssets: () => Promise<Asset[]>
   getSwapMarkets: () => Promise<SwapMarket[]>
   getSwapQuote: (params: {
@@ -50,7 +50,7 @@ export interface EarnOperations {
     amountIn?: number
     amountOut?: number
     provider?: string
-  }) => Promise<SwapQuote | null>
+  }) => Promise<PriceQuote | null>
 }
 
 interface UseLendProviderParams {

--- a/packages/demo/frontend/src/hooks/useSwap.ts
+++ b/packages/demo/frontend/src/hooks/useSwap.ts
@@ -1,9 +1,9 @@
 import { useCallback, useEffect, useState } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import type {
+  PriceQuote,
   SupportedChainId,
   SwapMarket,
-  SwapQuote,
 } from '@eth-optimism/actions-sdk/react'
 
 import type { Address } from 'viem'
@@ -96,7 +96,7 @@ export function useSwap({ operations, activeTab }: UseSwapParams) {
   }, [activeTab, refetchSwapAssets])
 
   const handleSwap = useCallback(
-    async (quote: SwapQuote) => {
+    async (quote: PriceQuote) => {
       if (isSwapping) return
       setIsSwapping(true)
       try {

--- a/packages/sdk/src/actions/swap/namespaces/ActionsSwapNamespace.ts
+++ b/packages/sdk/src/actions/swap/namespaces/ActionsSwapNamespace.ts
@@ -1,7 +1,52 @@
 import { BaseSwapNamespace } from '@/actions/swap/namespaces/BaseSwapNamespace.js'
+import type {
+  PriceQuote,
+  SwapQuote,
+  SwapQuoteParams,
+} from '@/types/swap/index.js'
+
+/**
+ * Strip the execution-only fields off a full quote, leaving a price-only
+ * {@link PriceQuote}. Drops `execution` and `recipient` (which, without a
+ * wallet bound, would otherwise carry the Universal Router `msg.sender`
+ * sentinel) plus the `approvalMode` execution hint.
+ */
+function toPriceQuote(quote: SwapQuote): PriceQuote {
+  const {
+    execution: _execution,
+    recipient: _recipient,
+    approvalMode: _approvalMode,
+    ...priceQuote
+  } = quote
+  return priceQuote
+}
 
 /**
  * Actions swap namespace (read-only, no wallet required).
- * Provides getQuote(), getMarket(), and getMarkets() for read-only access without a wallet.
+ * Provides getQuote(), getMarket(), and getMarkets() for read-only access
+ * without a wallet.
+ *
+ * Quotes are returned as {@link PriceQuote} — pricing, amounts, and route only,
+ * with no recipient or execution data. They are intentionally un-executable:
+ * re-quote via `wallet.swap.getQuote(...)` to obtain an executable
+ * {@link SwapQuote} bound to a wallet.
  */
-export class ActionsSwapNamespace extends BaseSwapNamespace {}
+export class ActionsSwapNamespace extends BaseSwapNamespace {
+  /**
+   * Get a price-only swap quote (no recipient, no execution data).
+   * @param params - Quote parameters (assets, amounts, chain, optional provider)
+   * @returns The best available PriceQuote
+   */
+  async getQuote(params: SwapQuoteParams): Promise<PriceQuote> {
+    return toPriceQuote(await this.resolveQuote(params))
+  }
+
+  /**
+   * Get price-only quotes from all eligible providers, best price first.
+   * @param params - Quote parameters (assets, amounts, chain, optional provider)
+   * @returns Array of PriceQuotes sorted by amountOut descending (best first)
+   */
+  async getQuotes(params: SwapQuoteParams): Promise<PriceQuote[]> {
+    return (await this.resolveQuotes(params)).map(toPriceQuote)
+  }
+}

--- a/packages/sdk/src/actions/swap/namespaces/ActionsSwapNamespace.ts
+++ b/packages/sdk/src/actions/swap/namespaces/ActionsSwapNamespace.ts
@@ -6,10 +6,27 @@ import type {
 } from '@/types/swap/index.js'
 
 /**
+ * Compile-time guard: the keys `SwapQuote` adds on top of `PriceQuote`. The
+ * `satisfies` clause forces this map to list exactly those fields, so adding
+ * any execution-only field to `SwapQuote` is a compile error here until the
+ * field is also dropped from {@link toPriceQuote} — preventing a new field
+ * from silently leaking through the price-only surface. Exists for its type
+ * check only; the runtime strip happens in `toPriceQuote`.
+ */
+const _swapOnlyKeys = {
+  execution: true,
+  recipient: true,
+  approvalMode: true,
+} satisfies Record<Exclude<keyof SwapQuote, keyof PriceQuote>, true>
+
+/**
  * Strip the execution-only fields off a full quote, leaving a price-only
  * {@link PriceQuote}. Drops `execution` and `recipient` (which, without a
  * wallet bound, would otherwise carry the Universal Router `msg.sender`
  * sentinel) plus the `approvalMode` execution hint.
+ *
+ * Keep the destructured keys in sync with {@link _swapOnlyKeys}; that map's
+ * type fails to compile if `SwapQuote` gains a field not omitted here.
  */
 function toPriceQuote(quote: SwapQuote): PriceQuote {
   const {

--- a/packages/sdk/src/actions/swap/namespaces/BaseSwapNamespace.ts
+++ b/packages/sdk/src/actions/swap/namespaces/BaseSwapNamespace.ts
@@ -44,73 +44,6 @@ export abstract class BaseSwapNamespace extends BaseNamespace<
   }
 
   /**
-   * Get a swap quote with pre-built execution data.
-   * When `routing: 'price'` is set in settings and no explicit provider is requested,
-   * fetches quotes from all eligible providers in parallel and returns the best price.
-   * @param params - Quote parameters (assets, amounts, chain, optional provider)
-   * @returns The best available SwapQuote
-   */
-  async getQuote(params: SwapQuoteParams): Promise<SwapQuote> {
-    const recipient = await this.resolveRecipient(params.recipient)
-    const resolved: SwapQuoteParamsResolved = { ...params, recipient }
-
-    // Explicit provider — skip routing
-    if (resolved.provider) {
-      return this.resolveProvider(
-        resolved.provider,
-        resolved.assetIn,
-        resolved.assetOut,
-        resolved.chainId,
-      ).getQuote(resolved)
-    }
-
-    // Price routing — quote all eligible providers, return best
-    if (this.settings?.routing === 'price') {
-      return this.getBestQuote(resolved)
-    }
-
-    // No routing — resolve single provider via fallback logic
-    return this.resolveProvider(
-      undefined,
-      resolved.assetIn,
-      resolved.assetOut,
-      resolved.chainId,
-    ).getQuote(resolved)
-  }
-
-  /**
-   * Fetch quotes from all providers with the wallet address as recipient.
-   * Unlike getQuote(), returns all successful quotes instead of just the best.
-   * If an explicit provider is specified, returns a single-element array from that provider.
-   * @param params - Quote parameters (assets, amounts, chain, optional provider)
-   * @returns Array of SwapQuotes sorted by amountOut descending (best first)
-   */
-  async getQuotes(params: SwapQuoteParams): Promise<SwapQuote[]> {
-    const recipient = await this.resolveRecipient(params.recipient)
-    const resolved: SwapQuoteParamsResolved = { ...params, recipient }
-
-    if (resolved.provider) {
-      return [
-        await this.resolveProvider(
-          resolved.provider,
-          resolved.assetIn,
-          resolved.assetOut,
-          resolved.chainId,
-        ).getQuote(resolved),
-      ]
-    }
-
-    const quotes = await this.fetchAllQuotes(resolved)
-    return quotes.sort((a, b) =>
-      a.amountOutRaw > b.amountOutRaw
-        ? -1
-        : a.amountOutRaw < b.amountOutRaw
-          ? 1
-          : 0,
-    )
-  }
-
-  /**
    * Get a specific swap market by ID.
    * @param params - Market identifier (poolId + chainId)
    * @param provider - Optional provider name to query directly instead of searching all
@@ -151,6 +84,80 @@ export abstract class BaseSwapNamespace extends BaseNamespace<
       this.getAllProviders().map((p) => p.getMarkets(params)),
     )
     return results.flat()
+  }
+
+  /**
+   * Resolve a full, executable swap quote (recipient + pre-built execution data).
+   * When `routing: 'price'` is set in settings and no explicit provider is requested,
+   * fetches quotes from all eligible providers in parallel and returns the best price.
+   *
+   * Protected because the two namespaces expose different public surfaces:
+   * `ActionsSwapNamespace` strips the result to a {@link PriceQuote} (no wallet
+   * bound), while `WalletSwapNamespace` returns the full {@link SwapQuote}.
+   * @param params - Quote parameters (assets, amounts, chain, optional provider)
+   * @returns The best available SwapQuote
+   */
+  protected async resolveQuote(params: SwapQuoteParams): Promise<SwapQuote> {
+    const recipient = await this.resolveRecipient(params.recipient)
+    const resolved: SwapQuoteParamsResolved = { ...params, recipient }
+
+    // Explicit provider — skip routing
+    if (resolved.provider) {
+      return this.resolveProvider(
+        resolved.provider,
+        resolved.assetIn,
+        resolved.assetOut,
+        resolved.chainId,
+      ).getQuote(resolved)
+    }
+
+    // Price routing — quote all eligible providers, return best
+    if (this.settings?.routing === 'price') {
+      return this.getBestQuote(resolved)
+    }
+
+    // No routing — resolve single provider via fallback logic
+    return this.resolveProvider(
+      undefined,
+      resolved.assetIn,
+      resolved.assetOut,
+      resolved.chainId,
+    ).getQuote(resolved)
+  }
+
+  /**
+   * Fetch quotes from all providers. Unlike resolveQuote(), returns all
+   * successful quotes instead of just the best. If an explicit provider is
+   * specified, returns a single-element array from that provider.
+   *
+   * Protected for the same reason as {@link resolveQuote}: each namespace maps
+   * the result to its own public quote type.
+   * @param params - Quote parameters (assets, amounts, chain, optional provider)
+   * @returns Array of SwapQuotes sorted by amountOut descending (best first)
+   */
+  protected async resolveQuotes(params: SwapQuoteParams): Promise<SwapQuote[]> {
+    const recipient = await this.resolveRecipient(params.recipient)
+    const resolved: SwapQuoteParamsResolved = { ...params, recipient }
+
+    if (resolved.provider) {
+      return [
+        await this.resolveProvider(
+          resolved.provider,
+          resolved.assetIn,
+          resolved.assetOut,
+          resolved.chainId,
+        ).getQuote(resolved),
+      ]
+    }
+
+    const quotes = await this.fetchAllQuotes(resolved)
+    return quotes.sort((a, b) =>
+      a.amountOutRaw > b.amountOutRaw
+        ? -1
+        : a.amountOutRaw < b.amountOutRaw
+          ? 1
+          : 0,
+    )
   }
 
   /**

--- a/packages/sdk/src/actions/swap/namespaces/WalletSwapNamespace.ts
+++ b/packages/sdk/src/actions/swap/namespaces/WalletSwapNamespace.ts
@@ -3,7 +3,10 @@ import { isAddressEqual } from 'viem'
 import { QUOTE_DISCRIMINATOR } from '@/actions/shared/quoteDiscriminator.js'
 import { BaseSwapNamespace } from '@/actions/swap/namespaces/BaseSwapNamespace.js'
 import type { SupportedChainId } from '@/constants/supportedChains.js'
-import { QuoteRecipientMismatchError } from '@/core/error/errors.js'
+import {
+  QuoteRecipientMismatchError,
+  QuoteRecipientMissingError,
+} from '@/core/error/errors.js'
 import type { SwapExecuteParamsResolved } from '@/services/nameservices/ens/types.js'
 import type { RecipientResolver } from '@/services/nameservices/ens/utils.js'
 import type { SwapSettings } from '@/types/actions.js'
@@ -90,8 +93,16 @@ export class WalletSwapNamespace extends BaseSwapNamespace {
    * quote's recipient differs from `wallet.address`; silently swapping
    * recipients would route output tokens to the wrong address on routers that
    * encode the recipient directly into calldata (e.g. Velodrome v2/leaf).
+   *
+   * Also guards the case where a price-only quote (from
+   * `actions.swap.getQuote`) reaches `execute`: it carries `quotedAt` (so it
+   * routes here) but has no `recipient`, so it fails loudly with a clear
+   * domain error instead of a cryptic address-comparison crash.
    */
   private requireQuoteForThisWallet(quote: SwapQuote): SwapQuote {
+    if (!quote.recipient) {
+      throw new QuoteRecipientMissingError()
+    }
     if (!isAddressEqual(quote.recipient, this.wallet.address)) {
       throw new QuoteRecipientMismatchError({
         quoteRecipient: quote.recipient,

--- a/packages/sdk/src/actions/swap/namespaces/WalletSwapNamespace.ts
+++ b/packages/sdk/src/actions/swap/namespaces/WalletSwapNamespace.ts
@@ -34,21 +34,22 @@ export class WalletSwapNamespace extends BaseSwapNamespace {
   }
 
   /**
-   * Get a swap quote with the wallet address as recipient.
+   * Get a full, executable swap quote with the wallet address as recipient.
    * Ensures calldata is encoded for the real wallet, not a placeholder.
    */
-  override async getQuote(params: SwapQuoteParams): Promise<SwapQuote> {
-    return super.getQuote({
+  async getQuote(params: SwapQuoteParams): Promise<SwapQuote> {
+    return this.resolveQuote({
       ...params,
       recipient: params.recipient ?? this.wallet.address,
     })
   }
 
   /**
-   * Get quotes from all providers with the wallet address as recipient.
+   * Get full, executable quotes from all providers with the wallet address as
+   * recipient.
    */
-  override async getQuotes(params: SwapQuoteParams): Promise<SwapQuote[]> {
-    return super.getQuotes({
+  async getQuotes(params: SwapQuoteParams): Promise<SwapQuote[]> {
+    return this.resolveQuotes({
       ...params,
       recipient: params.recipient ?? this.wallet.address,
     })

--- a/packages/sdk/src/actions/swap/namespaces/__tests__/BaseSwapNamespace.spec.ts
+++ b/packages/sdk/src/actions/swap/namespaces/__tests__/BaseSwapNamespace.spec.ts
@@ -97,6 +97,10 @@ describe('BaseSwapNamespace', () => {
 
       // Should pick velodrome because 1.8 > 1.2 (higher amountOut)
       expect(result.provider).toBe('velodrome')
+      // The price-routing branch returns through toPriceQuote too — still no
+      // sentinel recipient leak.
+      expect(result).not.toHaveProperty('recipient')
+      expect(result).not.toHaveProperty('execution')
     })
 
     it('skips providers that fail to quote', async () => {
@@ -203,6 +207,13 @@ describe('BaseSwapNamespace', () => {
       expect(quotes).toHaveLength(2)
       expect(quotes[0].provider).toBe('velodrome')
       expect(quotes[1].provider).toBe('uniswap')
+      // The plural path strips through the same toPriceQuote — no element may
+      // leak the sentinel recipient or execution data.
+      for (const quote of quotes) {
+        expect(quote).not.toHaveProperty('execution')
+        expect(quote).not.toHaveProperty('recipient')
+        expect(quote).not.toHaveProperty('approvalMode')
+      }
     })
 
     it('skips failed providers and returns successful ones', async () => {

--- a/packages/sdk/src/actions/swap/namespaces/__tests__/BaseSwapNamespace.spec.ts
+++ b/packages/sdk/src/actions/swap/namespaces/__tests__/BaseSwapNamespace.spec.ts
@@ -22,7 +22,7 @@ describe('BaseSwapNamespace', () => {
   }
 
   describe('getQuote', () => {
-    it('delegates to provider getQuote', async () => {
+    it('delegates to provider getQuote and returns a price-only quote', async () => {
       const provider = createMockSwapProvider()
       const namespace = new ActionsSwapNamespace({ uniswap: provider })
 
@@ -35,9 +35,26 @@ describe('BaseSwapNamespace', () => {
 
       expect(provider.mockGetQuote).toHaveBeenCalledTimes(1)
       expect(result.price).toBe(1.5)
-      expect(result.execution).toBeDefined()
-      expect(result.execution.swapCalldata).toMatch(/^0x/)
       expect(result.provider).toBe('uniswap')
+    })
+
+    it('strips execution and recipient so no msg.sender sentinel leaks', async () => {
+      const provider = createMockSwapProvider()
+      const namespace = new ActionsSwapNamespace({ uniswap: provider })
+
+      const result = await namespace.getQuote({
+        assetIn: USDC,
+        assetOut: ETH,
+        amountIn: 100,
+        chainId: 84532 as SupportedChainId,
+      })
+
+      // PriceQuote is intentionally un-executable: dropping recipient prevents
+      // the Universal Router msg.sender sentinel (address(1)) from leaking into
+      // a public field that consumers would trust for display/accounting.
+      expect(result).not.toHaveProperty('execution')
+      expect(result).not.toHaveProperty('recipient')
+      expect(result).not.toHaveProperty('approvalMode')
     })
 
     it('throws if no provider configured', async () => {

--- a/packages/sdk/src/actions/swap/namespaces/__tests__/WalletSwapNamespace.spec.ts
+++ b/packages/sdk/src/actions/swap/namespaces/__tests__/WalletSwapNamespace.spec.ts
@@ -5,6 +5,7 @@ import { createMockSwapProvider } from '@/actions/swap/__mocks__/MockSwapProvide
 import { ActionsSwapNamespace } from '@/actions/swap/namespaces/ActionsSwapNamespace.js'
 import { WalletSwapNamespace } from '@/actions/swap/namespaces/WalletSwapNamespace.js'
 import type { SupportedChainId } from '@/constants/supportedChains.js'
+import { QuoteRecipientMissingError } from '@/core/error/errors.js'
 import type { Wallet } from '@/wallet/core/wallets/abstract/Wallet.js'
 
 describe('WalletSwapNamespace', () => {
@@ -250,7 +251,9 @@ describe('WalletSwapNamespace', () => {
         chainId: 84532 as SupportedChainId,
       })
 
-      await expect(namespace.execute(priceQuote)).rejects.toThrow()
+      await expect(namespace.execute(priceQuote)).rejects.toThrow(
+        QuoteRecipientMissingError,
+      )
       expect(provider.mockExecute).not.toHaveBeenCalled()
     })
   })

--- a/packages/sdk/src/actions/swap/namespaces/__tests__/WalletSwapNamespace.spec.ts
+++ b/packages/sdk/src/actions/swap/namespaces/__tests__/WalletSwapNamespace.spec.ts
@@ -2,6 +2,7 @@ import type { Address } from 'viem'
 import { describe, expect, it, vi } from 'vitest'
 
 import { createMockSwapProvider } from '@/actions/swap/__mocks__/MockSwapProvider.js'
+import { ActionsSwapNamespace } from '@/actions/swap/namespaces/ActionsSwapNamespace.js'
 import { WalletSwapNamespace } from '@/actions/swap/namespaces/WalletSwapNamespace.js'
 import type { SupportedChainId } from '@/constants/supportedChains.js'
 import type { Wallet } from '@/wallet/core/wallets/abstract/Wallet.js'
@@ -230,6 +231,27 @@ describe('WalletSwapNamespace', () => {
       })
 
       expect(quote.recipient).toBe(customRecipient)
+    })
+
+    it('rejects a price-only quote passed to execute (no recipient to bind)', async () => {
+      const provider = createMockSwapProvider()
+      const wallet = createMockWallet()
+      const actions = new ActionsSwapNamespace({ uniswap: provider })
+      const namespace = new WalletSwapNamespace({ uniswap: provider }, wallet)
+
+      // A PriceQuote from actions.swap.getQuote carries quotedAt (so execute
+      // routes it down the pre-built-quote path) but has no recipient. It must
+      // fail loudly rather than silently re-quoting to the wallet — re-quote
+      // via wallet.swap.getQuote to execute.
+      const priceQuote = await actions.getQuote({
+        assetIn: USDC,
+        assetOut: ETH,
+        amountIn: 100,
+        chainId: 84532 as SupportedChainId,
+      })
+
+      await expect(namespace.execute(priceQuote)).rejects.toThrow()
+      expect(provider.mockExecute).not.toHaveBeenCalled()
     })
   })
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -132,6 +132,7 @@ export type {
   LendTransaction,
   LendTransactionReceipt,
   MorphoMarketParams,
+  PriceQuote,
   SwapConfig,
   SwapExecuteParams,
   SwapMarket,

--- a/packages/sdk/src/types/swap/base.ts
+++ b/packages/sdk/src/types/swap/base.ts
@@ -187,15 +187,20 @@ export interface SwapQuoteExecution {
 }
 
 /**
- * A complete swap quote: pricing, amounts, and pre-built execution data.
- * Pass to execute() to skip re-quoting.
+ * A price-only swap quote: pricing, amounts, route, and metadata — with **no**
+ * execution data and **no** recipient. Returned by `actions.swap.getQuote`
+ * (no wallet bound). Structurally un-executable: there is no `execution`
+ * calldata and no `recipient` to leak. For display, accounting, or analytics.
+ *
+ * To execute, re-quote via `wallet.swap.getQuote(...)`, which binds the quote
+ * to the wallet and returns a full {@link SwapQuote}.
  *
  * **Precision note:** `Raw` fields (bigint) are the on-chain source of truth.
  * Number fields (`amountIn`, `amountOut`, `price`, etc.) are display approximations
  * derived via `formatUnits` → `parseFloat`. For tokens with many significant digits,
  * numbers may lose precision. Use `Raw` fields for any math that matters.
  */
-export interface SwapQuote {
+export interface PriceQuote {
   // ── What you're swapping ──
   /** Token being sold */
   assetIn: Asset
@@ -230,10 +235,6 @@ export interface SwapQuote {
   /** Route taken for the swap */
   route: SwapRoute
 
-  // ── Execution ──
-  /** Pre-built transaction data. Pass quote to execute() to use. */
-  execution: SwapQuoteExecution
-
   // ── Metadata ──
   /** Provider that generated this quote */
   provider: SwapProviderName
@@ -247,6 +248,17 @@ export interface SwapQuote {
   expiresAt: number
   /** Estimated gas cost as raw bigint (native decimals) */
   gasEstimate?: bigint
+}
+
+/**
+ * A complete, executable swap quote: a {@link PriceQuote} plus pre-built
+ * execution data and a concrete recipient. Returned by `wallet.swap.getQuote`
+ * (bound to the wallet). Pass to `wallet.swap.execute()` to skip re-quoting.
+ */
+export interface SwapQuote extends PriceQuote {
+  // ── Execution ──
+  /** Pre-built transaction data. Pass quote to execute() to use. */
+  execution: SwapQuoteExecution
   /**
    * Recipient address baked into execution.swapCalldata at quote time.
    * Required. To execute a quote on a wallet, the quote must have been


### PR DESCRIPTION
Closes #435

## Problem

`actions.swap.getQuote(...)` (no wallet bound) returned a `SwapQuote` whose
`recipient: Address` was the Universal Router `msg.sender` sentinel
(`0x0000000000000000000000000000000000000001`) when no recipient was supplied.
The type said "ready to execute" while the value was un-executable — a footgun
for any consumer reading `quote.recipient` for display, accounting, or analytics.

## Change (Option B — split the type)

- New **`PriceQuote`** type: pricing, amounts, route, metadata only — no
  `recipient`, no `execution`. Structurally un-executable. `SwapQuote` now
  `extends PriceQuote` and adds `execution`, `recipient`, `approvalMode`.
- `actions.swap.getQuote` / `getQuotes` return `PriceQuote` (stripped at the
  namespace boundary via `toPriceQuote`). `wallet.swap.getQuote` / `getQuotes`
  still return the full `SwapQuote`; `wallet.swap.execute` is unchanged.
- `BaseSwapNamespace.getQuote/getQuotes` became `protected resolveQuote/
  resolveQuotes` (a covariant override can't widen the return type), with each
  namespace exposing its own public method.
- Consumers updated: CLI printer + `actions swap quote(s)` commands, demo
  backend `getQuote`, demo frontend `EarnOperations`/`useSwap`/`SwapAction`/
  `actionsApi`.

Providers are untouched — the sentinel remains a valid internal Universal
Router encoding detail; it's simply never exposed.

## Why B

The demo's `executeSwap` re-quotes from raw params via `wallet.swap.execute`
and never executes an actions-level quote, so the `execution`/`recipient` on a
price quote were already dead weight (and un-executable post-#434). Dropping
them breaks no execution path and gives price-display consumers a smaller,
honest surface.

Note: passing a `PriceQuote` to `execute` is structurally accepted as raw
params, but it carries `quotedAt`, so it routes to the pre-built-quote path and
throws on the missing `recipient` — a fail-loud runtime guard (regression-tested).

## Testing

- SDK 666, CLI 261, demo backend 130, demo frontend 73, contracts 18 — all green.
- New tests: `actions.swap.getQuote` strips `recipient`/`execution`/`approvalMode`
  (the leak fix); `execute` rejects a price-only quote.
- Manual CLI verification: `actions swap quote` (live, base-sepolia) JSON output
  contains no `recipient`/`execution`/sentinel; human output renders cleanly.
- `pnpm typecheck && pnpm lint && pnpm test` clean (zero new warnings).
- Changeset added (`minor`; breaking type change documented).

Plan: `docs/plans/2026-06-16-001-refactor-split-price-quote-from-swap-quote-plan.md`.
