### PR TITLE
Batch Wallet.getBalance asset fetches via Multicall3

### DIFF
--- a/packages/sdk/src/constants/multicall.ts
+++ b/packages/sdk/src/constants/multicall.ts
@@ -1,0 +1,26 @@
+import type { Abi, Address } from 'viem'
+
+/**
+ * Canonical Multicall3 deployment address. Multicall3 is deployed at this same
+ * address on every OP Stack chain and most other EVM chains.
+ * @see https://github.com/mds1/multicall
+ */
+export const MULTICALL3_ADDRESS: Address =
+  '0xcA11bde05977b3631167028862bE2a173976CA11'
+
+/**
+ * Minimal Multicall3 ABI fragment exposing `getEthBalance`.
+ * @description viem's exported `multicall3Abi` only carries `aggregate3` (the
+ * entry point it uses internally), so we declare `getEthBalance` here to read a
+ * wallet's native balance inside the same batched `eth_call` as the ERC-20
+ * `balanceOf` reads.
+ */
+export const multicall3GetEthBalanceAbi = [
+  {
+    type: 'function',
+    stateMutability: 'view',
+    name: 'getEthBalance',
+    inputs: [{ name: 'addr', type: 'address' }],
+    outputs: [{ name: 'balance', type: 'uint256' }],
+  },
+] as const satisfies Abi

--- a/packages/sdk/src/services/__mocks__/MockChainManager.ts
+++ b/packages/sdk/src/services/__mocks__/MockChainManager.ts
@@ -130,6 +130,16 @@ export class MockChainManager {
       getBalance: vi.fn().mockImplementation(() => {
         return Promise.resolve(this.config.defaultBalance)
       }),
+      multicall: vi
+        .fn()
+        .mockImplementation(({ contracts }: { contracts: unknown[] }) => {
+          return Promise.resolve(
+            contracts.map(() => ({
+              status: 'success' as const,
+              result: this.config.defaultBalance,
+            })),
+          )
+        }),
     } as any
   }
 

--- a/packages/sdk/src/services/__tests__/tokenBalance.spec.ts
+++ b/packages/sdk/src/services/__tests__/tokenBalance.spec.ts
@@ -1,15 +1,20 @@
 import type { Address } from 'viem'
+import { erc20Abi } from 'viem'
 import { base, optimism, unichain } from 'viem/chains'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { MockUSDCAsset } from '@/__mocks__/MockAssets.js'
 import { ETH } from '@/constants/assets.js'
+import {
+  MULTICALL3_ADDRESS,
+  multicall3GetEthBalanceAbi,
+} from '@/constants/multicall.js'
 import { MockChainManager } from '@/services/__mocks__/MockChainManager.js'
 import type { ChainManager } from '@/services/ChainManager.js'
-import { fetchERC20Balance, fetchETHBalance } from '@/services/tokenBalance.js'
+import { fetchBalances } from '@/services/tokenBalance.js'
 import type { Asset } from '@/types/asset.js'
 
-describe('TokenBalance', () => {
+describe('fetchBalances', () => {
   let chainManager: ChainManager
   const walletAddress: Address = '0x1234567890123456789012345678901234567890'
 
@@ -17,7 +22,7 @@ describe('TokenBalance', () => {
     chainManager = new MockChainManager({
       supportedChains: [unichain.id],
       defaultBalance: 1000000n,
-    }) as any
+    }) as unknown as ChainManager
   })
 
   const multiChainManager = (): ChainManager =>
@@ -26,119 +31,154 @@ describe('TokenBalance', () => {
       defaultBalance: 1000000n,
     }) as unknown as ChainManager
 
-  describe('fetchBalance', () => {
-    it('should fetch token balance across supported chains', async () => {
-      const balance = await fetchERC20Balance(
-        chainManager,
-        walletAddress,
-        MockUSDCAsset,
-      )
+  it('fetches ERC20 balances across supported chains', async () => {
+    const [usdc] = await fetchBalances(chainManager, walletAddress, [
+      MockUSDCAsset,
+    ])
 
-      expect(balance).toEqual({
-        asset: MockUSDCAsset,
-        totalBalance: 1,
-        totalBalanceRaw: 1000000n,
-        chains: {
-          [unichain.id]: {
-            balance: 1,
-            balanceRaw: 1000000n,
-          },
-        },
-      })
-    })
-
-    it('should return zero balance when token not supported on any chains', async () => {
-      const unsupportedAsset: Asset = {
-        metadata: {
-          symbol: 'UNSUPPORTED',
-          name: 'Unsupported Token',
-          decimals: 18,
-        },
-        address: {
-          27637: '0xBAa5CC21fd487B8Fcc2F632f3F4E8D37262a0842',
-        } as any,
-        type: 'erc20',
-      }
-
-      const balance = await fetchERC20Balance(
-        chainManager,
-        walletAddress,
-        unsupportedAsset,
-      )
-
-      expect(balance).toEqual({
-        asset: unsupportedAsset,
-        totalBalance: 0,
-        totalBalanceRaw: 0n,
-        chains: {},
-      })
+    expect(usdc).toEqual({
+      asset: MockUSDCAsset,
+      totalBalance: 1,
+      totalBalanceRaw: 1000000n,
+      chains: {
+        [unichain.id]: { balance: 1, balanceRaw: 1000000n },
+      },
     })
   })
 
-  describe('fetchETHBalance', () => {
-    it('should fetch ETH balance across supported chains', async () => {
-      const balance = await fetchETHBalance(chainManager, walletAddress)
+  it('fetches the native ETH balance via Multicall3 getEthBalance', async () => {
+    const [eth] = await fetchBalances(chainManager, walletAddress, [ETH])
 
-      expect(balance).toEqual({
-        asset: ETH,
-        totalBalance: 0.000000000001,
-        totalBalanceRaw: 1000000n,
-        chains: {
-          [unichain.id]: {
-            balance: 0.000000000001,
-            balanceRaw: 1000000n,
-          },
-        },
-      })
+    expect(eth).toEqual({
+      asset: ETH,
+      totalBalance: 0.000000000001,
+      totalBalanceRaw: 1000000n,
+      chains: {
+        [unichain.id]: { balance: 0.000000000001, balanceRaw: 1000000n },
+      },
     })
 
-    it('queries only the requested chains when chainIds is provided', async () => {
-      const cm = multiChainManager()
+    // The native balance is read through Multicall3's getEthBalance entry.
+    const client = chainManager.getPublicClient(unichain.id)
+    const contracts = vi.mocked(client.multicall).mock.calls[0][0]
+      .contracts as any[]
+    expect(contracts).toHaveLength(1)
+    expect(contracts[0].address.toLowerCase()).toBe(
+      MULTICALL3_ADDRESS.toLowerCase(),
+    )
+    expect(contracts[0].abi).toBe(multicall3GetEthBalanceAbi)
+    expect(contracts[0].functionName).toBe('getEthBalance')
+    expect(contracts[0].args).toEqual([walletAddress])
+  })
 
-      const balance = await fetchETHBalance(cm, walletAddress, {
-        chainIds: [base.id],
-      })
+  it('batches native + ERC20 reads into a single multicall per chain', async () => {
+    const balances = await fetchBalances(chainManager, walletAddress, [
+      ETH,
+      MockUSDCAsset,
+    ])
 
-      expect(balance.chains).toEqual({
-        [base.id]: { balance: 0.000000000001, balanceRaw: 1000000n },
-      })
-      expect(balance.totalBalanceRaw).toBe(1000000n)
-      expect(cm.getPublicClient).toHaveBeenCalledTimes(1)
-      expect(cm.getPublicClient).toHaveBeenCalledWith(base.id)
+    expect(balances.map((b) => b.asset)).toEqual([ETH, MockUSDCAsset])
+
+    const client = chainManager.getPublicClient(unichain.id)
+    expect(client.multicall).toHaveBeenCalledTimes(1)
+    const contracts = vi.mocked(client.multicall).mock.calls[0][0]
+      .contracts as any[]
+    expect(contracts).toHaveLength(2)
+    expect(contracts[0].functionName).toBe('getEthBalance')
+    expect(contracts[1]).toEqual({
+      address: MockUSDCAsset.address[unichain.id],
+      abi: erc20Abi,
+      functionName: 'balanceOf',
+      args: [walletAddress],
     })
   })
 
-  describe('fetchERC20Balance with chainIds filter', () => {
-    it('queries only the requested chains', async () => {
-      const cm = multiChainManager()
+  it('queries only the requested chains when chainIds is provided', async () => {
+    const cm = multiChainManager()
 
-      const balance = await fetchERC20Balance(
-        cm,
-        walletAddress,
-        MockUSDCAsset,
-        { chainIds: [optimism.id, base.id] },
-      )
-
-      expect(Object.keys(balance.chains).map(Number).sort()).toEqual(
-        [optimism.id, base.id].sort(),
-      )
-      expect(balance.totalBalanceRaw).toBe(2000000n)
+    const [usdc] = await fetchBalances(cm, walletAddress, [MockUSDCAsset], {
+      chainIds: [base.id],
     })
 
-    it('silently skips requested chains where the asset has no address', async () => {
-      const cm = multiChainManager()
-      const opOnly: Asset = {
-        ...MockUSDCAsset,
-        address: { [optimism.id]: MockUSDCAsset.address[optimism.id] } as any,
-      }
-
-      const balance = await fetchERC20Balance(cm, walletAddress, opOnly, {
-        chainIds: [optimism.id, base.id],
-      })
-
-      expect(balance.chains).toEqual({
-        [optimism.id]: { balance: 1, balanceRaw: 1000000n },
-      })
+    expect(usdc.chains).toEqual({
+      [base.id]: { balance: 1, balanceRaw: 1000000n },
     })
+    expect(usdc.totalBalanceRaw).toBe(1000000n)
+    expect(cm.getPublicClient).toHaveBeenCalledTimes(1)
+    expect(cm.getPublicClient).toHaveBeenCalledWith(base.id)
+  })
+
+  it('aggregates an ERC20 balance across multiple chains', async () => {
+    const cm = multiChainManager()
+
+    const [usdc] = await fetchBalances(cm, walletAddress, [MockUSDCAsset], {
+      chainIds: [optimism.id, base.id],
+    })
+
+    expect(Object.keys(usdc.chains).map(Number).sort()).toEqual(
+      [optimism.id, base.id].sort(),
+    )
+    expect(usdc.totalBalanceRaw).toBe(2000000n)
+  })
+
+  it('skips chains where the asset has no configured address', async () => {
+    const cm = multiChainManager()
+    const opOnly: Asset = {
+      ...MockUSDCAsset,
+      address: { [optimism.id]: MockUSDCAsset.address[optimism.id] } as any,
+    }
+
+    const [usdc] = await fetchBalances(cm, walletAddress, [opOnly], {
+      chainIds: [optimism.id, base.id],
+    })
+
+    expect(usdc.chains).toEqual({
+      [optimism.id]: { balance: 1, balanceRaw: 1000000n },
+    })
+    // No multicall is issued for a chain with no applicable assets.
+    expect(cm.getPublicClient).toHaveBeenCalledTimes(1)
+    expect(cm.getPublicClient).toHaveBeenCalledWith(optimism.id)
+  })
+
+  it('returns zero balance when an asset is unsupported on every chain', async () => {
+    const unsupportedAsset: Asset = {
+      metadata: {
+        symbol: 'UNSUPPORTED',
+        name: 'Unsupported Token',
+        decimals: 18,
+      },
+      address: { 27637: '0xBAa5CC21fd487B8Fcc2F632f3F4E8D37262a0842' } as any,
+      type: 'erc20',
+    }
+
+    const [balance] = await fetchBalances(chainManager, walletAddress, [
+      unsupportedAsset,
+    ])
+
+    expect(balance).toEqual({
+      asset: unsupportedAsset,
+      totalBalance: 0,
+      totalBalanceRaw: 0n,
+      chains: {},
+    })
+  })
+
+  it('omits an asset on a chain whose inner call failed', async () => {
+    const client = chainManager.getPublicClient(unichain.id)
+    vi.mocked(client.multicall).mockResolvedValueOnce([
+      { status: 'success', result: 1000000n },
+      { status: 'failure', error: new Error('reverted') },
+    ] as any)
+
+    const [eth, usdc] = await fetchBalances(chainManager, walletAddress, [
+      ETH,
+      MockUSDCAsset,
+    ])
+
+    expect(eth.chains).toEqual({
+      [unichain.id]: { balance: 0.000000000001, balanceRaw: 1000000n },
+    })
+    expect(usdc.chains).toEqual({})
+    expect(usdc.totalBalanceRaw).toBe(0n)
   })
 })

--- a/packages/sdk/src/services/__tests__/tokenBalance.spec.ts
+++ b/packages/sdk/src/services/__tests__/tokenBalance.spec.ts
@@ -1,6 +1,6 @@
 import type { Address } from 'viem'
 import { erc20Abi } from 'viem'
-import { base, optimism, unichain } from 'viem/chains'
+import { base, celo, optimism, unichain } from 'viem/chains'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { MockUSDCAsset } from '@/__mocks__/MockAssets.js'
@@ -180,5 +180,63 @@ describe('fetchBalances', () => {
     })
     expect(usdc.chains).toEqual({})
     expect(usdc.totalBalanceRaw).toBe(0n)
+  })
+
+  it('reads native ETH on supported chains absent from the asset address map', async () => {
+    // celo is a supported chain but has no entry in ETH.address; the native
+    // balance must still be read (matching the previous unconditional fan-out).
+    const cm = new MockChainManager({
+      supportedChains: [celo.id],
+      defaultBalance: 1000000n,
+    }) as unknown as ChainManager
+
+    const [eth] = await fetchBalances(cm, walletAddress, [ETH])
+
+    expect(eth.chains).toEqual({
+      [celo.id]: { balance: 0.000000000001, balanceRaw: 1000000n },
+    })
+    expect(eth.totalBalanceRaw).toBe(1000000n)
+  })
+
+  it('targets the chain-configured Multicall3 address when present', async () => {
+    const custom = '0x000000000000000000000000000000000000cafe' as Address
+    vi.spyOn(chainManager as any, 'getChain').mockReturnValue({
+      contracts: { multicall3: { address: custom } },
+    })
+
+    await fetchBalances(chainManager, walletAddress, [ETH])
+
+    const client = chainManager.getPublicClient(unichain.id)
+    const contracts = vi.mocked(client.multicall).mock.calls[0][0]
+      .contracts as any[]
+    expect(contracts[0].address).toBe(custom)
+  })
+
+  it('rejects when a chain multicall fails at the transport level', async () => {
+    const client = chainManager.getPublicClient(unichain.id)
+    vi.mocked(client.multicall).mockRejectedValueOnce(
+      new Error('transport down'),
+    )
+
+    await expect(
+      fetchBalances(chainManager, walletAddress, [ETH]),
+    ).rejects.toThrow('transport down')
+  })
+
+  it('aggregates only succeeding chains when one chain inner call fails', async () => {
+    const cm = multiChainManager()
+    const opClient = cm.getPublicClient(optimism.id)
+    vi.mocked(opClient.multicall).mockResolvedValueOnce([
+      { status: 'failure', error: new Error('reverted') },
+    ] as any)
+
+    const [usdc] = await fetchBalances(cm, walletAddress, [MockUSDCAsset], {
+      chainIds: [optimism.id, base.id],
+    })
+
+    expect(usdc.chains).toEqual({
+      [base.id]: { balance: 1, balanceRaw: 1000000n },
+    })
+    expect(usdc.totalBalanceRaw).toBe(1000000n)
   })
 })

--- a/packages/sdk/src/services/tokenBalance.ts
+++ b/packages/sdk/src/services/tokenBalance.ts
@@ -125,7 +125,7 @@ async function fetchChainBalances(
 
   results.forEach((result, index) => {
     if (result.status === 'success') {
-      balances.set(entries[index].asset, result.result as bigint)
+      balances.set(entries[index].asset, result.result)
     }
   })
 
@@ -143,10 +143,12 @@ function balanceContract(
   walletAddress: Address,
 ): BalanceContract | undefined {
   const tokenAddress = asset.address[chainId]
-  if (!tokenAddress) {
-    return undefined
-  }
 
+  // Native assets exist on every chain, so read them via Multicall3's
+  // `getEthBalance` regardless of whether the per-chain address map lists this
+  // chain. This matches the previous unconditional native-balance fan-out;
+  // gating on the address map would silently drop native balances on supported
+  // chains that have no entry in the asset's address map (e.g. celo, superseed).
   if (asset.type === 'native' || tokenAddress === 'native') {
     return {
       address: multicall3Address(chainManager, chainId),
@@ -154,6 +156,10 @@ function balanceContract(
       functionName: 'getEthBalance',
       args: [walletAddress],
     }
+  }
+
+  if (!tokenAddress) {
+    return undefined
   }
 
   return {

--- a/packages/sdk/src/services/tokenBalance.ts
+++ b/packages/sdk/src/services/tokenBalance.ts
@@ -1,136 +1,179 @@
 import type { Address } from 'viem'
-import { erc20Abi, formatEther, formatUnits } from 'viem'
+import { erc20Abi, formatUnits } from 'viem'
 
-import { ETH } from '@/constants/assets.js'
+import {
+  MULTICALL3_ADDRESS,
+  multicall3GetEthBalanceAbi,
+} from '@/constants/multicall.js'
 import type { SupportedChainId } from '@/constants/supportedChains.js'
 import type { ChainManager } from '@/services/ChainManager.js'
 import type { Asset, BalanceFetchOptions, TokenBalance } from '@/types/asset.js'
 
 /**
- * Fetch ETH balance across the requested chains (or all supported chains).
+ * Multicall3 contract entry that reads a single asset's balance for a wallet.
+ * Native assets resolve to Multicall3's `getEthBalance`; ERC-20s to `balanceOf`.
+ */
+type BalanceContract =
+  | {
+      address: Address
+      abi: typeof multicall3GetEthBalanceAbi
+      functionName: 'getEthBalance'
+      args: readonly [Address]
+    }
+  | {
+      address: Address
+      abi: typeof erc20Abi
+      functionName: 'balanceOf'
+      args: readonly [Address]
+    }
+
+/**
+ * Fetch balances for the given assets across the requested chains (or all
+ * supported chains).
+ * @description Issues one Multicall3 round trip per chain: the wallet's native
+ * balance (via Multicall3's `getEthBalance`) and every configured ERC-20
+ * `balanceOf` batch into a single `eth_call`. Total RPCs drop from
+ * `chains × (1 + erc20s)` to `chains`. Chains are queried in parallel and the
+ * returned array preserves the order of `assets`.
+ *
+ * Per-call failures are surfaced via `allowFailure: true`: a failed inner call
+ * (e.g. a revert from a non-token address) omits that asset on that chain,
+ * mirroring how an asset with no configured address is skipped. A transport
+ * failure of the whole multicall still rejects, preserving loud failure.
  * @param chainManager - The chain manager
  * @param walletAddress - The wallet address
+ * @param assets - Assets to fetch balances for
  * @param options - Optional `chainIds` filter (caller-validated)
- * @returns Promise resolving to ETH balance
+ * @returns Promise resolving to one {@link TokenBalance} per asset
  */
-export async function fetchETHBalance(
+export async function fetchBalances(
   chainManager: ChainManager,
   walletAddress: Address,
+  assets: Asset[],
   options?: BalanceFetchOptions,
-): Promise<TokenBalance> {
+): Promise<TokenBalance[]> {
   const targetChains = [
     ...new Set(options?.chainIds ?? chainManager.getSupportedChains()),
   ]
-  const chainBalancePromises = targetChains.map(async (chainId) => {
-    const publicClient = chainManager.getPublicClient(chainId)
-    const balanceRaw = await publicClient.getBalance({
-      address: walletAddress,
-    })
-    return {
-      chainId,
-      balanceRaw,
-      balance: parseFloat(formatEther(balanceRaw)),
-    }
-  })
-  const chainResults = await Promise.all(chainBalancePromises)
-  const totalBalanceRaw = chainResults.reduce(
-    (total, { balanceRaw }) => total + balanceRaw,
-    0n,
+
+  const perChainResults = await Promise.all(
+    targetChains.map((chainId) =>
+      fetchChainBalances(chainManager, walletAddress, assets, chainId),
+    ),
   )
 
-  const chains: TokenBalance['chains'] = {}
-  for (const { chainId, balance, balanceRaw } of chainResults) {
-    chains[chainId] = { balance, balanceRaw }
-  }
+  // Transpose the per-chain raw balances back into one TokenBalance per asset.
+  return assets.map((asset) => {
+    const chains: TokenBalance['chains'] = {}
+    let totalBalanceRaw = 0n
 
-  return {
-    asset: ETH,
-    totalBalance: parseFloat(formatEther(totalBalanceRaw)),
-    totalBalanceRaw,
-    chains,
-  }
+    for (const { chainId, balances } of perChainResults) {
+      const balanceRaw = balances.get(asset)
+      if (balanceRaw === undefined) {
+        continue
+      }
+      chains[chainId] = {
+        balanceRaw,
+        balance: parseFloat(formatUnits(balanceRaw, asset.metadata.decimals)),
+      }
+      totalBalanceRaw += balanceRaw
+    }
+
+    return {
+      asset,
+      totalBalance: parseFloat(
+        formatUnits(totalBalanceRaw, asset.metadata.decimals),
+      ),
+      totalBalanceRaw,
+      chains,
+    }
+  })
 }
 
 /**
- * Fetch total balance for this asset across the requested chains (or all
- * supported chains). Chains where the asset has no configured address are
- * silently skipped, matching the unfiltered behavior.
+ * Fetch every asset's raw balance on a single chain with one Multicall3 call.
+ * @returns The chain id and a map of asset to raw balance for assets that are
+ * configured on this chain and whose inner call succeeded.
  */
-export async function fetchERC20Balance(
+async function fetchChainBalances(
   chainManager: ChainManager,
   walletAddress: Address,
-  asset: Asset,
-  options?: BalanceFetchOptions,
-): Promise<TokenBalance> {
-  const targetChains = [
-    ...new Set(options?.chainIds ?? chainManager.getSupportedChains()),
-  ]
-  const chainsWithToken = targetChains.filter(
-    (chainId) => asset.address[chainId],
-  )
-
-  const chainBalancePromises = chainsWithToken.map(async (chainId) => {
-    const balanceRaw = await fetchBalanceForChain(
+  assets: Asset[],
+  chainId: SupportedChainId,
+): Promise<{ chainId: SupportedChainId; balances: Map<Asset, bigint> }> {
+  // Pair each asset with its multicall entry, dropping assets not on this chain.
+  const entries = assets.flatMap((asset) => {
+    const contract = balanceContract(
+      chainManager,
       asset,
       chainId,
       walletAddress,
-      chainManager,
     )
-    return {
-      chainId,
-      balanceRaw,
-      balance: parseFloat(formatUnits(balanceRaw, asset.metadata.decimals)),
-    }
+    return contract ? [{ asset, contract }] : []
   })
 
-  const chainResults = await Promise.all(chainBalancePromises)
-  const totalBalanceRaw = chainResults.reduce(
-    (total, { balanceRaw }) => total + balanceRaw,
-    0n,
-  )
-
-  const chains: TokenBalance['chains'] = {}
-  for (const { chainId, balance, balanceRaw } of chainResults) {
-    chains[chainId] = { balance, balanceRaw }
-  }
-
-  return {
-    asset,
-    totalBalance: parseFloat(
-      formatUnits(totalBalanceRaw, asset.metadata.decimals),
-    ),
-    totalBalanceRaw,
-    chains,
-  }
-}
-
-/**
- * Fetch balance for this asset on a specific chain
- */
-async function fetchBalanceForChain(
-  asset: Asset,
-  chainId: SupportedChainId,
-  walletAddress: Address,
-  chainManager: ChainManager,
-): Promise<bigint> {
-  const tokenAddress = asset.address[chainId]
-  if (!tokenAddress) {
-    throw new Error(
-      `${asset.metadata.symbol} not supported on chain ${chainId}`,
-    )
+  const balances = new Map<Asset, bigint>()
+  if (entries.length === 0) {
+    return { chainId, balances }
   }
 
   const publicClient = chainManager.getPublicClient(chainId)
+  const results = await publicClient.multicall({
+    allowFailure: true,
+    contracts: entries.map((entry) => entry.contract),
+  })
 
-  // Handle native ETH balance
-  if (asset.type === 'native' || tokenAddress === 'native') {
-    return publicClient.getBalance({ address: walletAddress })
+  results.forEach((result, index) => {
+    if (result.status === 'success') {
+      balances.set(entries[index].asset, result.result as bigint)
+    }
+  })
+
+  return { chainId, balances }
+}
+
+/**
+ * Build the Multicall3 contract entry that reads `asset`'s balance on `chainId`,
+ * or `undefined` when the asset has no configured address on that chain.
+ */
+function balanceContract(
+  chainManager: ChainManager,
+  asset: Asset,
+  chainId: SupportedChainId,
+  walletAddress: Address,
+): BalanceContract | undefined {
+  const tokenAddress = asset.address[chainId]
+  if (!tokenAddress) {
+    return undefined
   }
 
-  return publicClient.readContract({
+  if (asset.type === 'native' || tokenAddress === 'native') {
+    return {
+      address: multicall3Address(chainManager, chainId),
+      abi: multicall3GetEthBalanceAbi,
+      functionName: 'getEthBalance',
+      args: [walletAddress],
+    }
+  }
+
+  return {
     address: tokenAddress,
     abi: erc20Abi,
     functionName: 'balanceOf',
     args: [walletAddress],
-  })
+  }
+}
+
+/**
+ * Resolve the Multicall3 address for a chain, preferring the chain's own
+ * configured deployment and falling back to the canonical address.
+ */
+function multicall3Address(
+  chainManager: ChainManager,
+  chainId: SupportedChainId,
+): Address {
+  return (
+    chainManager.getChain(chainId).contracts?.multicall3?.address ??
+    MULTICALL3_ADDRESS
+  )
 }

--- a/packages/sdk/src/types/asset.ts
+++ b/packages/sdk/src/types/asset.ts
@@ -37,8 +37,8 @@ export interface TokenBalance {
 }
 
 /**
- * Options accepted by the SDK's balance fetch surface (`Wallet.getBalance` and the underlying `fetchETHBalance` / `fetchERC20Balance` helpers).
- * @property chainIds - Subset of supported chain ids to query. When omitted, all supported chains are queried. `Wallet.getBalance` validates this list via `validateChainIds`; the service helpers themselves trust their input.
+ * Options accepted by the SDK's balance fetch surface (`Wallet.getBalance` and the underlying `fetchBalances` helper).
+ * @property chainIds - Subset of supported chain ids to query. When omitted, all supported chains are queried. `Wallet.getBalance` validates this list via `validateChainIds`; the service helper itself trusts its input.
  */
 export interface BalanceFetchOptions {
   chainIds?: readonly SupportedChainId[]

--- a/packages/sdk/src/wallet/core/wallets/abstract/Wallet.ts
+++ b/packages/sdk/src/wallet/core/wallets/abstract/Wallet.ts
@@ -8,9 +8,10 @@ import type {
   ActionModuleDeps,
 } from '@/actions/shared/ActionModule.js'
 import type { WalletSwapNamespace } from '@/actions/swap/namespaces/WalletSwapNamespace.js'
+import { ETH } from '@/constants/assets.js'
 import type { SupportedChainId } from '@/constants/supportedChains.js'
 import type { ChainManager } from '@/services/ChainManager.js'
-import { fetchERC20Balance, fetchETHBalance } from '@/services/tokenBalance.js'
+import { fetchBalances } from '@/services/tokenBalance.js'
 import type {
   ActionModules,
   ActionName,
@@ -120,12 +121,12 @@ export abstract class Wallet {
    */
   async getBalance(options?: BalanceFetchOptions): Promise<TokenBalance[]> {
     validateBalanceFetchOptions(options, this.chainManager)
-    return Promise.all([
-      fetchETHBalance(this.chainManager, this.address, options),
-      ...this.supportedAssets.map((asset) =>
-        fetchERC20Balance(this.chainManager, this.address, asset, options),
-      ),
-    ])
+    return fetchBalances(
+      this.chainManager,
+      this.address,
+      [ETH, ...this.supportedAssets],
+      options,
+    )
   }
 
   /**

--- a/packages/sdk/src/wallet/core/wallets/abstract/__tests__/Wallet.spec.ts
+++ b/packages/sdk/src/wallet/core/wallets/abstract/__tests__/Wallet.spec.ts
@@ -11,13 +11,12 @@ import {
 } from '@/core/error/errors.js'
 import { MockChainManager } from '@/services/__mocks__/MockChainManager.js'
 import type { ChainManager } from '@/services/ChainManager.js'
-import { fetchERC20Balance, fetchETHBalance } from '@/services/tokenBalance.js'
+import { fetchBalances } from '@/services/tokenBalance.js'
 import { TestWallet } from '@/wallet/core/wallets/abstract/__mocks__/TestWallet.js'
 
 vi.mock('@/services/tokenBalance.js', async () => {
   return {
-    fetchETHBalance: vi.fn().mockResolvedValue({} as unknown),
-    fetchERC20Balance: vi.fn().mockResolvedValue({} as unknown),
+    fetchBalances: vi.fn().mockResolvedValue([] as unknown),
   }
 })
 
@@ -33,47 +32,50 @@ describe('Wallet (base)', () => {
     vi.clearAllMocks()
   })
 
-  it('getBalance returns only ETH when no supportedAssets configured', async () => {
+  it('getBalance fetches only ETH when no supportedAssets configured', async () => {
     const wallet = new TestWallet({ chainManager, address, signer })
 
     const result = await wallet.getBalance()
 
     expect(result).toBeTruthy()
-    expect(fetchETHBalance).toHaveBeenCalledTimes(1)
-    expect(fetchETHBalance).toHaveBeenCalledWith(
+    expect(fetchBalances).toHaveBeenCalledTimes(1)
+    expect(fetchBalances).toHaveBeenCalledWith(
       chainManager,
       address,
+      [ETH],
       undefined,
     )
-    // No supportedAssets configured, so no ERC20 balance fetches
-    expect(fetchERC20Balance).toHaveBeenCalledTimes(0)
   })
 
-  it('getBalance fetches ERC20 balances for explicitly configured assets', async () => {
+  it('getBalance fetches ETH plus explicitly configured assets', async () => {
     const wallet = new TestWallet({
       chainManager,
       address,
       signer,
-      supportedAssets: [ETH, USDC],
+      supportedAssets: [USDC],
     })
 
     const result = await wallet.getBalance()
 
     expect(result).toBeTruthy()
-    expect(fetchETHBalance).toHaveBeenCalledTimes(1)
-    // Should call fetchERC20Balance for each configured asset
-    expect(fetchERC20Balance).toHaveBeenCalledTimes(2)
+    expect(fetchBalances).toHaveBeenCalledTimes(1)
+    expect(fetchBalances).toHaveBeenCalledWith(
+      chainManager,
+      address,
+      [ETH, USDC],
+      undefined,
+    )
   })
 
-  it('getBalance propagates errors from underlying fetchers', async () => {
-    vi.mocked(fetchETHBalance).mockRejectedValueOnce(new Error('rpc error'))
+  it('getBalance propagates errors from the underlying fetcher', async () => {
+    vi.mocked(fetchBalances).mockRejectedValueOnce(new Error('rpc error'))
 
     const wallet = new TestWallet({ chainManager, address, signer })
 
     await expect(wallet.getBalance()).rejects.toThrow('rpc error')
   })
 
-  it('getBalance forwards chainIds to fetchers when provided', async () => {
+  it('getBalance forwards chainIds to the fetcher when provided', async () => {
     const multiCm = new MockChainManager({
       supportedChains: [optimism.id, base.id, unichain.id],
     }) as unknown as ChainManager
@@ -81,18 +83,14 @@ describe('Wallet (base)', () => {
       chainManager: multiCm,
       address,
       signer,
-      supportedAssets: [ETH, USDC],
+      supportedAssets: [USDC],
     })
 
     await wallet.getBalance({ chainIds: [base.id] })
 
-    expect(fetchETHBalance).toHaveBeenCalledWith(multiCm, address, {
+    expect(fetchBalances).toHaveBeenCalledWith(multiCm, address, [ETH, USDC], {
       chainIds: [base.id],
     })
-    expect(fetchERC20Balance).toHaveBeenCalledTimes(2)
-    for (const call of vi.mocked(fetchERC20Balance).mock.calls) {
-      expect(call[3]).toEqual({ chainIds: [base.id] })
-    }
   })
 
   it('getBalance throws ChainNotSupportedError for chains outside the manager', async () => {
@@ -101,8 +99,7 @@ describe('Wallet (base)', () => {
     await expect(
       wallet.getBalance({ chainIds: [base.id] }),
     ).rejects.toBeInstanceOf(ChainNotSupportedError)
-    expect(fetchETHBalance).not.toHaveBeenCalled()
-    expect(fetchERC20Balance).not.toHaveBeenCalled()
+    expect(fetchBalances).not.toHaveBeenCalled()
   })
 
   it('getBalance throws InvalidParamsError when chainIds is empty', async () => {
@@ -111,7 +108,7 @@ describe('Wallet (base)', () => {
     await expect(wallet.getBalance({ chainIds: [] })).rejects.toBeInstanceOf(
       InvalidParamsError,
     )
-    expect(fetchETHBalance).not.toHaveBeenCalled()
+    expect(fetchBalances).not.toHaveBeenCalled()
   })
 
   it('has lend namespace available for inheritance', () => {


### PR DESCRIPTION
Closes #452

## Summary

Reorganizes `Wallet.getBalance` from a per-(chain, asset) RPC fan-out to a per-chain Multicall3 batch.

Before: each asset helper (`fetchETHBalance` / `fetchERC20Balance`) iterated across chains, costing `chains × (1 + erc20s)` RPCs. After: one `publicClient.multicall` per chain reads the wallet's native balance (via Multicall3 `getEthBalance`) and every ERC-20 `balanceOf` in a single `eth_call`. Total RPCs drop to `chains` (e.g. 5 chains × 6 assets: **30 → 5**). Cross-chain parallelism is preserved via `Promise.all`.

The public `TokenBalance[]` shape is unchanged — per-chain results are transposed back into per-asset records, and the array preserves asset order.

## Changes

- New `src/constants/multicall.ts`: canonical `MULTICALL3_ADDRESS` + a minimal `getEthBalance` ABI fragment (viem's exported `multicall3Abi` only carries `aggregate3`).
- `src/services/tokenBalance.ts`: replaced the two per-asset helpers with a single `fetchBalances(chainManager, walletAddress, assets, options)` that batches per chain and transposes. The per-chain Multicall3 address is resolved from the chain's own viem config with the canonical address as fallback (the "override hook" from the issue), keeping the `getEthBalance` target consistent with how viem routes the aggregate call.
- `Wallet.getBalance` now makes one `fetchBalances([ETH, ...supportedAssets], …)` call.
- `MockChainManager` gained a `multicall` mock; both affected spec files were rewritten to mock `multicall` / `fetchBalances`.

## Failure handling decision

The issue left open whether a failed inner `balanceOf` should surface or zero. This PR uses `allowFailure: true` and **omits** the (chain, asset) entry on a per-call failure (e.g. a revert from a non-token address), mirroring how an asset with no configured address is already skipped. A transport-level failure of the whole multicall still rejects, preserving the previous loud-failure behavior for real RPC outages.

## Validation

- `pnpm test` (sdk): 666 passed / 10 skipped.
- `pnpm typecheck`, `pnpm build`, `pnpm lint`: clean (0 errors).
- Manual CLI: `actions wallet balance` run against live base-sepolia / op-sepolia RPCs with a throwaway zero-balance key — ETH/USDC_DEMO/OP_DEMO balances fetched through the new Multicall3 path.

## Self-review

Self-review across correctness, performance, testing, and maintainability before marking ready. Fixes applied:

- **P1 (correctness):** the first pass gated native ETH behind the per-chain address map, so native balances on supported chains absent from `ETH.address` (e.g. `celo`, `superseed`) silently vanished — a regression vs. the old unconditional native fan-out. `balanceContract` now resolves native assets to `getEthBalance` regardless of the address map. Added a `celo` regression test.
- **P2 (typescript):** dropped a redundant `result.result as bigint` cast (viem already infers `bigint`; typecheck stays clean without it).
- **Testing gaps:** added tests for transport-level multicall rejection (the documented loud-failure path), partial cross-chain inner-call failure, and the chain-configured Multicall3 address override branch.

Performance reviewer confirmed the efficiency goal is met (one multicall per chain, cross-chain parallelism preserved, zero-asset chains skip the RPC entirely).
