### PR TITLE
Uniswap provider: support multi-hop swaps (V4 EXACT_IN / EXACT_OUT)

### DIFF
--- a/packages/sdk/src/actions/swap/providers/uniswap/UniswapSwapProvider.ts
+++ b/packages/sdk/src/actions/swap/providers/uniswap/UniswapSwapProvider.ts
@@ -118,6 +118,7 @@ export class UniswapSwapProvider extends SwapProvider<UniswapSwapProviderConfig>
       this.resolveQuoteDefaults(params)
     const amountOutRaw = parseAssetAmount(assetOut, params.amountOut)
 
+    // A configured 2+ hop path takes precedence over a direct pool for this pair.
     const multiHop: MultiHopParams | undefined =
       marketConfig.path && marketConfig.path.length >= 2
         ? buildPath(marketConfig.assets[0], marketConfig.path)
@@ -180,6 +181,8 @@ export class UniswapSwapProvider extends SwapProvider<UniswapSwapProviderConfig>
         routerAddress: addresses.universalRouter,
         value: isNativeAsset(assetIn) ? (amountInRaw ?? 0n) : 0n,
         providerContext: {
+          // For multi-hop routes this reports the first hop's pool params only;
+          // the full per-hop breakdown lives in `route.pools`.
           fee: marketConfig.fee ?? marketConfig.path?.[0]?.fee,
           tickSpacing:
             marketConfig.tickSpacing ?? marketConfig.path?.[0]?.tickSpacing,

--- a/packages/sdk/src/actions/swap/providers/uniswap/UniswapSwapProvider.ts
+++ b/packages/sdk/src/actions/swap/providers/uniswap/UniswapSwapProvider.ts
@@ -7,8 +7,10 @@ import {
   getUniswapAddresses,
 } from '@/actions/swap/providers/uniswap/addresses.js'
 import {
+  buildPath,
   encodeUniversalRouterSwap,
   getQuote,
+  type MultiHopParams,
 } from '@/actions/swap/providers/uniswap/encoding.js'
 import {
   configToMarkets,
@@ -116,6 +118,11 @@ export class UniswapSwapProvider extends SwapProvider<UniswapSwapProviderConfig>
       this.resolveQuoteDefaults(params)
     const amountOutRaw = parseAssetAmount(assetOut, params.amountOut)
 
+    const multiHop: MultiHopParams | undefined =
+      marketConfig.path && marketConfig.path.length >= 2
+        ? buildPath(marketConfig.assets[0], marketConfig.path)
+        : undefined
+
     const quote = await getQuote({
       assetIn,
       assetOut,
@@ -127,6 +134,7 @@ export class UniswapSwapProvider extends SwapProvider<UniswapSwapProviderConfig>
       poolManagerAddress: addresses.poolManager,
       fee: marketConfig.fee,
       tickSpacing: marketConfig.tickSpacing,
+      multiHop,
     })
 
     const swapCalldata = encodeUniversalRouterSwap({
@@ -142,6 +150,7 @@ export class UniswapSwapProvider extends SwapProvider<UniswapSwapProviderConfig>
       universalRouterAddress: addresses.universalRouter,
       fee: marketConfig.fee,
       tickSpacing: marketConfig.tickSpacing,
+      multiHop,
     })
 
     const finalAmountInRaw = amountOutRaw ? quote.amountInRaw : amountInRaw
@@ -171,8 +180,9 @@ export class UniswapSwapProvider extends SwapProvider<UniswapSwapProviderConfig>
         routerAddress: addresses.universalRouter,
         value: isNativeAsset(assetIn) ? (amountInRaw ?? 0n) : 0n,
         providerContext: {
-          fee: marketConfig.fee,
-          tickSpacing: marketConfig.tickSpacing,
+          fee: marketConfig.fee ?? marketConfig.path?.[0]?.fee,
+          tickSpacing:
+            marketConfig.tickSpacing ?? marketConfig.path?.[0]?.tickSpacing,
           permit2Address: addresses.permit2,
         },
       },
@@ -219,21 +229,28 @@ export class UniswapSwapProvider extends SwapProvider<UniswapSwapProviderConfig>
 
   /**
    * Resolve and validate Uniswap market config for a pair.
-   * @throws If pair not in allowlist or missing fee/tickSpacing
+   * A pair must define either a direct pool (`fee` + `tickSpacing`) or a
+   * multi-hop `path` (2+ hops).
+   * @throws If pair not in allowlist or missing both pool params and a path
    */
   private resolveUniswapConfig(
     assetIn: Asset,
     assetOut: Asset,
     chainId: SupportedChainId,
-  ): UniswapMarketConfig & { fee: number; tickSpacing: number } {
+  ): UniswapMarketConfig {
     const config = this.resolveMarketConfig(assetIn, assetOut, chainId) as
       | UniswapMarketConfig
       | undefined
-    if (config?.fee === undefined || config?.tickSpacing === undefined) {
+
+    const hasDirectPool =
+      config?.fee !== undefined && config?.tickSpacing !== undefined
+    const hasPath = (config?.path?.length ?? 0) >= 2
+
+    if (!config || (!hasDirectPool && !hasPath)) {
       throw new AssetMetadataRequiredError(
-        `fee and tickSpacing must be configured for pair ${assetIn.metadata.symbol}/${assetOut.metadata.symbol}`,
+        `fee and tickSpacing (or a multi-hop path) must be configured for pair ${assetIn.metadata.symbol}/${assetOut.metadata.symbol}`,
       )
     }
-    return config as UniswapMarketConfig & { fee: number; tickSpacing: number }
+    return config
   }
 }

--- a/packages/sdk/src/actions/swap/providers/uniswap/__tests__/UniswapSwapProvider.test.ts
+++ b/packages/sdk/src/actions/swap/providers/uniswap/__tests__/UniswapSwapProvider.test.ts
@@ -109,7 +109,7 @@ describe('UniswapSwapProvider', () => {
       expect(result.transactionData.permit2Approval).toBeDefined()
     })
 
-    it('throws without fee/tickSpacing in market filter', async () => {
+    it('throws without fee/tickSpacing or a path in market filter', async () => {
       const provider = createProvider({
         marketAllowlist: [{ assets: [USDC, OP], chainId: CHAIN_ID }],
       })
@@ -123,7 +123,7 @@ describe('UniswapSwapProvider', () => {
           walletAddress:
             '0x4444444444444444444444444444444444444444' as Address,
         }),
-      ).rejects.toThrow('fee and tickSpacing must be configured')
+      ).rejects.toThrow('fee and tickSpacing (or a multi-hop path)')
     })
   })
 

--- a/packages/sdk/src/actions/swap/providers/uniswap/__tests__/UniswapSwapProvider.test.ts
+++ b/packages/sdk/src/actions/swap/providers/uniswap/__tests__/UniswapSwapProvider.test.ts
@@ -1,8 +1,17 @@
-import type { Address, PublicClient } from 'viem'
+import {
+  type Address,
+  decodeAbiParameters,
+  decodeFunctionData,
+  type PublicClient,
+} from 'viem'
 import { baseSepolia } from 'viem/chains'
 import { describe, expect, it, vi } from 'vitest'
 
 import { MockWETHAsset } from '@/__mocks__/MockAssets.js'
+import {
+  EXACT_INPUT_PARAMS,
+  UNIVERSAL_ROUTER_ABI,
+} from '@/actions/swap/providers/uniswap/abis.js'
 import type { UniswapSwapProviderConfig } from '@/actions/swap/providers/uniswap/types.js'
 import { UniswapSwapProvider } from '@/actions/swap/providers/uniswap/UniswapSwapProvider.js'
 import type { SupportedChainId } from '@/constants/supportedChains.js'
@@ -154,6 +163,61 @@ describe('UniswapSwapProvider', () => {
 
       // 1 USDC = 1000000 (6 decimals)
       expect(quote.amountInRaw).toBe(1000000n)
+    })
+
+    it('routes a path-configured pair through multi-hop end-to-end', async () => {
+      const provider = createProvider({
+        marketAllowlist: [
+          {
+            assets: [USDC, OP],
+            chainId: CHAIN_ID,
+            path: [
+              { asset: MockWETHAsset, fee: 500, tickSpacing: 10 },
+              { asset: OP, fee: 3000, tickSpacing: 60 },
+            ],
+          },
+        ],
+      })
+
+      const quote = await provider.getQuote({
+        assetIn: USDC,
+        assetOut: OP,
+        amountIn: 100,
+        chainId: CHAIN_ID,
+      })
+
+      // Route reflects the configured intermediate, not a direct pool.
+      expect(quote.route.path).toEqual([USDC, MockWETHAsset, OP])
+      expect(quote.route.pools).toHaveLength(2)
+
+      // Decoded calldata uses the multi-hop SWAP_EXACT_IN action (0x07).
+      const { args } = decodeFunctionData({
+        abi: UNIVERSAL_ROUTER_ABI,
+        data: quote.execution.swapCalldata,
+      })
+      const [, inputs] = args as readonly [
+        `0x${string}`,
+        ReadonlyArray<`0x${string}`>,
+        bigint,
+      ]
+      const [actions, actionParams] = decodeAbiParameters(
+        [{ type: 'bytes' }, { type: 'bytes[]' }],
+        inputs[0]!,
+      )
+      expect(actions).toBe('0x070c0f')
+
+      const [decoded] = decodeAbiParameters(
+        EXACT_INPUT_PARAMS,
+        (actionParams as ReadonlyArray<`0x${string}`>)[0]!,
+      )
+      const p = decoded as {
+        currencyIn: string
+        path: ReadonlyArray<{ intermediateCurrency: string }>
+      }
+      expect(p.currencyIn.toLowerCase()).toBe(
+        (USDC.address[CHAIN_ID] as string).toLowerCase(),
+      )
+      expect(p.path).toHaveLength(2)
     })
   })
 

--- a/packages/sdk/src/actions/swap/providers/uniswap/__tests__/sdk.test.ts
+++ b/packages/sdk/src/actions/swap/providers/uniswap/__tests__/sdk.test.ts
@@ -45,6 +45,12 @@ const DAI: Asset = {
   metadata: { name: 'Dai Stablecoin', symbol: 'DAI', decimals: 18 },
 }
 
+const OP: Asset = {
+  type: 'erc20',
+  address: { 84532: '0x4444444444444444444444444444444444444444' as Address },
+  metadata: { name: 'Optimism', symbol: 'OP', decimals: 18 },
+}
+
 const QUOTER = '0x4a6513c898fe1b2d0e78d3b0e0a4a151589b1cba' as Address
 const POOL_MANAGER = '0x05E73354cFDd6745C338b50BcFDfA3Aa6fA03408' as Address
 const CHAIN_ID = 84532 as SupportedChainId
@@ -640,6 +646,99 @@ describe('encodeUniversalRouterSwap — multi-hop', () => {
     // Exact-in path output currencies: [ETH→0x0, DAI]
     expect(p.path[0]!.intermediateCurrency).toBe(zeroAddress)
     expect(p.path[1]!.intermediateCurrency.toLowerCase()).toBe(addr(DAI))
+  })
+
+  it('throws when the path endpoints do not match the swap pair', () => {
+    // multiHop routes USDC→…→DAI, but the swap requests USDC→WETH (WETH is an
+    // intermediate, not an endpoint). Encoding must refuse rather than silently
+    // route to the wrong output currency.
+    expect(() =>
+      encodeUniversalRouterSwap({
+        amountInRaw: 100000000n,
+        assetIn: USDC,
+        assetOut: WETH,
+        slippage: 0.01,
+        deadline: 1700000000,
+        recipient: '0xrecipient' as Address,
+        chainId: CHAIN_ID,
+        quote: baseQuote,
+        universalRouterAddress: '0xrouter' as Address,
+        multiHop,
+      }),
+    ).toThrow(/path endpoints/)
+  })
+
+  it('encodes a 3-hop exact-in path with correct per-hop indexing', () => {
+    const threeHop: MultiHopParams = {
+      assets: [USDC, WETH, DAI, OP],
+      pools: [
+        { fee: 500, tickSpacing: 10 },
+        { fee: 3000, tickSpacing: 60 },
+        { fee: 100, tickSpacing: 1 },
+      ],
+    }
+
+    const calldata = encodeUniversalRouterSwap({
+      amountInRaw: 100000000n,
+      assetIn: USDC,
+      assetOut: OP,
+      slippage: 0.01,
+      deadline: 1700000000,
+      recipient: '0xrecipient' as Address,
+      chainId: CHAIN_ID,
+      quote: { ...baseQuote, route: { path: [USDC, OP], pools: [] } },
+      universalRouterAddress: '0xrouter' as Address,
+      multiHop: threeHop,
+    })
+
+    const { actions, params } = decodeV4Swap(calldata)
+    expect(actions).toBe('0x070c0f')
+
+    const [decoded] = decodeAbiParameters(EXACT_INPUT_PARAMS, params[0]!)
+    const p = decoded as {
+      currencyIn: string
+      path: ReadonlyArray<{ intermediateCurrency: string; fee: number }>
+    }
+    expect(p.currencyIn.toLowerCase()).toBe(addr(USDC))
+    // Exact-in lists each hop's output; final hop's output is OP.
+    expect(p.path.map((h) => h.intermediateCurrency.toLowerCase())).toEqual([
+      addr(WETH),
+      addr(DAI),
+      addr(OP),
+    ])
+    expect(p.path.map((h) => h.fee)).toEqual([500, 3000, 100])
+  })
+
+  it('encodes exact-out in the reverse direction (0x09, input-currency path)', () => {
+    const calldata = encodeUniversalRouterSwap({
+      amountOutRaw: 50000000n,
+      assetIn: DAI, // reverse of configured USDC → … → DAI
+      assetOut: USDC,
+      slippage: 0.01,
+      deadline: 1700000000,
+      recipient: '0xrecipient' as Address,
+      chainId: CHAIN_ID,
+      quote: { ...baseQuote, route: { path: [DAI, USDC], pools: [] } },
+      universalRouterAddress: '0xrouter' as Address,
+      multiHop,
+    })
+
+    const { actions, params } = decodeV4Swap(calldata)
+    expect(actions).toBe('0x090c0f')
+
+    const [decoded] = decodeAbiParameters(EXACT_OUTPUT_PARAMS, params[0]!)
+    const p = decoded as {
+      currencyOut: string
+      path: ReadonlyArray<{ intermediateCurrency: string; fee: number }>
+    }
+    // Reversed chain [DAI, WETH, USDC]; exact-out lists hop INPUT currencies
+    // [DAI, WETH] with reversed pool fees [3000, 500]; currencyOut = USDC.
+    expect(p.currencyOut.toLowerCase()).toBe(addr(USDC))
+    expect(p.path.map((h) => h.intermediateCurrency.toLowerCase())).toEqual([
+      addr(DAI),
+      addr(WETH),
+    ])
+    expect(p.path.map((h) => h.fee)).toEqual([3000, 500])
   })
 })
 

--- a/packages/sdk/src/actions/swap/providers/uniswap/__tests__/sdk.test.ts
+++ b/packages/sdk/src/actions/swap/providers/uniswap/__tests__/sdk.test.ts
@@ -7,11 +7,16 @@ import {
 } from 'viem'
 import { describe, expect, it, vi } from 'vitest'
 
-import { UNIVERSAL_ROUTER_ABI } from '@/actions/swap/providers/uniswap/abis.js'
+import {
+  EXACT_INPUT_PARAMS,
+  EXACT_OUTPUT_PARAMS,
+  UNIVERSAL_ROUTER_ABI,
+} from '@/actions/swap/providers/uniswap/abis.js'
 import {
   calculatePriceImpact,
   encodeUniversalRouterSwap,
   getQuote,
+  type MultiHopParams,
 } from '@/actions/swap/providers/uniswap/encoding.js'
 import type { SupportedChainId } from '@/constants/supportedChains.js'
 import type { Asset } from '@/types/asset.js'
@@ -32,6 +37,12 @@ const ETH: Asset = {
   type: 'native',
   address: { 84532: 'native' },
   metadata: { name: 'Ethereum', symbol: 'ETH', decimals: 18 },
+}
+
+const DAI: Asset = {
+  type: 'erc20',
+  address: { 84532: '0x3333333333333333333333333333333333333333' as Address },
+  metadata: { name: 'Dai Stablecoin', symbol: 'DAI', decimals: 18 },
 }
 
 const QUOTER = '0x4a6513c898fe1b2d0e78d3b0e0a4a151589b1cba' as Address
@@ -427,5 +438,337 @@ describe('encodeUniversalRouterSwap', () => {
 
     // Different slippage should produce different calldata
     expect(noSlippage).not.toBe(withSlippage)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Multi-hop (V4 path-based SWAP_EXACT_IN 0x07 / SWAP_EXACT_OUT 0x09)
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Decode the (actions, params[]) tuple from a V4_SWAP execute() calldata.
+function decodeV4Swap(calldata: `0x${string}`): {
+  actions: `0x${string}`
+  params: ReadonlyArray<`0x${string}`>
+} {
+  const { args } = decodeFunctionData({
+    abi: UNIVERSAL_ROUTER_ABI,
+    data: calldata,
+  })
+  const [, inputs] = args as readonly [
+    `0x${string}`,
+    ReadonlyArray<`0x${string}`>,
+    bigint,
+  ]
+  const [actions, params] = decodeAbiParameters(
+    [{ type: 'bytes' }, { type: 'bytes[]' }],
+    inputs[0]!,
+  )
+  return {
+    actions: actions as `0x${string}`,
+    params: params as ReadonlyArray<`0x${string}`>,
+  }
+}
+
+const addr = (asset: Asset): string =>
+  (asset.address[84532] as string).toLowerCase()
+
+describe('encodeUniversalRouterSwap — multi-hop', () => {
+  // Configured forward route USDC → WETH → DAI.
+  const multiHop: MultiHopParams = {
+    assets: [USDC, WETH, DAI],
+    pools: [
+      { fee: 500, tickSpacing: 10 },
+      { fee: 3000, tickSpacing: 60 },
+    ],
+  }
+
+  const baseQuote = {
+    price: '1',
+    priceInverse: '1',
+    amountIn: 100,
+    amountOut: 99,
+    amountInRaw: 100000000n,
+    amountOutRaw: 99000000000000000000n,
+    priceImpact: 0,
+    route: { path: [USDC, DAI], pools: [] },
+    gasEstimate: 200000n,
+  }
+
+  it('encodes exact-in as SWAP_EXACT_IN (0x07) with forward PathKeys', () => {
+    const calldata = encodeUniversalRouterSwap({
+      amountInRaw: 100000000n,
+      assetIn: USDC,
+      assetOut: DAI,
+      slippage: 0.01,
+      deadline: 1700000000,
+      recipient: '0xrecipient' as Address,
+      chainId: CHAIN_ID,
+      quote: baseQuote,
+      universalRouterAddress: '0xrouter' as Address,
+      multiHop,
+    })
+
+    const { actions, params } = decodeV4Swap(calldata)
+    expect(actions).toBe('0x070c0f')
+
+    const [decoded] = decodeAbiParameters(EXACT_INPUT_PARAMS, params[0]!)
+    const p = decoded as {
+      currencyIn: string
+      path: ReadonlyArray<{
+        intermediateCurrency: string
+        fee: number
+        tickSpacing: number
+      }>
+      amountIn: bigint
+      amountOutMinimum: bigint
+    }
+
+    expect(p.currencyIn.toLowerCase()).toBe(addr(USDC))
+    expect(p.amountIn).toBe(100000000n)
+    // Exact-in path lists each hop's OUTPUT currency, fees aligned to pools.
+    expect(p.path.map((h) => h.intermediateCurrency.toLowerCase())).toEqual([
+      addr(WETH),
+      addr(DAI),
+    ])
+    expect(p.path.map((h) => h.fee)).toEqual([500, 3000])
+    expect(p.path.map((h) => h.tickSpacing)).toEqual([10, 60])
+    // amountOutMinimum = 99e18 * (1 - 0.01)
+    expect(p.amountOutMinimum).toBe((99000000000000000000n * 9900n) / 10000n)
+  })
+
+  it('encodes exact-out as SWAP_EXACT_OUT (0x09) with reversed PathKey currencies', () => {
+    const calldata = encodeUniversalRouterSwap({
+      amountOutRaw: 99000000000000000000n,
+      assetIn: USDC,
+      assetOut: DAI,
+      slippage: 0.01,
+      deadline: 1700000000,
+      recipient: '0xrecipient' as Address,
+      chainId: CHAIN_ID,
+      quote: baseQuote,
+      universalRouterAddress: '0xrouter' as Address,
+      multiHop,
+    })
+
+    const { actions, params } = decodeV4Swap(calldata)
+    expect(actions).toBe('0x090c0f')
+
+    const [decoded] = decodeAbiParameters(EXACT_OUTPUT_PARAMS, params[0]!)
+    const p = decoded as {
+      currencyOut: string
+      path: ReadonlyArray<{
+        intermediateCurrency: string
+        fee: number
+        tickSpacing: number
+      }>
+      amountOut: bigint
+      amountInMaximum: bigint
+    }
+
+    expect(p.currencyOut.toLowerCase()).toBe(addr(DAI))
+    expect(p.amountOut).toBe(99000000000000000000n)
+    // Exact-out path lists each hop's INPUT currency (V4 walks it backward):
+    // chain [USDC, WETH, DAI] → path intermediates [USDC, WETH], fees pool-aligned.
+    expect(p.path.map((h) => h.intermediateCurrency.toLowerCase())).toEqual([
+      addr(USDC),
+      addr(WETH),
+    ])
+    expect(p.path.map((h) => h.fee)).toEqual([500, 3000])
+    // amountInMaximum = 100e6 * (1 + 0.01)
+    expect(p.amountInMaximum).toBe(100000000n + (100000000n * 100n) / 10000n)
+  })
+
+  it('reverses the configured path for the opposite swap direction', () => {
+    const calldata = encodeUniversalRouterSwap({
+      amountInRaw: 99000000000000000000n,
+      assetIn: DAI, // reverse of configured USDC → ... → DAI
+      assetOut: USDC,
+      slippage: 0.01,
+      deadline: 1700000000,
+      recipient: '0xrecipient' as Address,
+      chainId: CHAIN_ID,
+      quote: { ...baseQuote, route: { path: [DAI, USDC], pools: [] } },
+      universalRouterAddress: '0xrouter' as Address,
+      multiHop,
+    })
+
+    const { actions, params } = decodeV4Swap(calldata)
+    expect(actions).toBe('0x070c0f')
+
+    const [decoded] = decodeAbiParameters(EXACT_INPUT_PARAMS, params[0]!)
+    const p = decoded as {
+      currencyIn: string
+      path: ReadonlyArray<{ intermediateCurrency: string; fee: number }>
+    }
+
+    expect(p.currencyIn.toLowerCase()).toBe(addr(DAI))
+    // Reversed chain [DAI, WETH, USDC], reversed pools [3000, 500].
+    expect(p.path.map((h) => h.intermediateCurrency.toLowerCase())).toEqual([
+      addr(WETH),
+      addr(USDC),
+    ])
+    expect(p.path.map((h) => h.fee)).toEqual([3000, 500])
+  })
+
+  it('encodes native ETH intermediates as address(0)', () => {
+    const ethMultiHop: MultiHopParams = {
+      assets: [USDC, ETH, DAI],
+      pools: [
+        { fee: 500, tickSpacing: 10 },
+        { fee: 3000, tickSpacing: 60 },
+      ],
+    }
+
+    const calldata = encodeUniversalRouterSwap({
+      amountInRaw: 100000000n,
+      assetIn: USDC,
+      assetOut: DAI,
+      slippage: 0.01,
+      deadline: 1700000000,
+      recipient: '0xrecipient' as Address,
+      chainId: CHAIN_ID,
+      quote: baseQuote,
+      universalRouterAddress: '0xrouter' as Address,
+      multiHop: ethMultiHop,
+    })
+
+    const { params } = decodeV4Swap(calldata)
+    const [decoded] = decodeAbiParameters(EXACT_INPUT_PARAMS, params[0]!)
+    const p = decoded as {
+      path: ReadonlyArray<{ intermediateCurrency: string }>
+    }
+    // Exact-in path output currencies: [ETH→0x0, DAI]
+    expect(p.path[0]!.intermediateCurrency).toBe(zeroAddress)
+    expect(p.path[1]!.intermediateCurrency.toLowerCase()).toBe(addr(DAI))
+  })
+})
+
+describe('getQuote — multi-hop dispatch', () => {
+  const multiHop: MultiHopParams = {
+    assets: [USDC, WETH, DAI],
+    pools: [
+      { fee: 500, tickSpacing: 10 },
+      { fee: 3000, tickSpacing: 60 },
+    ],
+  }
+
+  it('calls quoteExactInput with a forward PathKey[] for exact-in', async () => {
+    const publicClient = createMockPublicClient(99000000000000000000n)
+    const quote = await getQuote({
+      assetIn: USDC,
+      assetOut: DAI,
+      amountInRaw: 100000000n,
+      chainId: CHAIN_ID,
+      publicClient,
+      quoterAddress: QUOTER,
+      poolManagerAddress: POOL_MANAGER,
+      multiHop,
+    })
+
+    expect(publicClient.simulateContract).toHaveBeenCalledWith(
+      expect.objectContaining({ functionName: 'quoteExactInput' }),
+    )
+    // Multi-hop must not read a single-pool mid-price.
+    expect(publicClient.readContract).not.toHaveBeenCalled()
+
+    const call = vi.mocked(publicClient.simulateContract).mock.calls[0][0]
+    const args = (call as any).args[0]
+    expect(args.exactCurrency.toLowerCase()).toBe(addr(USDC))
+    expect(
+      args.path.map((h: { intermediateCurrency: string }) =>
+        h.intermediateCurrency.toLowerCase(),
+      ),
+    ).toEqual([addr(WETH), addr(DAI)])
+
+    expect(quote.amountInRaw).toBe(100000000n)
+    expect(quote.amountOutRaw).toBe(99000000000000000000n)
+    expect(quote.priceImpact).toBe(0)
+    expect(quote.route.path).toEqual([USDC, WETH, DAI])
+    expect(quote.route.pools).toHaveLength(2)
+  })
+
+  it('calls quoteExactOutput with the output currency for exact-out', async () => {
+    const publicClient = createMockPublicClient(100000000n)
+    const quote = await getQuote({
+      assetIn: USDC,
+      assetOut: DAI,
+      amountOutRaw: 99000000000000000000n,
+      chainId: CHAIN_ID,
+      publicClient,
+      quoterAddress: QUOTER,
+      poolManagerAddress: POOL_MANAGER,
+      multiHop,
+    })
+
+    expect(publicClient.simulateContract).toHaveBeenCalledWith(
+      expect.objectContaining({ functionName: 'quoteExactOutput' }),
+    )
+
+    const call = vi.mocked(publicClient.simulateContract).mock.calls[0][0]
+    const args = (call as any).args[0]
+    expect(args.exactCurrency.toLowerCase()).toBe(addr(DAI))
+    // Exact-out path lists hop INPUT currencies.
+    expect(
+      args.path.map((h: { intermediateCurrency: string }) =>
+        h.intermediateCurrency.toLowerCase(),
+      ),
+    ).toEqual([addr(USDC), addr(WETH)])
+
+    expect(quote.amountInRaw).toBe(100000000n)
+    expect(quote.amountOutRaw).toBe(99000000000000000000n)
+  })
+})
+
+describe('encodeUniversalRouterSwap — single-hop byte parity', () => {
+  const baseQuote = {
+    price: '0.005',
+    priceInverse: '200',
+    amountIn: 100,
+    amountOut: 0.5,
+    amountInRaw: 100000000n,
+    amountOutRaw: 500000000000000000n,
+    priceImpact: 0.001,
+    route: { path: [USDC, WETH], pools: [] },
+    gasEstimate: 150000n,
+  }
+
+  // Regression: single-hop calldata must remain byte-identical after the
+  // multi-hop refactor. Pinned values captured from the pre-refactor encoder.
+  it('exact-in single-hop calldata is unchanged', () => {
+    const calldata = encodeUniversalRouterSwap({
+      amountInRaw: 100000000n,
+      assetIn: USDC,
+      assetOut: WETH,
+      slippage: 0.005,
+      deadline: 1700000000,
+      recipient: '0xrecipient' as Address,
+      chainId: CHAIN_ID,
+      quote: baseQuote,
+      universalRouterAddress: '0xrouter' as Address,
+      fee: FEE,
+      tickSpacing: TICK_SPACING,
+    })
+    expect(calldata).toMatchInlineSnapshot(
+      `"0x3593564c000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000006553f10000000000000000000000000000000000000000000000000000000000000000011000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000340000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000003060c0f00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000001e00000000000000000000000000000000000000000000000000000000000000240000000000000000000000000000000000000000000000000000000000000016000000000000000000000000000000000000000000000000000000000000000200000000000000000000000001111111111111111111111111111111111111111000000000000000000000000222222222222222222222222222222222222222200000000000000000000000000000000000000000000000000000000000000640000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000005f5e10000000000000000000000000000000000000000000000000006e7799d37c1c00000000000000000000000000000000000000000000000000000000000000001200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000011111111111111111111111111111111111111110000000000000000000000000000000000000000000000000000000005f5e1000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000222222222222222222222222222222222222222200000000000000000000000000000000000000000000000006e7799d37c1c000"`,
+    )
+  })
+
+  it('exact-out single-hop calldata is unchanged', () => {
+    const calldata = encodeUniversalRouterSwap({
+      amountOutRaw: 500000000000000000n,
+      assetIn: USDC,
+      assetOut: WETH,
+      slippage: 0.005,
+      deadline: 1700000000,
+      recipient: '0xrecipient' as Address,
+      chainId: CHAIN_ID,
+      quote: baseQuote,
+      universalRouterAddress: '0xrouter' as Address,
+      fee: FEE,
+      tickSpacing: TICK_SPACING,
+    })
+    expect(calldata).toMatchInlineSnapshot(
+      `"0x3593564c000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000006553f10000000000000000000000000000000000000000000000000000000000000000011000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000340000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000003080c0f00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000001e000000000000000000000000000000000000000000000000000000000000002400000000000000000000000000000000000000000000000000000000000000160000000000000000000000000000000000000000000000000000000000000002000000000000000000000000011111111111111111111111111111111111111110000000000000000000000002222222222222222222222222222222222222222000000000000000000000000000000000000000000000000000000000000006400000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000006f05b59d3b200000000000000000000000000000000000000000000000000000000000005fd822000000000000000000000000000000000000000000000000000000000000001200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000011111111111111111111111111111111111111110000000000000000000000000000000000000000000000000000000005fd82200000000000000000000000000000000000000000000000000000000000000040000000000000000000000000222222222222222222222222222222222222222200000000000000000000000000000000000000000000000006f05b59d3b20000"`,
+    )
   })
 })

--- a/packages/sdk/src/actions/swap/providers/uniswap/abis.ts
+++ b/packages/sdk/src/actions/swap/providers/uniswap/abis.ts
@@ -10,6 +10,18 @@ const POOL_KEY_COMPONENTS = [
 ] as const
 
 /**
+ * PathKey tuple components for multi-hop V4 routes.
+ * @see https://github.com/Uniswap/v4-periphery/blob/main/src/libraries/PathKey.sol
+ */
+export const PATH_KEY_COMPONENTS = [
+  { name: 'intermediateCurrency', type: 'address' },
+  { name: 'fee', type: 'uint24' },
+  { name: 'tickSpacing', type: 'int24' },
+  { name: 'hooks', type: 'address' },
+  { name: 'hookData', type: 'bytes' },
+] as const
+
+/**
  * V4 Quoter ABI (subset for quoting)
  * @see https://docs.uniswap.org/contracts/v4/reference/periphery/interfaces/IQuoter
  */
@@ -48,6 +60,46 @@ export const QUOTER_ABI = [
           { name: 'zeroForOne', type: 'bool' },
           { name: 'exactAmount', type: 'uint128' },
           { name: 'hookData', type: 'bytes' },
+        ],
+      },
+    ],
+    outputs: [
+      { name: 'amountIn', type: 'uint256' },
+      { name: 'gasEstimate', type: 'uint256' },
+    ],
+  },
+  {
+    name: 'quoteExactInput',
+    type: 'function',
+    stateMutability: 'nonpayable',
+    inputs: [
+      {
+        name: 'params',
+        type: 'tuple',
+        components: [
+          { name: 'exactCurrency', type: 'address' },
+          { name: 'path', type: 'tuple[]', components: PATH_KEY_COMPONENTS },
+          { name: 'exactAmount', type: 'uint128' },
+        ],
+      },
+    ],
+    outputs: [
+      { name: 'amountOut', type: 'uint256' },
+      { name: 'gasEstimate', type: 'uint256' },
+    ],
+  },
+  {
+    name: 'quoteExactOutput',
+    type: 'function',
+    stateMutability: 'nonpayable',
+    inputs: [
+      {
+        name: 'params',
+        type: 'tuple',
+        components: [
+          { name: 'exactCurrency', type: 'address' },
+          { name: 'path', type: 'tuple[]', components: PATH_KEY_COMPONENTS },
+          { name: 'exactAmount', type: 'uint128' },
         ],
       },
     ],
@@ -108,6 +160,37 @@ export const EXACT_OUTPUT_SINGLE_PARAMS = [
       { name: 'amountOut', type: 'uint128' },
       { name: 'amountInMaximum', type: 'uint128' },
       { name: 'hookData', type: 'bytes' },
+    ],
+  },
+] as const
+
+/**
+ * ABI type for ExactInputParams (multi-hop, exact in).
+ * Matches the deployed V4Router shape used by this repo's single-hop encoding
+ * (no `minHopPriceX36` — that field exists only in newer v4-periphery).
+ * @see https://docs.uniswap.org/contracts/v4/reference/periphery/interfaces/IV4Router
+ */
+export const EXACT_INPUT_PARAMS = [
+  {
+    type: 'tuple',
+    components: [
+      { name: 'currencyIn', type: 'address' },
+      { name: 'path', type: 'tuple[]', components: [...PATH_KEY_COMPONENTS] },
+      { name: 'amountIn', type: 'uint128' },
+      { name: 'amountOutMinimum', type: 'uint128' },
+    ],
+  },
+] as const
+
+/** ABI type for ExactOutputParams (multi-hop, exact out) */
+export const EXACT_OUTPUT_PARAMS = [
+  {
+    type: 'tuple',
+    components: [
+      { name: 'currencyOut', type: 'address' },
+      { name: 'path', type: 'tuple[]', components: [...PATH_KEY_COMPONENTS] },
+      { name: 'amountOut', type: 'uint128' },
+      { name: 'amountInMaximum', type: 'uint128' },
     ],
   },
 ] as const

--- a/packages/sdk/src/actions/swap/providers/uniswap/encoding.ts
+++ b/packages/sdk/src/actions/swap/providers/uniswap/encoding.ts
@@ -35,6 +35,9 @@ import { getAssetAddress, isNativeAsset } from '@/utils/assets.js'
  */
 const NATIVE_CURRENCY = zeroAddress
 
+/** V4 pools/hops with no attached hook contract use address(0) for `hooks`. */
+const ZERO_HOOKS = zeroAddress
+
 /**
  * Resolve an asset to its V4 currency address (native ETH → address(0)).
  */
@@ -70,13 +73,8 @@ function resolvePoolParams(
   fee: number,
   tickSpacing: number,
 ): ResolvedPoolParams {
-  const tokenIn = isNativeAsset(assetIn)
-    ? NATIVE_CURRENCY
-    : getAssetAddress(assetIn, chainId)
-
-  const tokenOut = isNativeAsset(assetOut)
-    ? NATIVE_CURRENCY
-    : getAssetAddress(assetOut, chainId)
+  const tokenIn = getAssetCurrency(assetIn, chainId)
+  const tokenOut = getAssetCurrency(assetOut, chainId)
 
   // V4 requires sorted tokens: currency0 < currency1
   const [currency0, currency1] =
@@ -90,7 +88,7 @@ function resolvePoolParams(
     currency1,
     fee,
     tickSpacing,
-    hooks: '0x0000000000000000000000000000000000000000' as Address,
+    hooks: ZERO_HOOKS,
   }
 
   return { tokenIn, tokenOut, zeroForOne, poolKey }
@@ -120,6 +118,8 @@ interface ResolvedPathParams {
   currencyIn: Address
   currencyOut: Address
   path: PathKey[]
+  /** Asset chain oriented to the swap direction (in → out), for route display. */
+  routeAssets: Asset[]
 }
 
 /**
@@ -150,14 +150,32 @@ export function buildPath(
  */
 function resolvePathParams(
   assetIn: Asset,
+  assetOut: Asset,
   chainId: SupportedChainId,
   multiHop: MultiHopParams,
   isExactInput: boolean,
 ): ResolvedPathParams {
   // Orient the configured forward route to the actual swap direction (in → out).
   const inCurrency = getAssetCurrency(assetIn, chainId).toLowerCase()
-  const forward =
-    getAssetCurrency(multiHop.assets[0], chainId).toLowerCase() === inCurrency
+  const outCurrency = getAssetCurrency(assetOut, chainId).toLowerCase()
+  const origin = getAssetCurrency(multiHop.assets[0], chainId).toLowerCase()
+  const destination = getAssetCurrency(
+    multiHop.assets[multiHop.assets.length - 1],
+    chainId,
+  ).toLowerCase()
+
+  // The configured path must connect exactly the requested pair. Without this
+  // guard a pair-match on a wider config (e.g. an intermediate asset) would
+  // silently encode a swap to the wrong currency — a wrong byte here bare-reverts
+  // on-chain or delivers the wrong token.
+  const forward = inCurrency === origin && outCurrency === destination
+  const reverse = inCurrency === destination && outCurrency === origin
+  if (!forward && !reverse) {
+    throw new Error(
+      `multi-hop path endpoints (${origin} → ${destination}) do not match swap pair (${inCurrency} → ${outCurrency})`,
+    )
+  }
+
   const assets = forward ? multiHop.assets : [...multiHop.assets].reverse()
   const pools = forward ? multiHop.pools : [...multiHop.pools].reverse()
 
@@ -170,7 +188,7 @@ function resolvePathParams(
     intermediateCurrency: isExactInput ? currencies[i + 1] : currencies[i],
     fee: pool.fee,
     tickSpacing: pool.tickSpacing,
-    hooks: NATIVE_CURRENCY,
+    hooks: ZERO_HOOKS,
     hookData: '0x',
   }))
 
@@ -178,6 +196,7 @@ function resolvePathParams(
     currencyIn: currencies[0],
     currencyOut: currencies[n],
     path,
+    routeAssets: assets,
   }
 }
 
@@ -194,7 +213,11 @@ export interface GetQuoteParams {
   fee?: number
   /** Tick spacing for the pool. Required for single-hop swaps. */
   tickSpacing?: number
-  /** Multi-hop route. When set, overrides `fee`/`tickSpacing` single-hop quoting. */
+  /**
+   * Multi-hop route. When set, overrides `fee`/`tickSpacing` single-hop quoting.
+   * Note: multi-hop quotes report `priceImpact: 0` in v1 — a single mid-price
+   * across multiple pools is not derived. Use per-pool data in `route.pools`.
+   */
   multiHop?: MultiHopParams
 }
 
@@ -320,6 +343,7 @@ async function quoteMultiHop(
 ): Promise<QuoteAmounts> {
   const {
     assetIn,
+    assetOut,
     amountInRaw,
     amountOutRaw,
     chainId,
@@ -327,8 +351,9 @@ async function quoteMultiHop(
     quoterAddress,
   } = params
 
-  const { currencyIn, currencyOut, path } = resolvePathParams(
+  const { currencyIn, currencyOut, path, routeAssets } = resolvePathParams(
     assetIn,
+    assetOut,
     chainId,
     multiHop,
     isExactInput,
@@ -368,9 +393,7 @@ async function quoteMultiHop(
   const amountIn = isExactInput ? amountInRaw! : quoteResult.result[0]
   const amountOut = isExactInput ? quoteResult.result[0] : amountOutRaw!
 
-  // Orient the asset chain to the swap direction for the route's display path.
-  const forward = getAssetCurrency(multiHop.assets[0], chainId) === currencyIn
-  const routeAssets = forward ? multiHop.assets : [...multiHop.assets].reverse()
+  // routeAssets is already oriented to the swap direction by resolvePathParams.
   const pools: SwapMarketInfo[] = path.map((hop, i) => ({
     // Mirror single-hop's "input currency as address" choice for each hop.
     address: getAssetCurrency(routeAssets[i], chainId),
@@ -542,10 +565,11 @@ function encodeMultiHopActions(
   isExactInput: boolean,
   { minAmountOut, maxAmountIn }: SlippageBounds,
 ): EncodedActions {
-  const { amountInRaw, assetIn, chainId, quote } = params
+  const { amountInRaw, assetIn, assetOut, chainId, quote } = params
 
   const { currencyIn, currencyOut, path } = resolvePathParams(
     assetIn,
+    assetOut,
     chainId,
     multiHop,
     isExactInput,

--- a/packages/sdk/src/actions/swap/providers/uniswap/encoding.ts
+++ b/packages/sdk/src/actions/swap/providers/uniswap/encoding.ts
@@ -9,16 +9,23 @@ import {
 
 import {
   CURRENCY_AMOUNT_PARAMS,
+  EXACT_INPUT_PARAMS,
   EXACT_INPUT_SINGLE_PARAMS,
+  EXACT_OUTPUT_PARAMS,
   EXACT_OUTPUT_SINGLE_PARAMS,
   EXTSLOAD_ABI,
   POOL_KEY_ABI_TYPE,
   QUOTER_ABI,
   UNIVERSAL_ROUTER_ABI,
 } from '@/actions/swap/providers/uniswap/abis.js'
+import type { UniswapPathHop } from '@/actions/swap/providers/uniswap/types.js'
 import type { SupportedChainId } from '@/constants/supportedChains.js'
 import type { Asset } from '@/types/asset.js'
-import type { SwapPrice, SwapRoute } from '@/types/swap/index.js'
+import type {
+  SwapMarketInfo,
+  SwapPrice,
+  SwapRoute,
+} from '@/types/swap/index.js'
 import { getAssetAddress, isNativeAsset } from '@/utils/assets.js'
 
 /**
@@ -27,6 +34,15 @@ import { getAssetAddress, isNativeAsset } from '@/utils/assets.js'
  * @see https://github.com/Uniswap/v4-core/blob/main/src/types/Currency.sol
  */
 const NATIVE_CURRENCY = zeroAddress
+
+/**
+ * Resolve an asset to its V4 currency address (native ETH → address(0)).
+ */
+function getAssetCurrency(asset: Asset, chainId: SupportedChainId): Address {
+  return isNativeAsset(asset)
+    ? NATIVE_CURRENCY
+    : getAssetAddress(asset, chainId)
+}
 
 /**
  * Resolved V4 pool parameters
@@ -80,6 +96,91 @@ function resolvePoolParams(
   return { tokenIn, tokenOut, zeroForOne, poolKey }
 }
 
+/**
+ * A configured multi-hop route, oriented forward from `assets[0]` to the last asset.
+ * `pools[i]` is the V4 pool connecting `assets[i]` and `assets[i + 1]`.
+ */
+export interface MultiHopParams {
+  /** Full forward asset chain: `[origin, ...intermediates, destination]`. */
+  assets: Asset[]
+  /** Per-segment pool params; length === `assets.length - 1`. */
+  pools: Array<{ fee: number; tickSpacing: number }>
+}
+
+/** A single V4 PathKey, ready for ABI encoding. */
+interface PathKey {
+  intermediateCurrency: Address
+  fee: number
+  tickSpacing: number
+  hooks: Address
+  hookData: Hex
+}
+
+interface ResolvedPathParams {
+  currencyIn: Address
+  currencyOut: Address
+  path: PathKey[]
+}
+
+/**
+ * Build a hooks-free multi-hop route config from per-hop config entries.
+ * `origin` is the path's starting asset (`config.assets[0]`); `hops` are the
+ * output-first segments from {@link UniswapPathHop}.
+ */
+export function buildPath(
+  origin: Asset,
+  hops: UniswapPathHop[],
+): MultiHopParams {
+  return {
+    assets: [origin, ...hops.map((h) => h.asset)],
+    pools: hops.map((h) => ({ fee: h.fee, tickSpacing: h.tickSpacing })),
+  }
+}
+
+/**
+ * Resolve a configured forward route into V4 PathKeys oriented for the actual
+ * swap direction and amount kind.
+ *
+ * V4 consumes the path differently per amount kind: exact-input iterates the
+ * path forward (each `intermediateCurrency` is a hop's **output**), while
+ * exact-output iterates it backward (each `intermediateCurrency` is a hop's
+ * **input**). The fee/tickSpacing stay positionally aligned with the pools in
+ * both cases.
+ * @see https://github.com/Uniswap/v4-periphery/blob/main/src/libraries/PathKey.sol
+ */
+function resolvePathParams(
+  assetIn: Asset,
+  chainId: SupportedChainId,
+  multiHop: MultiHopParams,
+  isExactInput: boolean,
+): ResolvedPathParams {
+  // Orient the configured forward route to the actual swap direction (in → out).
+  const inCurrency = getAssetCurrency(assetIn, chainId).toLowerCase()
+  const forward =
+    getAssetCurrency(multiHop.assets[0], chainId).toLowerCase() === inCurrency
+  const assets = forward ? multiHop.assets : [...multiHop.assets].reverse()
+  const pools = forward ? multiHop.pools : [...multiHop.pools].reverse()
+
+  // currencies[i] = currency at chain position i; pools[i] connects i and i+1.
+  const currencies = assets.map((a) => getAssetCurrency(a, chainId))
+  const n = pools.length
+
+  const path: PathKey[] = pools.map((pool, i) => ({
+    // exact-in lists the hop's output (C[i+1]); exact-out lists its input (C[i]).
+    intermediateCurrency: isExactInput ? currencies[i + 1] : currencies[i],
+    fee: pool.fee,
+    tickSpacing: pool.tickSpacing,
+    hooks: NATIVE_CURRENCY,
+    hookData: '0x',
+  }))
+
+  return {
+    currencyIn: currencies[0],
+    currencyOut: currencies[n],
+    path,
+  }
+}
+
 export interface GetQuoteParams {
   assetIn: Asset
   assetOut: Asset
@@ -89,16 +190,52 @@ export interface GetQuoteParams {
   publicClient: PublicClient
   quoterAddress: Address
   poolManagerAddress: Address
-  /** Fee tier in pips (e.g. 100 = 0.01%) */
-  fee: number
-  /** Tick spacing for the pool */
-  tickSpacing: number
+  /** Fee tier in pips (e.g. 100 = 0.01%). Required for single-hop swaps. */
+  fee?: number
+  /** Tick spacing for the pool. Required for single-hop swaps. */
+  tickSpacing?: number
+  /** Multi-hop route. When set, overrides `fee`/`tickSpacing` single-hop quoting. */
+  multiHop?: MultiHopParams
 }
 
 /**
- * Get a swap quote from the Quoter contract
+ * Get a swap quote from the Quoter contract.
+ * Routes through V4's path-based quoter when `multiHop` is supplied, otherwise
+ * quotes a single direct pool.
  */
 export async function getQuote(params: GetQuoteParams): Promise<SwapPrice> {
+  const { assetIn, assetOut, amountInRaw, multiHop } = params
+  const isExactInput = amountInRaw !== undefined
+
+  const { amountIn, amountOut, gasEstimate, priceImpact, route } = multiHop
+    ? await quoteMultiHop(params, multiHop, isExactInput)
+    : await quoteSingleHop(params, isExactInput)
+
+  return {
+    price: calculatePrice(amountIn, amountOut, assetIn, assetOut),
+    priceInverse: calculatePrice(amountOut, amountIn, assetOut, assetIn),
+    amountIn: parseFloat(formatUnits(amountIn, assetIn.metadata.decimals)),
+    amountOut: parseFloat(formatUnits(amountOut, assetOut.metadata.decimals)),
+    amountInRaw: amountIn,
+    amountOutRaw: amountOut,
+    priceImpact,
+    route,
+    gasEstimate,
+  }
+}
+
+interface QuoteAmounts {
+  amountIn: bigint
+  amountOut: bigint
+  gasEstimate: bigint
+  priceImpact: number
+  route: SwapRoute
+}
+
+async function quoteSingleHop(
+  params: GetQuoteParams,
+  isExactInput: boolean,
+): Promise<QuoteAmounts> {
   const {
     assetIn,
     assetOut,
@@ -112,6 +249,10 @@ export async function getQuote(params: GetQuoteParams): Promise<SwapPrice> {
     tickSpacing,
   } = params
 
+  if (fee === undefined || tickSpacing === undefined) {
+    throw new Error('fee and tickSpacing are required for single-hop quoting')
+  }
+
   const { tokenIn, zeroForOne, poolKey } = resolvePoolParams(
     assetIn,
     assetOut,
@@ -119,8 +260,6 @@ export async function getQuote(params: GetQuoteParams): Promise<SwapPrice> {
     fee,
     tickSpacing,
   )
-
-  const isExactInput = amountInRaw !== undefined
 
   // Read pool mid-price and quote in parallel — no extra sequential RPC call
   const [sqrtPriceX96, quoteResult] = await Promise.all([
@@ -134,7 +273,7 @@ export async function getQuote(params: GetQuoteParams): Promise<SwapPrice> {
             {
               poolKey,
               zeroForOne,
-              exactAmount: amountInRaw,
+              exactAmount: amountInRaw!,
               hookData: '0x' as `0x${string}`,
             },
           ],
@@ -154,40 +293,98 @@ export async function getQuote(params: GetQuoteParams): Promise<SwapPrice> {
         }),
   ])
 
-  const amountIn = isExactInput ? amountInRaw : quoteResult.result[0]
+  const amountIn = isExactInput ? amountInRaw! : quoteResult.result[0]
   const amountOut = isExactInput ? quoteResult.result[0] : amountOutRaw!
-  const gasEstimate = quoteResult.result[1]
-
-  const price = calculatePrice(amountIn, amountOut, assetIn, assetOut)
-  const priceInverse = calculatePrice(amountOut, amountIn, assetOut, assetIn)
-  const priceImpact = calculatePriceImpact({
-    sqrtPriceX96,
-    amountIn,
-    amountOut,
-    zeroForOne,
-  })
-
-  const route: SwapRoute = {
-    path: [assetIn, assetOut],
-    pools: [
-      {
-        address: tokenIn,
-        fee,
-        version: 'v4',
-      },
-    ],
-  }
 
   return {
-    price,
-    priceInverse,
-    amountIn: parseFloat(formatUnits(amountIn, assetIn.metadata.decimals)),
-    amountOut: parseFloat(formatUnits(amountOut, assetOut.metadata.decimals)),
-    amountInRaw: amountIn,
-    amountOutRaw: amountOut,
-    priceImpact,
-    route,
-    gasEstimate,
+    amountIn,
+    amountOut,
+    gasEstimate: quoteResult.result[1],
+    priceImpact: calculatePriceImpact({
+      sqrtPriceX96,
+      amountIn,
+      amountOut,
+      zeroForOne,
+    }),
+    route: {
+      path: [assetIn, assetOut],
+      pools: [{ address: tokenIn, fee, version: 'v4' }],
+    },
+  }
+}
+
+async function quoteMultiHop(
+  params: GetQuoteParams,
+  multiHop: MultiHopParams,
+  isExactInput: boolean,
+): Promise<QuoteAmounts> {
+  const {
+    assetIn,
+    amountInRaw,
+    amountOutRaw,
+    chainId,
+    publicClient,
+    quoterAddress,
+  } = params
+
+  const { currencyIn, currencyOut, path } = resolvePathParams(
+    assetIn,
+    chainId,
+    multiHop,
+    isExactInput,
+  )
+
+  // Separate calls per function name keep viem's arg-type inference happy.
+  // viem 2.x mis-infers a dynamic `tuple[]` arg as `never[]`; the PathKey shape
+  // is validated at encode time via EXACT_INPUT_PARAMS / EXACT_OUTPUT_PARAMS, so
+  // we cast only the `path` field while keeping the other args type-checked.
+  const pathArg = path as never[]
+  const quoteResult = isExactInput
+    ? await publicClient.simulateContract({
+        address: quoterAddress,
+        abi: QUOTER_ABI,
+        functionName: 'quoteExactInput',
+        args: [
+          {
+            exactCurrency: currencyIn,
+            path: pathArg,
+            exactAmount: amountInRaw!,
+          },
+        ],
+      })
+    : await publicClient.simulateContract({
+        address: quoterAddress,
+        abi: QUOTER_ABI,
+        functionName: 'quoteExactOutput',
+        args: [
+          {
+            exactCurrency: currencyOut,
+            path: pathArg,
+            exactAmount: amountOutRaw!,
+          },
+        ],
+      })
+
+  const amountIn = isExactInput ? amountInRaw! : quoteResult.result[0]
+  const amountOut = isExactInput ? quoteResult.result[0] : amountOutRaw!
+
+  // Orient the asset chain to the swap direction for the route's display path.
+  const forward = getAssetCurrency(multiHop.assets[0], chainId) === currencyIn
+  const routeAssets = forward ? multiHop.assets : [...multiHop.assets].reverse()
+  const pools: SwapMarketInfo[] = path.map((hop, i) => ({
+    // Mirror single-hop's "input currency as address" choice for each hop.
+    address: getAssetCurrency(routeAssets[i], chainId),
+    fee: hop.fee,
+    version: 'v4',
+  }))
+
+  return {
+    amountIn,
+    amountOut,
+    gasEstimate: quoteResult.result[1],
+    // Mid-price across multiple pools is not derived in v1; report 0 impact.
+    priceImpact: 0,
+    route: { path: routeAssets, pools },
   }
 }
 
@@ -202,10 +399,12 @@ export interface EncodeSwapParams {
   chainId: SupportedChainId
   quote: SwapPrice
   universalRouterAddress: Address
-  /** Fee tier in pips (e.g. 100 = 0.01%) */
-  fee: number
-  /** Tick spacing for the pool */
-  tickSpacing: number
+  /** Fee tier in pips (e.g. 100 = 0.01%). Required for single-hop swaps. */
+  fee?: number
+  /** Tick spacing for the pool. Required for single-hop swaps. */
+  tickSpacing?: number
+  /** Multi-hop route. When set, encodes a path-based swap instead of single-hop. */
+  multiHop?: MultiHopParams
 }
 
 // V4 Universal Router command
@@ -213,85 +412,42 @@ const V4_SWAP = 0x10
 
 // V4 action types
 const SWAP_EXACT_IN_SINGLE = 0x06
+const SWAP_EXACT_IN = 0x07
 const SWAP_EXACT_OUT_SINGLE = 0x08
+const SWAP_EXACT_OUT = 0x09
 const SETTLE_ALL = 0x0c
 const TAKE_ALL = 0x0f
 
+/** Pack V4 action bytes into a single hex string (e.g. [0x06,0x0c,0x0f] → "0x060c0f"). */
+function encodeActions(actions: number[]): Hex {
+  return `0x${actions.map((a) => a.toString(16).padStart(2, '0')).join('')}` as Hex
+}
+
 /**
  * Encode Universal Router V4 swap calldata
- * @description Builds calldata for executing a V4 swap through Universal Router
+ * @description Builds calldata for executing a V4 swap through Universal Router.
+ * Routes through V4's path-based actions when `multiHop` is supplied, otherwise
+ * encodes a single direct pool.
  */
 export function encodeUniversalRouterSwap(params: EncodeSwapParams): Hex {
-  const {
-    amountInRaw,
-    assetIn,
-    assetOut,
-    slippage,
-    deadline,
-    chainId,
-    quote,
-    fee,
-    tickSpacing,
-  } = params
-
-  const { tokenIn, tokenOut, zeroForOne, poolKey } = resolvePoolParams(
-    assetIn,
-    assetOut,
-    chainId,
-    fee,
-    tickSpacing,
-  )
-
+  const { amountInRaw, slippage, quote, multiHop, deadline } = params
   const isExactInput = amountInRaw !== undefined
 
-  let actions: Hex
-  let actionParams: Hex[]
+  const minAmountOut =
+    (quote.amountOutRaw * BigInt(Math.round((1 - slippage) * 10000))) / 10000n
+  const maxAmountIn =
+    quote.amountInRaw +
+    (quote.amountInRaw * BigInt(Math.round(slippage * 10000))) / 10000n
 
-  if (isExactInput) {
-    const minAmountOut =
-      (quote.amountOutRaw * BigInt(Math.round((1 - slippage) * 10000))) / 10000n
-
-    actions =
-      `0x${[SWAP_EXACT_IN_SINGLE, SETTLE_ALL, TAKE_ALL].map((a) => a.toString(16).padStart(2, '0')).join('')}` as Hex
-
-    actionParams = [
-      encodeAbiParameters(EXACT_INPUT_SINGLE_PARAMS, [
-        {
-          poolKey,
-          zeroForOne,
-          amountIn: amountInRaw,
-          amountOutMinimum: minAmountOut,
-          hookData: '0x',
-        },
-      ]),
-      encodeAbiParameters(CURRENCY_AMOUNT_PARAMS, [tokenIn, amountInRaw]),
-      encodeAbiParameters(CURRENCY_AMOUNT_PARAMS, [tokenOut, minAmountOut]),
-    ]
-  } else {
-    const maxAmountIn =
-      quote.amountInRaw +
-      (quote.amountInRaw * BigInt(Math.round(slippage * 10000))) / 10000n
-
-    actions =
-      `0x${[SWAP_EXACT_OUT_SINGLE, SETTLE_ALL, TAKE_ALL].map((a) => a.toString(16).padStart(2, '0')).join('')}` as Hex
-
-    actionParams = [
-      encodeAbiParameters(EXACT_OUTPUT_SINGLE_PARAMS, [
-        {
-          poolKey,
-          zeroForOne,
-          amountOut: quote.amountOutRaw,
-          amountInMaximum: maxAmountIn,
-          hookData: '0x',
-        },
-      ]),
-      encodeAbiParameters(CURRENCY_AMOUNT_PARAMS, [tokenIn, maxAmountIn]),
-      encodeAbiParameters(CURRENCY_AMOUNT_PARAMS, [
-        tokenOut,
-        quote.amountOutRaw,
-      ]),
-    ]
-  }
+  const { actions, actionParams } = multiHop
+    ? encodeMultiHopActions(params, multiHop, isExactInput, {
+        minAmountOut,
+        maxAmountIn,
+      })
+    : encodeSingleHopActions(params, isExactInput, {
+        minAmountOut,
+        maxAmountIn,
+      })
 
   // Encode V4_SWAP input: abi.encode(bytes actions, bytes[] params)
   const v4SwapInput = encodeAbiParameters(
@@ -308,6 +464,132 @@ export function encodeUniversalRouterSwap(params: EncodeSwapParams): Hex {
       BigInt(deadline),
     ],
   })
+}
+
+interface SlippageBounds {
+  minAmountOut: bigint
+  maxAmountIn: bigint
+}
+
+interface EncodedActions {
+  actions: Hex
+  actionParams: Hex[]
+}
+
+function encodeSingleHopActions(
+  params: EncodeSwapParams,
+  isExactInput: boolean,
+  { minAmountOut, maxAmountIn }: SlippageBounds,
+): EncodedActions {
+  const { amountInRaw, assetIn, assetOut, chainId, quote, fee, tickSpacing } =
+    params
+
+  if (fee === undefined || tickSpacing === undefined) {
+    throw new Error('fee and tickSpacing are required for single-hop encoding')
+  }
+
+  const { tokenIn, tokenOut, zeroForOne, poolKey } = resolvePoolParams(
+    assetIn,
+    assetOut,
+    chainId,
+    fee,
+    tickSpacing,
+  )
+
+  if (isExactInput) {
+    return {
+      actions: encodeActions([SWAP_EXACT_IN_SINGLE, SETTLE_ALL, TAKE_ALL]),
+      actionParams: [
+        encodeAbiParameters(EXACT_INPUT_SINGLE_PARAMS, [
+          {
+            poolKey,
+            zeroForOne,
+            amountIn: amountInRaw!,
+            amountOutMinimum: minAmountOut,
+            hookData: '0x',
+          },
+        ]),
+        encodeAbiParameters(CURRENCY_AMOUNT_PARAMS, [tokenIn, amountInRaw!]),
+        encodeAbiParameters(CURRENCY_AMOUNT_PARAMS, [tokenOut, minAmountOut]),
+      ],
+    }
+  }
+
+  return {
+    actions: encodeActions([SWAP_EXACT_OUT_SINGLE, SETTLE_ALL, TAKE_ALL]),
+    actionParams: [
+      encodeAbiParameters(EXACT_OUTPUT_SINGLE_PARAMS, [
+        {
+          poolKey,
+          zeroForOne,
+          amountOut: quote.amountOutRaw,
+          amountInMaximum: maxAmountIn,
+          hookData: '0x',
+        },
+      ]),
+      encodeAbiParameters(CURRENCY_AMOUNT_PARAMS, [tokenIn, maxAmountIn]),
+      encodeAbiParameters(CURRENCY_AMOUNT_PARAMS, [
+        tokenOut,
+        quote.amountOutRaw,
+      ]),
+    ],
+  }
+}
+
+function encodeMultiHopActions(
+  params: EncodeSwapParams,
+  multiHop: MultiHopParams,
+  isExactInput: boolean,
+  { minAmountOut, maxAmountIn }: SlippageBounds,
+): EncodedActions {
+  const { amountInRaw, assetIn, chainId, quote } = params
+
+  const { currencyIn, currencyOut, path } = resolvePathParams(
+    assetIn,
+    chainId,
+    multiHop,
+    isExactInput,
+  )
+
+  if (isExactInput) {
+    return {
+      actions: encodeActions([SWAP_EXACT_IN, SETTLE_ALL, TAKE_ALL]),
+      actionParams: [
+        encodeAbiParameters(EXACT_INPUT_PARAMS, [
+          {
+            currencyIn,
+            path,
+            amountIn: amountInRaw!,
+            amountOutMinimum: minAmountOut,
+          },
+        ]),
+        encodeAbiParameters(CURRENCY_AMOUNT_PARAMS, [currencyIn, amountInRaw!]),
+        encodeAbiParameters(CURRENCY_AMOUNT_PARAMS, [
+          currencyOut,
+          minAmountOut,
+        ]),
+      ],
+    }
+  }
+
+  return {
+    actions: encodeActions([SWAP_EXACT_OUT, SETTLE_ALL, TAKE_ALL]),
+    actionParams: [
+      encodeAbiParameters(EXACT_OUTPUT_PARAMS, [
+        {
+          currencyOut,
+          path,
+          amountOut: quote.amountOutRaw,
+          amountInMaximum: maxAmountIn,
+        },
+      ]),
+      encodeAbiParameters(CURRENCY_AMOUNT_PARAMS, [currencyIn, maxAmountIn]),
+      encodeAbiParameters(CURRENCY_AMOUNT_PARAMS, [
+        currencyOut,
+        quote.amountOutRaw,
+      ]),
+    ],
+  }
 }
 
 function calculatePrice(

--- a/packages/sdk/src/actions/swap/providers/uniswap/types.ts
+++ b/packages/sdk/src/actions/swap/providers/uniswap/types.ts
@@ -1,7 +1,24 @@
+import type { Asset } from '@/types/asset.js'
 import type {
   SwapMarketConfig,
   SwapProviderConfig,
 } from '@/types/swap/index.js'
+
+/**
+ * One segment of a multi-hop V4 route.
+ *
+ * Each hop describes the pool whose **output** is `asset`: i.e. for a path
+ * `assets[0] → A → assets[1]`, the hops are `[{ asset: A, ... }, { asset: assets[1], ... }]`,
+ * where hop 0's pool is `assets[0]/A` and hop 1's pool is `A/assets[1]`.
+ */
+export interface UniswapPathHop {
+  /** Output currency of this hop (an intermediate, or the final output asset). */
+  asset: Asset
+  /** Fee tier in pips for this hop's pool (e.g. 100 = 0.01%) */
+  fee: number
+  /** Tick spacing for this hop's pool */
+  tickSpacing: number
+}
 
 /**
  * Uniswap-specific market config with V4 pool parameters
@@ -11,6 +28,13 @@ export interface UniswapMarketConfig extends SwapMarketConfig {
   fee?: number
   /** Tick spacing for the pool */
   tickSpacing?: number
+  /**
+   * Explicit multi-hop route from `assets[0]` to `assets[1]`, ordered output-first
+   * per hop. When set with 2+ hops, swaps for this pair route through V4's
+   * path-based `SWAP_EXACT_IN` / `SWAP_EXACT_OUT` instead of a direct pool.
+   * Reverse-direction swaps reuse this same forward path, walked backward.
+   */
+  path?: UniswapPathHop[]
 }
 
 /**


### PR DESCRIPTION
Closes #440

## Summary

Adds Uniswap V4 **multi-hop** swap support (`SWAP_EXACT_IN` `0x07` / `SWAP_EXACT_OUT` `0x09`) over a `PathKey[]` path, alongside the existing single-hop path. When a pair has no direct V4 pool, swaps can now route through configured intermediates (e.g. `X → ETH → Y`).

### Path discovery — decision

Went with **Option 1 (explicit per-pair path config)** from the issue's open question. It mirrors the existing per-pair `fee`/`tickSpacing` pattern, is permissionless and deterministic, and needs no RPC fan-out or external routing dependency. Option 2 (static-intermediate quote fan-out) is a reasonable follow-up but adds RPC discovery; kept out of a focused v1.

A `UniswapMarketConfig` gains an optional `path: UniswapPathHop[]` describing the forward route `assets[0] → assets[1]`, output-first per hop (`{ asset, fee, tickSpacing }`). One forward config serves both swap directions — reverse swaps walk the chain backward.

### What changed

- **`abis.ts`**: `PATH_KEY_COMPONENTS`, `EXACT_INPUT_PARAMS`, `EXACT_OUTPUT_PARAMS`, and quoter `quoteExactInput` / `quoteExactOutput` (`QuoteExactParams`).
- **`types.ts`**: `UniswapPathHop` + `path?` on `UniswapMarketConfig`.
- **`encoding.ts`**: `SWAP_EXACT_IN`/`SWAP_EXACT_OUT` constants, `buildPath()`, `resolvePathParams()`, and multi-hop branches in `getQuote` and `encodeUniversalRouterSwap`. Single-hop logic extracted into helpers with **byte-identical output** (verified — see tests).
- **`UniswapSwapProvider.ts`**: builds multi-hop params from `config.path`; `resolveUniswapConfig` now accepts a path-only config (direct pool *or* a 2+ hop path).

### Correctness notes (V4 semantics)

- **ABI shape matches the deployed router.** The pinned issue reference commit (`9dafaaec`) includes a `minHopPriceX36` field, but this repo's existing single-hop encoding (and the Uniswap docs for the deployed `ExactInputSingleParams`) **omit** it. To stay consistent with the router this SDK actually targets, the multi-hop structs omit `minHopPriceX36` too. Flagged here so a future router upgrade revisits both single- and multi-hop structs together.
- **Exact-out path is reversed.** V4 iterates the exact-output path backward, so `path[i].intermediateCurrency` holds each hop's **output** for exact-in but its **input** for exact-out (with `exactCurrency = currencyOut`). `resolvePathParams` encodes this difference; tests decode the calldata to assert it.
- `hooks: 0x0` for all hops (per issue out-of-scope); native ETH intermediates encode as `address(0)`.
- Multi-hop `priceImpact` reports `0` in v1 (single cross-pool mid-price isn't derived); noted in code.

## Testing

- Unit (`@eth-optimism/actions-sdk`): **672 passed**. New tests cover multi-hop exact-in (`0x070c0f`) and exact-out (`0x090c0f`) calldata decoding, reverse-direction path reversal, native-ETH intermediates, quoter dispatch (`quoteExactInput`/`quoteExactOutput`), and a **single-hop byte-parity regression** (calldata verified byte-identical to the pre-refactor encoder).
- Typecheck + lint clean (SDK and CLI).
- Manually exercised end-to-end against the compiled SDK (offline, mocked RPC): `buildPath → getQuote → encodeUniversalRouterSwap`, decoding the calldata for both directions and amount kinds.

> Note: the issue's on-chain 2-hop integration test against a live V4 deployment is not included — it needs a funded multi-hop route + RPC egress unavailable in this environment. The decode-based unit tests + compiled-SDK exercise verify the encoding/quoting contract.
