### PR TITLE
Add agent accounts to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default owners
-* @ethereum-optimism/ecosystem
+* @ethereum-optimism/ecosystem @its-everdred @its-applekid
 
 # Infra & security — cloud-security-team approval required
 # (rules below override the catch-all per GitHub last-match-wins semantics)


### PR DESCRIPTION
Adds `@its-everdred` and `@its-applekid` to the default CODEOWNERS owners.

## Why

aiur filters PR/issue comments through the repository's CODEOWNERS file — comments from non-codeowner authors are dropped, so the working agent never sees them. The default owner here is `@ethereum-optimism/ecosystem` (an upstream org team that doesn't include the fork's collaborators), so operator comments from `@its-everdred` on agent PRs were being filtered out and ignored.

Adding both agent-side accounts as default owners lets their PR comments reach the agent subscribed to that ticket.