### PR TITLE
Improve swap slippage bounds

### DIFF
--- a/.changeset/calm-swaps-sip.md
+++ b/.changeset/calm-swaps-sip.md
@@ -1,0 +1,6 @@
+---
+'@eth-optimism/actions-sdk': patch
+---
+
+Clamp swap slippage validation to finite values in [0, 1) and reuse
+provider-derived slippage bounds when encoding Uniswap calldata.

--- a/packages/sdk/src/actions/swap/__mocks__/MockSwapProvider.ts
+++ b/packages/sdk/src/actions/swap/__mocks__/MockSwapProvider.ts
@@ -122,6 +122,13 @@ export class MockSwapProvider extends SwapProvider<SwapProviderConfig> {
     return this.computeSlippageBounds(amountOutRaw, slippage, assetOut)
   }
 
+  public testComputeAmountInMaxRaw(
+    amountInRaw: bigint,
+    slippage: number,
+  ): bigint {
+    return this.computeAmountInMaxRaw(amountInRaw, slippage)
+  }
+
   protected async _execute(
     params: ResolvedSwapParams,
   ): Promise<SwapTransaction> {

--- a/packages/sdk/src/actions/swap/__mocks__/MockSwapProvider.ts
+++ b/packages/sdk/src/actions/swap/__mocks__/MockSwapProvider.ts
@@ -114,6 +114,14 @@ export class MockSwapProvider extends SwapProvider<SwapProviderConfig> {
     return this.buildSwapTransactions(quote)
   }
 
+  public testComputeSlippageBounds(
+    amountOutRaw: bigint,
+    slippage: number,
+    assetOut: Asset,
+  ): { amountOutMinRaw: bigint; amountOutMin: number } {
+    return this.computeSlippageBounds(amountOutRaw, slippage, assetOut)
+  }
+
   protected async _execute(
     params: ResolvedSwapParams,
   ): Promise<SwapTransaction> {

--- a/packages/sdk/src/actions/swap/core/SwapProvider.ts
+++ b/packages/sdk/src/actions/swap/core/SwapProvider.ts
@@ -164,9 +164,7 @@ export abstract class SwapProvider<
    */
   async getQuote(params: SwapQuoteParamsResolved): Promise<SwapQuote> {
     this.assertChainSupported(params.chainId)
-    // Run the value-relevant guards before quoting so a quote can never encode
-    // a negative-floor calldata that execute() would have rejected. Scoped to
-    // the slippage/amount guards needed to close the negative-min-out path.
+    // Validate slippage and amounts before quote calldata is built.
     validateNotBothAmounts(params.amountIn, params.amountOut)
     validateAmountPositiveIfExists(params.amountIn)
     validateAmountPositiveIfExists(params.amountOut)

--- a/packages/sdk/src/actions/swap/core/SwapProvider.ts
+++ b/packages/sdk/src/actions/swap/core/SwapProvider.ts
@@ -8,6 +8,7 @@ import { QUOTE_DISCRIMINATOR } from '@/actions/shared/quoteDiscriminator.js'
 import { UNIVERSAL_ROUTER_MSG_SENDER } from '@/actions/swap/core/markets.js'
 import type { SupportedChainId } from '@/constants/supportedChains.js'
 import {
+  InvalidParamsError,
   MarketNotAllowedError,
   ProviderNotConfiguredError,
   QuoteRecipientMissingError,
@@ -163,6 +164,12 @@ export abstract class SwapProvider<
    */
   async getQuote(params: SwapQuoteParamsResolved): Promise<SwapQuote> {
     this.assertChainSupported(params.chainId)
+    // Run the value-relevant guards before quoting so a quote can never encode
+    // a negative-floor calldata that execute() would have rejected. Scoped to
+    // the slippage/amount guards needed to close the negative-min-out path.
+    validateAmountPositiveIfExists(params.amountIn)
+    validateAmountPositiveIfExists(params.amountOut)
+    validateSlippage(params.slippage ?? this.defaultSlippage, this.maxSlippage)
     return this._getQuote(params)
   }
 
@@ -288,13 +295,49 @@ export abstract class SwapProvider<
     slippage: number,
     assetOut: Asset,
   ): { amountOutMinRaw: bigint; amountOutMin: number } {
+    // Defense-in-depth: reject non-finite slippage even if a future caller
+    // reaches this without going through validateSlippage.
+    if (!Number.isFinite(slippage)) {
+      throw new InvalidParamsError({
+        param: 'slippage',
+        expected: 'a finite number in [0, 1)',
+        received: `${slippage}`,
+      })
+    }
     const slippageBps = BigInt(Math.round(slippage * Number(BPS_DENOMINATOR)))
     const amountOutMinRaw =
       (amountOutRaw * (BPS_DENOMINATOR - slippageBps)) / BPS_DENOMINATOR
+    // The min-out floor is the only on-chain slippage protection. A floor
+    // outside [0, amountOutRaw] means protection is disabled (negative) or
+    // impossible (above the quote), so fail loud rather than silently sign it.
+    if (amountOutMinRaw < 0n || amountOutMinRaw > amountOutRaw) {
+      throw new InvalidParamsError({
+        param: 'slippage',
+        expected: `amountOutMinRaw within [0, ${amountOutRaw}]`,
+        received: `${amountOutMinRaw}`,
+      })
+    }
     const amountOutMin = parseFloat(
       formatUnits(amountOutMinRaw, assetOut.metadata.decimals),
     )
     return { amountOutMinRaw, amountOutMin }
+  }
+
+  /**
+   * Compute the maximum input for an exact-output swap after slippage.
+   * Symmetric to {@link computeSlippageBounds} on the input side. The ceiling
+   * can only grow with slippage, so it needs no negative-floor clamp; callers
+   * pass this through to the encoder so the displayed and enforced max-in are
+   * the same number.
+   * @param amountInRaw - Quoted input as raw bigint
+   * @param slippage - Slippage tolerance as decimal (0.005 = 0.5%)
+   */
+  protected computeAmountInMaxRaw(
+    amountInRaw: bigint,
+    slippage: number,
+  ): bigint {
+    const slippageBps = BigInt(Math.round(slippage * Number(BPS_DENOMINATOR)))
+    return amountInRaw + (amountInRaw * slippageBps) / BPS_DENOMINATOR
   }
 
   protected resolveMarketConfig(

--- a/packages/sdk/src/actions/swap/core/SwapProvider.ts
+++ b/packages/sdk/src/actions/swap/core/SwapProvider.ts
@@ -467,6 +467,9 @@ export abstract class SwapProvider<
   // Private helpers
   // ─────────────────────────────────────────────────────────────────────────────
 
+  // Flooring to whole bps is conservative because it tightens bounds rather than
+  // allowing extra slippage. Raw amount inputs are tracked in
+  // https://github.com/ethereum-optimism/actions/issues/379 for exact callers.
   private computeSlippageBps(slippage: number): bigint {
     validateSlippage(slippage, this.maxSlippage)
     return BigInt(Math.floor(slippage * Number(BPS_DENOMINATOR)))

--- a/packages/sdk/src/actions/swap/core/SwapProvider.ts
+++ b/packages/sdk/src/actions/swap/core/SwapProvider.ts
@@ -295,9 +295,9 @@ export abstract class SwapProvider<
     slippage: number,
     assetOut: Asset,
   ): { amountOutMinRaw: bigint; amountOutMin: number } {
-    // Defense-in-depth: reject non-finite slippage even if a future caller
-    // reaches this without going through validateSlippage.
-    if (!Number.isFinite(slippage)) {
+    // Defense-in-depth: enforce the same invariant as validateSlippage in case
+    // a future caller reaches this helper directly.
+    if (!Number.isFinite(slippage) || slippage < 0 || slippage >= 1) {
       throw new InvalidParamsError({
         param: 'slippage',
         expected: 'a finite number in [0, 1)',

--- a/packages/sdk/src/actions/swap/core/SwapProvider.ts
+++ b/packages/sdk/src/actions/swap/core/SwapProvider.ts
@@ -167,6 +167,7 @@ export abstract class SwapProvider<
     // Run the value-relevant guards before quoting so a quote can never encode
     // a negative-floor calldata that execute() would have rejected. Scoped to
     // the slippage/amount guards needed to close the negative-min-out path.
+    validateNotBothAmounts(params.amountIn, params.amountOut)
     validateAmountPositiveIfExists(params.amountIn)
     validateAmountPositiveIfExists(params.amountOut)
     validateSlippage(params.slippage ?? this.defaultSlippage, this.maxSlippage)
@@ -466,14 +467,8 @@ export abstract class SwapProvider<
   // ─────────────────────────────────────────────────────────────────────────────
 
   private computeSlippageBps(slippage: number): bigint {
-    if (!Number.isFinite(slippage) || slippage < 0 || slippage >= 1) {
-      throw new InvalidParamsError({
-        param: 'slippage',
-        expected: 'a finite number in [0, 1)',
-        received: `${slippage}`,
-      })
-    }
-    return BigInt(Math.round(slippage * Number(BPS_DENOMINATOR)))
+    validateSlippage(slippage, this.maxSlippage)
+    return BigInt(Math.floor(slippage * Number(BPS_DENOMINATOR)))
   }
 
   private async executeFromQuote(quote: SwapQuote): Promise<SwapTransaction> {

--- a/packages/sdk/src/actions/swap/core/SwapProvider.ts
+++ b/packages/sdk/src/actions/swap/core/SwapProvider.ts
@@ -295,16 +295,7 @@ export abstract class SwapProvider<
     slippage: number,
     assetOut: Asset,
   ): { amountOutMinRaw: bigint; amountOutMin: number } {
-    // Defense-in-depth: enforce the same invariant as validateSlippage in case
-    // a future caller reaches this helper directly.
-    if (!Number.isFinite(slippage) || slippage < 0 || slippage >= 1) {
-      throw new InvalidParamsError({
-        param: 'slippage',
-        expected: 'a finite number in [0, 1)',
-        received: `${slippage}`,
-      })
-    }
-    const slippageBps = BigInt(Math.round(slippage * Number(BPS_DENOMINATOR)))
+    const slippageBps = this.computeSlippageBps(slippage)
     const amountOutMinRaw =
       (amountOutRaw * (BPS_DENOMINATOR - slippageBps)) / BPS_DENOMINATOR
     // The min-out floor is the only on-chain slippage protection. A floor
@@ -336,7 +327,7 @@ export abstract class SwapProvider<
     amountInRaw: bigint,
     slippage: number,
   ): bigint {
-    const slippageBps = BigInt(Math.round(slippage * Number(BPS_DENOMINATOR)))
+    const slippageBps = this.computeSlippageBps(slippage)
     return amountInRaw + (amountInRaw * slippageBps) / BPS_DENOMINATOR
   }
 
@@ -473,6 +464,17 @@ export abstract class SwapProvider<
   // ─────────────────────────────────────────────────────────────────────────────
   // Private helpers
   // ─────────────────────────────────────────────────────────────────────────────
+
+  private computeSlippageBps(slippage: number): bigint {
+    if (!Number.isFinite(slippage) || slippage < 0 || slippage >= 1) {
+      throw new InvalidParamsError({
+        param: 'slippage',
+        expected: 'a finite number in [0, 1)',
+        received: `${slippage}`,
+      })
+    }
+    return BigInt(Math.round(slippage * Number(BPS_DENOMINATOR)))
+  }
 
   private async executeFromQuote(quote: SwapQuote): Promise<SwapTransaction> {
     validateQuoteNotExpired(quote.expiresAt)

--- a/packages/sdk/src/actions/swap/core/SwapProvider.ts
+++ b/packages/sdk/src/actions/swap/core/SwapProvider.ts
@@ -297,9 +297,7 @@ export abstract class SwapProvider<
     const slippageBps = this.computeSlippageBps(slippage)
     const amountOutMinRaw =
       (amountOutRaw * (BPS_DENOMINATOR - slippageBps)) / BPS_DENOMINATOR
-    // The min-out floor is the only on-chain slippage protection. A floor
-    // outside [0, amountOutRaw] means protection is disabled (negative) or
-    // impossible (above the quote), so fail loud rather than silently sign it.
+    // Reject min-out floors that disable protection or exceed the quote.
     if (amountOutMinRaw < 0n || amountOutMinRaw > amountOutRaw) {
       throw new InvalidParamsError({
         param: 'slippage',
@@ -313,15 +311,7 @@ export abstract class SwapProvider<
     return { amountOutMinRaw, amountOutMin }
   }
 
-  /**
-   * Compute the maximum input for an exact-output swap after slippage.
-   * Symmetric to {@link computeSlippageBounds} on the input side. The ceiling
-   * can only grow with slippage, so it needs no negative-floor clamp; callers
-   * pass this through to the encoder so the displayed and enforced max-in are
-   * the same number.
-   * @param amountInRaw - Quoted input as raw bigint
-   * @param slippage - Slippage tolerance as decimal (0.005 = 0.5%)
-   */
+  /** Compute max input after slippage, rounded up so displayed and enforced max-in match. */
   protected computeAmountInMaxRaw(
     amountInRaw: bigint,
     slippage: number,
@@ -467,9 +457,8 @@ export abstract class SwapProvider<
   // Private helpers
   // ─────────────────────────────────────────────────────────────────────────────
 
-  // Flooring to whole bps is conservative because it tightens bounds rather than
-  // allowing extra slippage. Raw amount inputs are tracked in
-  // https://github.com/ethereum-optimism/actions/issues/379 for exact callers.
+  // Flooring to whole bps is conservative because it tightens bounds.
+  // https://github.com/ethereum-optimism/actions/issues/379
   private computeSlippageBps(slippage: number): bigint {
     validateSlippage(slippage, this.maxSlippage)
     return BigInt(Math.floor(slippage * Number(BPS_DENOMINATOR)))

--- a/packages/sdk/src/actions/swap/core/SwapProvider.ts
+++ b/packages/sdk/src/actions/swap/core/SwapProvider.ts
@@ -297,7 +297,9 @@ export abstract class SwapProvider<
     const slippageBps = this.computeSlippageBps(slippage)
     const amountOutMinRaw =
       (amountOutRaw * (BPS_DENOMINATOR - slippageBps)) / BPS_DENOMINATOR
-    // Reject min-out floors that disable protection or exceed the quote.
+    // The min-out floor is the only on-chain slippage protection. A floor
+    // outside [0, amountOutRaw] means protection is disabled (negative) or
+    // impossible (above the quote), so fail loud rather than silently sign it.
     if (amountOutMinRaw < 0n || amountOutMinRaw > amountOutRaw) {
       throw new InvalidParamsError({
         param: 'slippage',
@@ -311,7 +313,15 @@ export abstract class SwapProvider<
     return { amountOutMinRaw, amountOutMin }
   }
 
-  /** Compute max input after slippage, rounded up so displayed and enforced max-in match. */
+  /**
+   * Compute the maximum input for an exact-output swap after slippage.
+   * Symmetric to {@link computeSlippageBounds} on the input side. The ceiling
+   * can only grow with slippage, so it needs no negative-floor clamp; callers
+   * pass this through to the encoder so the displayed and enforced max-in are
+   * the same number.
+   * @param amountInRaw - Quoted input as raw bigint
+   * @param slippage - Slippage tolerance as decimal (0.005 = 0.5%)
+   */
   protected computeAmountInMaxRaw(
     amountInRaw: bigint,
     slippage: number,

--- a/packages/sdk/src/actions/swap/core/SwapProvider.ts
+++ b/packages/sdk/src/actions/swap/core/SwapProvider.ts
@@ -465,7 +465,7 @@ export abstract class SwapProvider<
   // Private helpers
   // ─────────────────────────────────────────────────────────────────────────────
 
-  // Flooring to whole bps is conservative because it tightens bounds.
+  // Safe but not ideal, flooring to whole bps is conservative because it tightens bounds. This issue expands flexibility:
   // https://github.com/ethereum-optimism/actions/issues/379
   private computeSlippageBps(slippage: number): bigint {
     validateSlippage(slippage, this.maxSlippage)

--- a/packages/sdk/src/actions/swap/core/SwapProvider.ts
+++ b/packages/sdk/src/actions/swap/core/SwapProvider.ts
@@ -329,7 +329,10 @@ export abstract class SwapProvider<
     slippage: number,
   ): bigint {
     const slippageBps = this.computeSlippageBps(slippage)
-    return amountInRaw + (amountInRaw * slippageBps) / BPS_DENOMINATOR
+    return (
+      (amountInRaw * (BPS_DENOMINATOR + slippageBps) + BPS_DENOMINATOR - 1n) /
+      BPS_DENOMINATOR
+    )
   }
 
   protected resolveMarketConfig(

--- a/packages/sdk/src/actions/swap/core/SwapProvider.ts
+++ b/packages/sdk/src/actions/swap/core/SwapProvider.ts
@@ -297,9 +297,7 @@ export abstract class SwapProvider<
     const slippageBps = this.computeSlippageBps(slippage)
     const amountOutMinRaw =
       (amountOutRaw * (BPS_DENOMINATOR - slippageBps)) / BPS_DENOMINATOR
-    // The min-out floor is the only on-chain slippage protection. A floor
-    // outside [0, amountOutRaw] means protection is disabled (negative) or
-    // impossible (above the quote), so fail loud rather than silently sign it.
+    // Reject min-out floors that disable protection or exceed the quote.
     if (amountOutMinRaw < 0n || amountOutMinRaw > amountOutRaw) {
       throw new InvalidParamsError({
         param: 'slippage',

--- a/packages/sdk/src/actions/swap/core/__tests__/SwapProvider.test.ts
+++ b/packages/sdk/src/actions/swap/core/__tests__/SwapProvider.test.ts
@@ -426,6 +426,14 @@ describe('SwapProvider', () => {
     })
   })
 
+  describe('computeAmountInMaxRaw()', () => {
+    it('rounds up non-divisible exact-output slippage math', () => {
+      const provider = new MockSwapProvider()
+
+      expect(provider.testComputeAmountInMaxRaw(1n, 0.005)).toBe(2n)
+    })
+  })
+
   describe('getMarket()', () => {
     it('should throw if chain not supported', async () => {
       const provider = new MockSwapProvider()

--- a/packages/sdk/src/actions/swap/core/__tests__/SwapProvider.test.ts
+++ b/packages/sdk/src/actions/swap/core/__tests__/SwapProvider.test.ts
@@ -307,7 +307,7 @@ describe('SwapProvider', () => {
     })
 
     // F186: getQuote previously skipped validateSwapExecute, so a slippage in
-    // [maxSlippage, ∞) or a non-finite slippage reached the bounds math and a
+    // [maxSlippage, Infinity) or a non-finite slippage reached the bounds math and a
     // negative/zero floor was encoded into the returned quote's calldata.
     it.each([1.5, NaN])(
       'rejects slippage %p instead of returning a negative-floor quote',
@@ -356,12 +356,26 @@ describe('SwapProvider', () => {
       },
     )
 
-    it('throws instead of returning a negative floor for slippage >= 1', () => {
+    it.each([1.0, 1.5])(
+      'throws instead of returning a disabled floor for slippage %p',
+      (slippage) => {
+        const provider = new MockSwapProvider()
+        expect(() =>
+          provider.testComputeSlippageBounds(
+            1_000_000_000_000_000_000n,
+            slippage,
+            MockWETH,
+          ),
+        ).toThrow(InvalidParamsError)
+      },
+    )
+
+    it('throws instead of returning an impossible floor for negative slippage', () => {
       const provider = new MockSwapProvider()
       expect(() =>
         provider.testComputeSlippageBounds(
           1_000_000_000_000_000_000n,
-          1.5,
+          -0.1,
           MockWETH,
         ),
       ).toThrow(InvalidParamsError)

--- a/packages/sdk/src/actions/swap/core/__tests__/SwapProvider.test.ts
+++ b/packages/sdk/src/actions/swap/core/__tests__/SwapProvider.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 
 import { MockSwapProvider } from '@/actions/swap/__mocks__/MockSwapProvider.js'
 import type { SupportedChainId } from '@/constants/supportedChains.js'
+import { InvalidParamsError } from '@/core/error/errors.js'
 import type { Asset } from '@/types/asset.js'
 import type { SwapMarketConfig } from '@/types/swap/index.js'
 
@@ -303,6 +304,78 @@ describe('SwapProvider', () => {
       expect(quote.amountIn).toBeDefined()
       expect(quote.amountOut).toBeDefined()
       expect(quote.route).toBeDefined()
+    })
+
+    // F186: getQuote previously skipped validateSwapExecute, so a slippage in
+    // [maxSlippage, ∞) or a non-finite slippage reached the bounds math and a
+    // negative/zero floor was encoded into the returned quote's calldata.
+    it.each([1.5, NaN])(
+      'rejects slippage %p instead of returning a negative-floor quote',
+      async (slippage) => {
+        const provider = new MockSwapProvider()
+        await expect(
+          provider.getQuote({
+            assetIn: MockUSDC,
+            assetOut: MockWETH,
+            amountIn: 100,
+            chainId: 84532 as SupportedChainId,
+            slippage,
+          }),
+        ).rejects.toThrow('out of range')
+        expect(provider.mockGetQuote).not.toHaveBeenCalled()
+      },
+    )
+
+    it('rejects a non-finite amount before quoting', async () => {
+      const provider = new MockSwapProvider()
+      await expect(
+        provider.getQuote({
+          assetIn: MockUSDC,
+          assetOut: MockWETH,
+          amountIn: NaN,
+          chainId: 84532 as SupportedChainId,
+        }),
+      ).rejects.toThrow('Amount must be positive')
+      expect(provider.mockGetQuote).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('computeSlippageBounds()', () => {
+    it.each([0, 0.005, 0.5])(
+      'keeps amountOutMinRaw within [0, amountOutRaw] for slippage %p',
+      (slippage) => {
+        const provider = new MockSwapProvider()
+        const amountOutRaw = 1_000_000_000_000_000_000n
+        const { amountOutMinRaw } = provider.testComputeSlippageBounds(
+          amountOutRaw,
+          slippage,
+          MockWETH,
+        )
+        expect(amountOutMinRaw).toBeGreaterThanOrEqual(0n)
+        expect(amountOutMinRaw).toBeLessThanOrEqual(amountOutRaw)
+      },
+    )
+
+    it('throws instead of returning a negative floor for slippage >= 1', () => {
+      const provider = new MockSwapProvider()
+      expect(() =>
+        provider.testComputeSlippageBounds(
+          1_000_000_000_000_000_000n,
+          1.5,
+          MockWETH,
+        ),
+      ).toThrow(InvalidParamsError)
+    })
+
+    it('throws for a non-finite slippage', () => {
+      const provider = new MockSwapProvider()
+      expect(() =>
+        provider.testComputeSlippageBounds(
+          1_000_000_000_000_000_000n,
+          NaN,
+          MockWETH,
+        ),
+      ).toThrow(InvalidParamsError)
     })
   })
 

--- a/packages/sdk/src/actions/swap/core/__tests__/SwapProvider.test.ts
+++ b/packages/sdk/src/actions/swap/core/__tests__/SwapProvider.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest'
 
 import { MockSwapProvider } from '@/actions/swap/__mocks__/MockSwapProvider.js'
 import type { SupportedChainId } from '@/constants/supportedChains.js'
-import { InvalidParamsError } from '@/core/error/errors.js'
+import { SlippageOutOfRangeError } from '@/core/error/errors.js'
 import type { Asset } from '@/types/asset.js'
 import type { SwapMarketConfig } from '@/types/swap/index.js'
 
@@ -326,16 +326,39 @@ describe('SwapProvider', () => {
       },
     )
 
-    it('rejects a non-finite amount before quoting', async () => {
+    it.each([
+      { amountIn: NaN, amountOut: undefined },
+      { amountIn: undefined, amountOut: NaN },
+      { amountIn: undefined, amountOut: 0 },
+      { amountIn: undefined, amountOut: -1 },
+    ])(
+      'rejects invalid quote amount shape %p before quoting',
+      async ({ amountIn, amountOut }) => {
+        const provider = new MockSwapProvider()
+        await expect(
+          provider.getQuote({
+            assetIn: MockUSDC,
+            assetOut: MockWETH,
+            amountIn,
+            amountOut,
+            chainId: 84532 as SupportedChainId,
+          }),
+        ).rejects.toThrow('Amount must be a positive finite number')
+        expect(provider.mockGetQuote).not.toHaveBeenCalled()
+      },
+    )
+
+    it('rejects conflicting quote amounts before quoting', async () => {
       const provider = new MockSwapProvider()
       await expect(
         provider.getQuote({
           assetIn: MockUSDC,
           assetOut: MockWETH,
-          amountIn: NaN,
+          amountIn: 100,
+          amountOut: 1,
           chainId: 84532 as SupportedChainId,
         }),
-      ).rejects.toThrow('Amount must be positive')
+      ).rejects.toThrow('Provide either amountIn or amountOut, not both')
       expect(provider.mockGetQuote).not.toHaveBeenCalled()
     })
   })
@@ -366,7 +389,7 @@ describe('SwapProvider', () => {
             slippage,
             MockWETH,
           ),
-        ).toThrow(InvalidParamsError)
+        ).toThrow(SlippageOutOfRangeError)
       },
     )
 
@@ -378,7 +401,7 @@ describe('SwapProvider', () => {
           -0.1,
           MockWETH,
         ),
-      ).toThrow(InvalidParamsError)
+      ).toThrow(SlippageOutOfRangeError)
     })
 
     it('throws for a non-finite slippage', () => {
@@ -389,7 +412,17 @@ describe('SwapProvider', () => {
           NaN,
           MockWETH,
         ),
-      ).toThrow(InvalidParamsError)
+      ).toThrow(SlippageOutOfRangeError)
+    })
+
+    it('does not round near-one slippage to a zero floor', () => {
+      const provider = new MockSwapProvider({ maxSlippage: 1 })
+      const { amountOutMinRaw } = provider.testComputeSlippageBounds(
+        1_000_000_000_000_000_000n,
+        0.99996,
+        MockWETH,
+      )
+      expect(amountOutMinRaw).toBeGreaterThan(0n)
     })
   })
 

--- a/packages/sdk/src/actions/swap/core/__tests__/SwapProvider.test.ts
+++ b/packages/sdk/src/actions/swap/core/__tests__/SwapProvider.test.ts
@@ -306,9 +306,7 @@ describe('SwapProvider', () => {
       expect(quote.route).toBeDefined()
     })
 
-    // F186: getQuote previously skipped validateSwapExecute, so a slippage in
-    // [maxSlippage, Infinity) or a non-finite slippage reached the bounds math
-    // and a negative/zero floor was encoded into the returned quote's calldata.
+    // Invalid quote slippage must be rejected before calldata bounds are built.
     it.each([1.5, NaN])(
       'rejects slippage %p instead of returning a negative-floor quote',
       async (slippage) => {

--- a/packages/sdk/src/actions/swap/core/__tests__/SwapProvider.test.ts
+++ b/packages/sdk/src/actions/swap/core/__tests__/SwapProvider.test.ts
@@ -307,8 +307,8 @@ describe('SwapProvider', () => {
     })
 
     // F186: getQuote previously skipped validateSwapExecute, so a slippage in
-    // [maxSlippage, Infinity) or a non-finite slippage reached the bounds math and a
-    // negative/zero floor was encoded into the returned quote's calldata.
+    // [maxSlippage, Infinity) or a non-finite slippage reached the bounds math
+    // and a negative/zero floor was encoded into the returned quote's calldata.
     it.each([1.5, NaN])(
       'rejects slippage %p instead of returning a negative-floor quote',
       async (slippage) => {

--- a/packages/sdk/src/actions/swap/providers/uniswap/UniswapSwapProvider.ts
+++ b/packages/sdk/src/actions/swap/providers/uniswap/UniswapSwapProvider.ts
@@ -129,12 +129,26 @@ export class UniswapSwapProvider extends SwapProvider<UniswapSwapProviderConfig>
       tickSpacing: marketConfig.tickSpacing,
     })
 
+    const { amountOutMinRaw, amountOutMin } = this.computeSlippageBounds(
+      quote.amountOutRaw,
+      slippage,
+      assetOut,
+    )
+
+    // Derive the exact-out max-in ceiling once and feed it (and the min-out
+    // floor) to the encoder so the displayed bounds and the bounds baked into
+    // calldata come from a single computation, not two that can diverge.
+    const amountInMaxRaw = amountOutRaw
+      ? this.computeAmountInMaxRaw(quote.amountInRaw, slippage)
+      : undefined
+
     const swapCalldata = encodeUniversalRouterSwap({
       amountInRaw: amountOutRaw ? undefined : amountInRaw,
       amountOutRaw,
       assetIn,
       assetOut,
-      slippage,
+      amountOutMinRaw,
+      amountInMaxRaw,
       deadline,
       recipient,
       chainId,
@@ -145,12 +159,6 @@ export class UniswapSwapProvider extends SwapProvider<UniswapSwapProviderConfig>
     })
 
     const finalAmountInRaw = amountOutRaw ? quote.amountInRaw : amountInRaw
-
-    const { amountOutMinRaw, amountOutMin } = this.computeSlippageBounds(
-      quote.amountOutRaw,
-      slippage,
-      assetOut,
-    )
 
     return {
       assetIn,

--- a/packages/sdk/src/actions/swap/providers/uniswap/UniswapSwapProvider.ts
+++ b/packages/sdk/src/actions/swap/providers/uniswap/UniswapSwapProvider.ts
@@ -1,4 +1,4 @@
-import { formatUnits } from 'viem'
+import { formatUnits, type Hex } from 'viem'
 
 import { expandMarkets, findMarket } from '@/actions/swap/core/markets.js'
 import { SwapProvider } from '@/actions/swap/core/SwapProvider.js'
@@ -81,6 +81,7 @@ export class UniswapSwapProvider extends SwapProvider<UniswapSwapProviderConfig>
 
   protected async _buildApprovals(quote: SwapQuote) {
     const addresses = getUniswapAddresses(quote.chainId)
+    const requiredAmount = quote.amountInMaxRaw ?? quote.amountInRaw
 
     return this.buildPermit2Approvals(
       {
@@ -91,14 +92,14 @@ export class UniswapSwapProvider extends SwapProvider<UniswapSwapProviderConfig>
         recipient: quote.recipient,
         walletAddress: quote.recipient,
         chainId: quote.chainId,
-        amountInRaw: quote.amountInRaw,
+        amountInRaw: requiredAmount,
         approvalMode: resolveApprovalMode(
           quote.approvalMode,
           this._config.approvalMode,
           this._settings.approvalMode,
         ),
       },
-      quote.amountInRaw,
+      requiredAmount,
       addresses.permit2,
       addresses.universalRouter,
     )
@@ -135,30 +136,46 @@ export class UniswapSwapProvider extends SwapProvider<UniswapSwapProviderConfig>
       assetOut,
     )
 
-    // Derive the exact-out max-in ceiling once and feed it (and the min-out
-    // floor) to the encoder so the displayed bounds and the bounds baked into
-    // calldata come from a single computation, not two that can diverge.
-    const amountInMaxRaw = amountOutRaw
-      ? this.computeAmountInMaxRaw(quote.amountInRaw, slippage)
-      : undefined
+    let amountInMaxRaw: bigint | undefined
+    let swapCalldata: Hex
 
-    const swapCalldata = encodeUniversalRouterSwap({
-      amountInRaw: amountOutRaw ? undefined : amountInRaw,
-      amountOutRaw,
-      assetIn,
-      assetOut,
-      amountOutMinRaw,
-      amountInMaxRaw,
-      deadline,
-      recipient,
-      chainId,
-      quote,
-      universalRouterAddress: addresses.universalRouter,
-      fee: marketConfig.fee,
-      tickSpacing: marketConfig.tickSpacing,
-    })
+    if (amountOutRaw !== undefined) {
+      amountInMaxRaw = this.computeAmountInMaxRaw(quote.amountInRaw, slippage)
+      swapCalldata = encodeUniversalRouterSwap({
+        amountOutRaw,
+        amountInMaxRaw,
+        assetIn,
+        assetOut,
+        deadline,
+        recipient,
+        chainId,
+        quote,
+        universalRouterAddress: addresses.universalRouter,
+        fee: marketConfig.fee,
+        tickSpacing: marketConfig.tickSpacing,
+      })
+    } else {
+      swapCalldata = encodeUniversalRouterSwap({
+        amountInRaw,
+        amountOutMinRaw,
+        assetIn,
+        assetOut,
+        deadline,
+        recipient,
+        chainId,
+        quote,
+        universalRouterAddress: addresses.universalRouter,
+        fee: marketConfig.fee,
+        tickSpacing: marketConfig.tickSpacing,
+      })
+    }
 
-    const finalAmountInRaw = amountOutRaw ? quote.amountInRaw : amountInRaw
+    const finalAmountInRaw =
+      amountOutRaw !== undefined ? quote.amountInRaw : amountInRaw
+
+    const executionValue = isNativeAsset(assetIn)
+      ? (amountInMaxRaw ?? finalAmountInRaw)
+      : 0n
 
     return {
       assetIn,
@@ -170,6 +187,7 @@ export class UniswapSwapProvider extends SwapProvider<UniswapSwapProviderConfig>
       amountOutRaw: quote.amountOutRaw,
       amountOutMin,
       amountOutMinRaw,
+      amountInMaxRaw,
       price: quote.amountOut / quote.amountIn,
       priceInverse: quote.amountIn / quote.amountOut,
       priceImpact: quote.priceImpact,
@@ -177,7 +195,7 @@ export class UniswapSwapProvider extends SwapProvider<UniswapSwapProviderConfig>
       execution: {
         swapCalldata,
         routerAddress: addresses.universalRouter,
-        value: isNativeAsset(assetIn) ? (amountInRaw ?? 0n) : 0n,
+        value: executionValue,
         providerContext: {
           fee: marketConfig.fee,
           tickSpacing: marketConfig.tickSpacing,

--- a/packages/sdk/src/actions/swap/providers/uniswap/UniswapSwapProvider.ts
+++ b/packages/sdk/src/actions/swap/providers/uniswap/UniswapSwapProvider.ts
@@ -1,4 +1,4 @@
-import { formatUnits, type Hex } from 'viem'
+import { formatUnits } from 'viem'
 
 import { expandMarkets, findMarket } from '@/actions/swap/core/markets.js'
 import { SwapProvider } from '@/actions/swap/core/SwapProvider.js'
@@ -136,43 +136,38 @@ export class UniswapSwapProvider extends SwapProvider<UniswapSwapProviderConfig>
       assetOut,
     )
 
-    let amountInMaxRaw: bigint | undefined
-    let swapCalldata: Hex
-
-    if (amountOutRaw !== undefined) {
-      amountInMaxRaw = this.computeAmountInMaxRaw(quote.amountInRaw, slippage)
-      swapCalldata = encodeUniversalRouterSwap({
-        amountOutRaw,
-        amountInMaxRaw,
-        assetIn,
-        assetOut,
-        deadline,
-        recipient,
-        chainId,
-        quote,
-        universalRouterAddress: addresses.universalRouter,
-        fee: marketConfig.fee,
-        tickSpacing: marketConfig.tickSpacing,
-      })
-    } else {
-      swapCalldata = encodeUniversalRouterSwap({
-        amountInRaw,
-        amountOutMinRaw,
-        assetIn,
-        assetOut,
-        deadline,
-        recipient,
-        chainId,
-        quote,
-        universalRouterAddress: addresses.universalRouter,
-        fee: marketConfig.fee,
-        tickSpacing: marketConfig.tickSpacing,
-      })
-    }
+    const swapAmounts =
+      amountOutRaw !== undefined
+        ? {
+            amountOutRaw,
+            amountInMaxRaw: this.computeAmountInMaxRaw(
+              quote.amountInRaw,
+              slippage,
+            ),
+          }
+        : {
+            amountInRaw,
+            amountOutMinRaw,
+          }
+    const amountInMaxRaw =
+      'amountInMaxRaw' in swapAmounts ? swapAmounts.amountInMaxRaw : undefined
+    const swapCalldata = encodeUniversalRouterSwap({
+      ...swapAmounts,
+      assetIn,
+      assetOut,
+      deadline,
+      recipient,
+      chainId,
+      quote,
+      universalRouterAddress: addresses.universalRouter,
+      fee: marketConfig.fee,
+      tickSpacing: marketConfig.tickSpacing,
+    })
 
     const finalAmountInRaw =
       amountOutRaw !== undefined ? quote.amountInRaw : amountInRaw
 
+    // Native exact-output swaps prepay max input because ETH has no approval path.
     const executionValue = isNativeAsset(assetIn)
       ? (amountInMaxRaw ?? finalAmountInRaw)
       : 0n

--- a/packages/sdk/src/actions/swap/providers/uniswap/__tests__/UniswapSwapProvider.test.ts
+++ b/packages/sdk/src/actions/swap/providers/uniswap/__tests__/UniswapSwapProvider.test.ts
@@ -1,13 +1,26 @@
-import type { Address, PublicClient } from 'viem'
+import {
+  type Address,
+  decodeAbiParameters,
+  decodeFunctionData,
+  erc20Abi,
+  type Hex,
+  type PublicClient,
+} from 'viem'
 import { baseSepolia } from 'viem/chains'
 import { describe, expect, it, vi } from 'vitest'
 
-import { MockWETHAsset } from '@/__mocks__/MockAssets.js'
+import { MockETHAsset, MockWETHAsset } from '@/__mocks__/MockAssets.js'
+import {
+  EXACT_INPUT_SINGLE_PARAMS,
+  EXACT_OUTPUT_SINGLE_PARAMS,
+  UNIVERSAL_ROUTER_ABI,
+} from '@/actions/swap/providers/uniswap/abis.js'
 import type { UniswapSwapProviderConfig } from '@/actions/swap/providers/uniswap/types.js'
 import { UniswapSwapProvider } from '@/actions/swap/providers/uniswap/UniswapSwapProvider.js'
 import type { SupportedChainId } from '@/constants/supportedChains.js'
 import type { ChainManager } from '@/services/ChainManager.js'
 import type { Asset } from '@/types/asset.js'
+import { PERMIT2_ABI } from '@/utils/abi/permit2.js'
 
 const CHAIN_ID = baseSepolia.id as SupportedChainId
 
@@ -27,10 +40,14 @@ const OP: Asset = {
   metadata: { name: 'Optimism', symbol: 'OP', decimals: 18 },
 }
 
-function createMockChainManager(): ChainManager {
+const WALLET = '0x4444444444444444444444444444444444444444' as Address
+
+function createMockChainManager(
+  quoteResult = 500000000000000000n,
+): ChainManager {
   const mockPublicClient = {
     simulateContract: vi.fn().mockResolvedValue({
-      result: [500000000000000000n, 150000n],
+      result: [quoteResult, 150000n],
     }),
     readContract: vi
       .fn()
@@ -56,6 +73,7 @@ function createMockChainManager(): ChainManager {
 
 function createProvider(
   configOverrides?: Partial<UniswapSwapProviderConfig>,
+  quoteResult?: bigint,
 ): UniswapSwapProvider {
   const config: UniswapSwapProviderConfig = {
     defaultSlippage: 0.005,
@@ -64,7 +82,81 @@ function createProvider(
     ],
     ...configOverrides,
   }
-  return new UniswapSwapProvider(config, createMockChainManager())
+  return new UniswapSwapProvider(config, createMockChainManager(quoteResult))
+}
+
+const isHex = (value: unknown): value is Hex =>
+  typeof value === 'string' && /^0x[0-9a-fA-F]*$/.test(value)
+
+const isReadonlyArray = (value: unknown): value is readonly unknown[] =>
+  Array.isArray(value)
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+function expectHex(value: unknown, label: string): Hex {
+  if (!isHex(value)) throw new Error(`${label} is not hex`)
+  return value
+}
+
+function expectBigInt(value: unknown, label: string): bigint {
+  if (typeof value !== 'bigint') throw new Error(`${label} is not bigint`)
+  return value
+}
+
+function decodeRouterInput(calldata: Hex): Hex {
+  const { functionName, args } = decodeFunctionData({
+    abi: UNIVERSAL_ROUTER_ABI,
+    data: calldata,
+  })
+  expect(functionName).toBe('execute')
+  if (!isReadonlyArray(args) || !isReadonlyArray(args[1])) {
+    throw new Error('execute args are malformed')
+  }
+  return expectHex(args[1][0], 'router input')
+}
+
+function decodeV4SwapParams(calldata: Hex): readonly unknown[] {
+  const [, swapParams] = decodeAbiParameters(
+    [{ type: 'bytes' }, { type: 'bytes[]' }],
+    decodeRouterInput(calldata),
+  )
+  if (!isReadonlyArray(swapParams)) {
+    throw new Error('V4 swap params are malformed')
+  }
+  return swapParams
+}
+
+function decodeMinAmountOut(calldata: Hex): bigint {
+  const [swap] = decodeAbiParameters(
+    EXACT_INPUT_SINGLE_PARAMS,
+    expectHex(decodeV4SwapParams(calldata)[0], 'exact-in params'),
+  )
+  if (!isRecord(swap)) throw new Error('exact-in swap is malformed')
+  return expectBigInt(swap.amountOutMinimum, 'amountOutMinimum')
+}
+
+function decodeMaxAmountIn(calldata: Hex): bigint {
+  const [swap] = decodeAbiParameters(
+    EXACT_OUTPUT_SINGLE_PARAMS,
+    expectHex(decodeV4SwapParams(calldata)[0], 'exact-out params'),
+  )
+  if (!isRecord(swap)) throw new Error('exact-out swap is malformed')
+  return expectBigInt(swap.amountInMaximum, 'amountInMaximum')
+}
+
+function decodeErc20ApprovalAmount(data: Hex): bigint {
+  const { functionName, args } = decodeFunctionData({ abi: erc20Abi, data })
+  expect(functionName).toBe('approve')
+  if (!isReadonlyArray(args)) throw new Error('ERC20 approve args malformed')
+  return expectBigInt(args[1], 'ERC20 approval amount')
+}
+
+function decodePermit2ApprovalAmount(data: Hex): bigint {
+  const { functionName, args } = decodeFunctionData({ abi: PERMIT2_ABI, data })
+  expect(functionName).toBe('approve')
+  if (!isReadonlyArray(args)) throw new Error('Permit2 approve args malformed')
+  return expectBigInt(args[2], 'Permit2 approval amount')
 }
 
 describe('UniswapSwapProvider', () => {
@@ -142,6 +234,106 @@ describe('UniswapSwapProvider', () => {
       expect(quote.amountOut).toBeDefined()
       expect(quote.route.path).toEqual([USDC, OP])
       expect(quote.execution).toBeDefined()
+    })
+
+    it('encodes the provider-derived exact-in min-out bound', async () => {
+      const provider = createProvider()
+      const quote = await provider.getQuote({
+        assetIn: USDC,
+        assetOut: OP,
+        amountIn: 100,
+        chainId: CHAIN_ID,
+        slippage: 0.005,
+      })
+
+      expect(decodeMinAmountOut(quote.execution.swapCalldata)).toBe(
+        quote.amountOutMinRaw,
+      )
+      expect(quote.amountInMaxRaw).toBeUndefined()
+    })
+
+    it('encodes the provider-derived exact-out max-in bound', async () => {
+      const provider = createProvider(undefined, 100000000n)
+      const quote = await provider.getQuote({
+        assetIn: USDC,
+        assetOut: OP,
+        amountOut: 0.5,
+        chainId: CHAIN_ID,
+        slippage: 0.005,
+      })
+
+      expect(quote.amountInMaxRaw).toBe(100500000n)
+      expect(decodeMaxAmountIn(quote.execution.swapCalldata)).toBe(
+        quote.amountInMaxRaw,
+      )
+    })
+
+    it('uses exact-output max-in for exact approvals', async () => {
+      const provider = createProvider(undefined, 100000000n)
+      const quote = await provider.getQuote({
+        assetIn: USDC,
+        assetOut: OP,
+        amountOut: 0.5,
+        chainId: CHAIN_ID,
+        slippage: 0.005,
+        recipient: WALLET,
+      })
+      const amountInMaxRaw = quote.amountInMaxRaw
+      if (amountInMaxRaw === undefined) {
+        throw new Error('Expected exact-output quote to include amountInMaxRaw')
+      }
+
+      const transaction = await provider.execute({
+        ...quote,
+        approvalMode: 'exact',
+      })
+      const { tokenApproval, permit2Approval, swap } =
+        transaction.transactionData
+      if (!tokenApproval || !permit2Approval) {
+        throw new Error('Expected exact ERC20 and Permit2 approvals')
+      }
+
+      expect(decodeMaxAmountIn(swap.data)).toBe(amountInMaxRaw)
+      expect(decodeErc20ApprovalAmount(tokenApproval.data)).toBe(amountInMaxRaw)
+      expect(decodePermit2ApprovalAmount(permit2Approval.data)).toBe(
+        amountInMaxRaw,
+      )
+    })
+
+    it('uses exact-output max-in as native input value', async () => {
+      const provider = createProvider(
+        {
+          marketAllowlist: [
+            {
+              assets: [MockETHAsset, OP],
+              fee: 100,
+              tickSpacing: 2,
+              chainId: CHAIN_ID,
+            },
+          ],
+        },
+        123000000000000000n,
+      )
+      const quote = await provider.getQuote({
+        assetIn: MockETHAsset,
+        assetOut: OP,
+        amountOut: 0.5,
+        chainId: CHAIN_ID,
+        slippage: 0.005,
+        recipient: WALLET,
+      })
+      const amountInMaxRaw = quote.amountInMaxRaw
+      if (amountInMaxRaw === undefined) {
+        throw new Error('Expected exact-output quote to include amountInMaxRaw')
+      }
+
+      const transaction = await provider.execute(quote)
+
+      expect(quote.execution.value).toBe(amountInMaxRaw)
+      expect(transaction.transactionData.swap.value).toBe(amountInMaxRaw)
+      expect(decodeMaxAmountIn(quote.execution.swapCalldata)).toBe(
+        amountInMaxRaw,
+      )
     })
 
     it('defaults to 1 unit when no amount specified', async () => {

--- a/packages/sdk/src/actions/swap/providers/uniswap/__tests__/UniswapSwapProvider.test.ts
+++ b/packages/sdk/src/actions/swap/providers/uniswap/__tests__/UniswapSwapProvider.test.ts
@@ -1,6 +1,5 @@
 import {
   type Address,
-  decodeAbiParameters,
   decodeFunctionData,
   erc20Abi,
   type Hex,
@@ -10,17 +9,19 @@ import { baseSepolia } from 'viem/chains'
 import { describe, expect, it, vi } from 'vitest'
 
 import { MockETHAsset, MockWETHAsset } from '@/__mocks__/MockAssets.js'
-import {
-  EXACT_INPUT_SINGLE_PARAMS,
-  EXACT_OUTPUT_SINGLE_PARAMS,
-  UNIVERSAL_ROUTER_ABI,
-} from '@/actions/swap/providers/uniswap/abis.js'
 import type { UniswapSwapProviderConfig } from '@/actions/swap/providers/uniswap/types.js'
 import { UniswapSwapProvider } from '@/actions/swap/providers/uniswap/UniswapSwapProvider.js'
 import type { SupportedChainId } from '@/constants/supportedChains.js'
 import type { ChainManager } from '@/services/ChainManager.js'
 import type { Asset } from '@/types/asset.js'
 import { PERMIT2_ABI } from '@/utils/abi/permit2.js'
+
+import {
+  decodeMaxAmountIn,
+  decodeMinAmountOut,
+  expectBigInt,
+  isReadonlyArray,
+} from './calldataTestUtils.js'
 
 const CHAIN_ID = baseSepolia.id as SupportedChainId
 
@@ -83,66 +84,6 @@ function createProvider(
     ...configOverrides,
   }
   return new UniswapSwapProvider(config, createMockChainManager(quoteResult))
-}
-
-const isHex = (value: unknown): value is Hex =>
-  typeof value === 'string' && /^0x[0-9a-fA-F]*$/.test(value)
-
-const isReadonlyArray = (value: unknown): value is readonly unknown[] =>
-  Array.isArray(value)
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === 'object' && value !== null && !Array.isArray(value)
-
-function expectHex(value: unknown, label: string): Hex {
-  if (!isHex(value)) throw new Error(`${label} is not hex`)
-  return value
-}
-
-function expectBigInt(value: unknown, label: string): bigint {
-  if (typeof value !== 'bigint') throw new Error(`${label} is not bigint`)
-  return value
-}
-
-function decodeRouterInput(calldata: Hex): Hex {
-  const { functionName, args } = decodeFunctionData({
-    abi: UNIVERSAL_ROUTER_ABI,
-    data: calldata,
-  })
-  expect(functionName).toBe('execute')
-  if (!isReadonlyArray(args) || !isReadonlyArray(args[1])) {
-    throw new Error('execute args are malformed')
-  }
-  return expectHex(args[1][0], 'router input')
-}
-
-function decodeV4SwapParams(calldata: Hex): readonly unknown[] {
-  const [, swapParams] = decodeAbiParameters(
-    [{ type: 'bytes' }, { type: 'bytes[]' }],
-    decodeRouterInput(calldata),
-  )
-  if (!isReadonlyArray(swapParams)) {
-    throw new Error('V4 swap params are malformed')
-  }
-  return swapParams
-}
-
-function decodeMinAmountOut(calldata: Hex): bigint {
-  const [swap] = decodeAbiParameters(
-    EXACT_INPUT_SINGLE_PARAMS,
-    expectHex(decodeV4SwapParams(calldata)[0], 'exact-in params'),
-  )
-  if (!isRecord(swap)) throw new Error('exact-in swap is malformed')
-  return expectBigInt(swap.amountOutMinimum, 'amountOutMinimum')
-}
-
-function decodeMaxAmountIn(calldata: Hex): bigint {
-  const [swap] = decodeAbiParameters(
-    EXACT_OUTPUT_SINGLE_PARAMS,
-    expectHex(decodeV4SwapParams(calldata)[0], 'exact-out params'),
-  )
-  if (!isRecord(swap)) throw new Error('exact-out swap is malformed')
-  return expectBigInt(swap.amountInMaximum, 'amountInMaximum')
 }
 
 function decodeErc20ApprovalAmount(data: Hex): bigint {

--- a/packages/sdk/src/actions/swap/providers/uniswap/__tests__/calldataTestUtils.ts
+++ b/packages/sdk/src/actions/swap/providers/uniswap/__tests__/calldataTestUtils.ts
@@ -9,7 +9,7 @@ import {
 export const isReadonlyArray = (value: unknown): value is readonly unknown[] =>
   Array.isArray(value)
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
+export const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value)
 
 export function expectHex(value: unknown, label: string): Hex {

--- a/packages/sdk/src/actions/swap/providers/uniswap/__tests__/calldataTestUtils.ts
+++ b/packages/sdk/src/actions/swap/providers/uniswap/__tests__/calldataTestUtils.ts
@@ -1,0 +1,64 @@
+import { decodeAbiParameters, decodeFunctionData, type Hex, isHex } from 'viem'
+
+import {
+  EXACT_INPUT_SINGLE_PARAMS,
+  EXACT_OUTPUT_SINGLE_PARAMS,
+  UNIVERSAL_ROUTER_ABI,
+} from '@/actions/swap/providers/uniswap/abis.js'
+
+export const isReadonlyArray = (value: unknown): value is readonly unknown[] =>
+  Array.isArray(value)
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+export function expectHex(value: unknown, label: string): Hex {
+  if (!isHex(value)) throw new Error(`${label} is not hex`)
+  return value
+}
+
+export function expectBigInt(value: unknown, label: string): bigint {
+  if (typeof value !== 'bigint') throw new Error(`${label} is not bigint`)
+  return value
+}
+
+export function decodeRouterInput(calldata: Hex): Hex {
+  const { functionName, args } = decodeFunctionData({
+    abi: UNIVERSAL_ROUTER_ABI,
+    data: calldata,
+  })
+  if (functionName !== 'execute') throw new Error('router call is not execute')
+  if (!isReadonlyArray(args) || !isReadonlyArray(args[1])) {
+    throw new Error('execute args are malformed')
+  }
+  return expectHex(args[1][0], 'router input')
+}
+
+export function decodeV4SwapParams(calldata: Hex): readonly unknown[] {
+  const [, swapParams] = decodeAbiParameters(
+    [{ type: 'bytes' }, { type: 'bytes[]' }],
+    decodeRouterInput(calldata),
+  )
+  if (!isReadonlyArray(swapParams)) {
+    throw new Error('V4 swap params are malformed')
+  }
+  return swapParams
+}
+
+export function decodeMinAmountOut(calldata: Hex): bigint {
+  const [swap] = decodeAbiParameters(
+    EXACT_INPUT_SINGLE_PARAMS,
+    expectHex(decodeV4SwapParams(calldata)[0], 'exact-in params'),
+  )
+  if (!isRecord(swap)) throw new Error('exact-in swap is malformed')
+  return expectBigInt(swap.amountOutMinimum, 'amountOutMinimum')
+}
+
+export function decodeMaxAmountIn(calldata: Hex): bigint {
+  const [swap] = decodeAbiParameters(
+    EXACT_OUTPUT_SINGLE_PARAMS,
+    expectHex(decodeV4SwapParams(calldata)[0], 'exact-out params'),
+  )
+  if (!isRecord(swap)) throw new Error('exact-out swap is malformed')
+  return expectBigInt(swap.amountInMaximum, 'amountInMaximum')
+}

--- a/packages/sdk/src/actions/swap/providers/uniswap/__tests__/sdk.test.ts
+++ b/packages/sdk/src/actions/swap/providers/uniswap/__tests__/sdk.test.ts
@@ -1,18 +1,13 @@
 import {
   type Address,
   decodeAbiParameters,
-  decodeFunctionData,
   type Hex,
+  isAddress,
   type PublicClient,
   zeroAddress,
 } from 'viem'
 import { describe, expect, it, vi } from 'vitest'
 
-import {
-  EXACT_INPUT_SINGLE_PARAMS,
-  EXACT_OUTPUT_SINGLE_PARAMS,
-  UNIVERSAL_ROUTER_ABI,
-} from '@/actions/swap/providers/uniswap/abis.js'
 import {
   calculatePriceImpact,
   encodeUniversalRouterSwap,
@@ -20,6 +15,14 @@ import {
 } from '@/actions/swap/providers/uniswap/encoding.js'
 import type { SupportedChainId } from '@/constants/supportedChains.js'
 import type { Asset } from '@/types/asset.js'
+
+import {
+  decodeMaxAmountIn,
+  decodeMinAmountOut,
+  decodeRouterInput,
+  expectHex,
+  isReadonlyArray,
+} from './calldataTestUtils.js'
 
 const USDC: Asset = {
   type: 'erc20',
@@ -61,6 +64,34 @@ function createMockPublicClient(
     }),
     readContract: vi.fn().mockResolvedValue(MOCK_SQRT_PRICE),
   } as unknown as PublicClient
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+function expectContractArgs(value: unknown): readonly unknown[] {
+  if (!isRecord(value) || !isReadonlyArray(value.args)) {
+    throw new Error('contract call args are malformed')
+  }
+  return value.args
+}
+
+function expectPoolKeyArgs(value: unknown): {
+  poolKey: { currency0: Address; currency1: Address }
+} {
+  if (!isRecord(value) || !isRecord(value.poolKey)) {
+    throw new Error('pool key args are malformed')
+  }
+  const { currency0, currency1 } = value.poolKey
+  if (
+    typeof currency0 !== 'string' ||
+    typeof currency1 !== 'string' ||
+    !isAddress(currency0) ||
+    !isAddress(currency1)
+  ) {
+    throw new Error('pool key currencies are malformed')
+  }
+  return { poolKey: { currency0, currency1 } }
 }
 
 describe('getQuote', () => {
@@ -143,7 +174,7 @@ describe('getQuote', () => {
     })
 
     const call = vi.mocked(publicClient.simulateContract).mock.calls[0][0]
-    const args = (call as any).args[0]
+    const args = expectPoolKeyArgs(expectContractArgs(call)[0])
     // currency0 should be the lower address
     expect(
       args.poolKey.currency0.toLowerCase() <
@@ -166,7 +197,7 @@ describe('getQuote', () => {
     })
 
     const call = vi.mocked(publicClient.simulateContract).mock.calls[0][0]
-    const args = (call as any).args[0]
+    const args = expectPoolKeyArgs(expectContractArgs(call)[0])
     // Native ETH should be address(0), sorted as currency0 (lowest possible address)
     expect(args.poolKey.currency0).toBe(zeroAddress)
   })
@@ -186,7 +217,7 @@ describe('getQuote', () => {
     })
 
     const call = vi.mocked(publicClient.simulateContract).mock.calls[0][0]
-    const args = (call as any).args[0]
+    const args = expectPoolKeyArgs(expectContractArgs(call)[0])
     // Native ETH should be address(0) regardless of swap direction
     expect(args.poolKey.currency0).toBe(zeroAddress)
   })
@@ -279,68 +310,6 @@ describe('encodeUniversalRouterSwap', () => {
   // Provider-derived bounds for baseQuote at 0.5% slippage.
   const AMOUNT_OUT_MIN = 497500000000000000n
   const AMOUNT_IN_MAX = 100500000n
-
-  const isHex = (value: unknown): value is Hex =>
-    typeof value === 'string' && /^0x[0-9a-fA-F]*$/.test(value)
-
-  const isReadonlyArray = (value: unknown): value is readonly unknown[] =>
-    Array.isArray(value)
-
-  const isRecord = (value: unknown): value is Record<string, unknown> =>
-    typeof value === 'object' && value !== null && !Array.isArray(value)
-
-  const expectHex = (value: unknown, label: string): Hex => {
-    if (!isHex(value)) throw new Error(`${label} is not hex`)
-    return value
-  }
-
-  const expectBigInt = (value: unknown, label: string): bigint => {
-    if (typeof value !== 'bigint') throw new Error(`${label} is not bigint`)
-    return value
-  }
-
-  const decodeRouterInput = (calldata: Hex): Hex => {
-    const { functionName, args } = decodeFunctionData({
-      abi: UNIVERSAL_ROUTER_ABI,
-      data: calldata,
-    })
-    expect(functionName).toBe('execute')
-    if (!isReadonlyArray(args) || !isReadonlyArray(args[1])) {
-      throw new Error('execute args are malformed')
-    }
-    return expectHex(args[1][0], 'router input')
-  }
-
-  const decodeV4SwapParams = (calldata: Hex): readonly unknown[] => {
-    const [, swapParams] = decodeAbiParameters(
-      [{ type: 'bytes' }, { type: 'bytes[]' }],
-      decodeRouterInput(calldata),
-    )
-    if (!isReadonlyArray(swapParams)) {
-      throw new Error('V4 swap params are malformed')
-    }
-    return swapParams
-  }
-
-  /** Decode the amountOutMinimum baked into exact-in calldata. */
-  const decodeMinAmountOut = (calldata: Hex): bigint => {
-    const [swap] = decodeAbiParameters(
-      EXACT_INPUT_SINGLE_PARAMS,
-      expectHex(decodeV4SwapParams(calldata)[0], 'exact-in params'),
-    )
-    if (!isRecord(swap)) throw new Error('exact-in swap is malformed')
-    return expectBigInt(swap.amountOutMinimum, 'amountOutMinimum')
-  }
-
-  /** Decode the amountInMaximum baked into exact-out calldata. */
-  const decodeMaxAmountIn = (calldata: Hex): bigint => {
-    const [swap] = decodeAbiParameters(
-      EXACT_OUTPUT_SINGLE_PARAMS,
-      expectHex(decodeV4SwapParams(calldata)[0], 'exact-out params'),
-    )
-    if (!isRecord(swap)) throw new Error('exact-out swap is malformed')
-    return expectBigInt(swap.amountInMaximum, 'amountInMaximum')
-  }
 
   it('encodes exact-in swap calldata', () => {
     const calldata = encodeUniversalRouterSwap({

--- a/packages/sdk/src/actions/swap/providers/uniswap/__tests__/sdk.test.ts
+++ b/packages/sdk/src/actions/swap/providers/uniswap/__tests__/sdk.test.ts
@@ -7,7 +7,11 @@ import {
 } from 'viem'
 import { describe, expect, it, vi } from 'vitest'
 
-import { UNIVERSAL_ROUTER_ABI } from '@/actions/swap/providers/uniswap/abis.js'
+import {
+  EXACT_INPUT_SINGLE_PARAMS,
+  EXACT_OUTPUT_SINGLE_PARAMS,
+  UNIVERSAL_ROUTER_ABI,
+} from '@/actions/swap/providers/uniswap/abis.js'
 import {
   calculatePriceImpact,
   encodeUniversalRouterSwap,
@@ -271,12 +275,62 @@ describe('encodeUniversalRouterSwap', () => {
     gasEstimate: 150000n,
   }
 
+  // Provider-derived bounds for baseQuote at 0.5% slippage:
+  //   amountOutMinRaw = 500000000000000000 * 9950/10000
+  //   amountInMaxRaw  = 100000000 + 100000000 * 50/10000
+  const AMOUNT_OUT_MIN = 497500000000000000n
+  const AMOUNT_IN_MAX = 100500000n
+
+  /** Decode the amountOutMinimum baked into exact-in calldata. */
+  const decodeMinAmountOut = (calldata: `0x${string}`): bigint => {
+    const { args } = decodeFunctionData({
+      abi: UNIVERSAL_ROUTER_ABI,
+      data: calldata,
+    })
+    const [, inputs] = args as readonly [
+      `0x${string}`,
+      ReadonlyArray<`0x${string}`>,
+      bigint,
+    ]
+    const [, swapParams] = decodeAbiParameters(
+      [{ type: 'bytes' }, { type: 'bytes[]' }],
+      inputs[0]!,
+    )
+    const [swap] = decodeAbiParameters(
+      EXACT_INPUT_SINGLE_PARAMS,
+      (swapParams as ReadonlyArray<`0x${string}`>)[0]!,
+    )
+    return (swap as { amountOutMinimum: bigint }).amountOutMinimum
+  }
+
+  /** Decode the amountInMaximum baked into exact-out calldata. */
+  const decodeMaxAmountIn = (calldata: `0x${string}`): bigint => {
+    const { args } = decodeFunctionData({
+      abi: UNIVERSAL_ROUTER_ABI,
+      data: calldata,
+    })
+    const [, inputs] = args as readonly [
+      `0x${string}`,
+      ReadonlyArray<`0x${string}`>,
+      bigint,
+    ]
+    const [, swapParams] = decodeAbiParameters(
+      [{ type: 'bytes' }, { type: 'bytes[]' }],
+      inputs[0]!,
+    )
+    const [swap] = decodeAbiParameters(
+      EXACT_OUTPUT_SINGLE_PARAMS,
+      (swapParams as ReadonlyArray<`0x${string}`>)[0]!,
+    )
+    return (swap as { amountInMaximum: bigint }).amountInMaximum
+  }
+
   it('encodes exact-in swap calldata', () => {
     const calldata = encodeUniversalRouterSwap({
       amountInRaw: 100000000n,
       assetIn: USDC,
       assetOut: WETH,
-      slippage: 0.005,
+      amountOutMinRaw: AMOUNT_OUT_MIN,
       deadline: 1700000000,
       recipient: '0xrecipient' as Address,
       chainId: CHAIN_ID,
@@ -295,7 +349,7 @@ describe('encodeUniversalRouterSwap', () => {
       amountOutRaw: 500000000000000000n,
       assetIn: USDC,
       assetOut: WETH,
-      slippage: 0.005,
+      amountInMaxRaw: AMOUNT_IN_MAX,
       deadline: 1700000000,
       recipient: '0xrecipient' as Address,
       chainId: CHAIN_ID,
@@ -307,6 +361,72 @@ describe('encodeUniversalRouterSwap', () => {
 
     expect(calldata).toMatch(/^0x/)
     expect(calldata.length).toBeGreaterThan(10)
+  })
+
+  it('bakes the provider-derived bound into calldata without recomputing (F005)', () => {
+    const exactIn = encodeUniversalRouterSwap({
+      amountInRaw: 100000000n,
+      assetIn: USDC,
+      assetOut: WETH,
+      amountOutMinRaw: AMOUNT_OUT_MIN,
+      deadline: 1700000000,
+      recipient: '0xrecipient' as Address,
+      chainId: CHAIN_ID,
+      quote: baseQuote,
+      universalRouterAddress: '0xrouter' as Address,
+      fee: FEE,
+      tickSpacing: TICK_SPACING,
+    })
+    expect(decodeMinAmountOut(exactIn)).toBe(AMOUNT_OUT_MIN)
+
+    const exactOut = encodeUniversalRouterSwap({
+      amountOutRaw: 500000000000000000n,
+      assetIn: USDC,
+      assetOut: WETH,
+      amountInMaxRaw: AMOUNT_IN_MAX,
+      deadline: 1700000000,
+      recipient: '0xrecipient' as Address,
+      chainId: CHAIN_ID,
+      quote: baseQuote,
+      universalRouterAddress: '0xrouter' as Address,
+      fee: FEE,
+      tickSpacing: TICK_SPACING,
+    })
+    expect(decodeMaxAmountIn(exactOut)).toBe(AMOUNT_IN_MAX)
+  })
+
+  it('throws when the exact-in min-out floor is not supplied', () => {
+    expect(() =>
+      encodeUniversalRouterSwap({
+        amountInRaw: 100000000n,
+        assetIn: USDC,
+        assetOut: WETH,
+        deadline: 1700000000,
+        recipient: '0xrecipient' as Address,
+        chainId: CHAIN_ID,
+        quote: baseQuote,
+        universalRouterAddress: '0xrouter' as Address,
+        fee: FEE,
+        tickSpacing: TICK_SPACING,
+      }),
+    ).toThrow(/amountOutMinRaw/)
+  })
+
+  it('throws when the exact-out max-in ceiling is not supplied', () => {
+    expect(() =>
+      encodeUniversalRouterSwap({
+        amountOutRaw: 500000000000000000n,
+        assetIn: USDC,
+        assetOut: WETH,
+        deadline: 1700000000,
+        recipient: '0xrecipient' as Address,
+        chainId: CHAIN_ID,
+        quote: baseQuote,
+        universalRouterAddress: '0xrouter' as Address,
+        fee: FEE,
+        tickSpacing: TICK_SPACING,
+      }),
+    ).toThrow(/amountInMaxRaw/)
   })
 
   it('tags V4 action bytes per Uniswap v4-periphery Actions.sol', () => {
@@ -337,7 +457,7 @@ describe('encodeUniversalRouterSwap', () => {
       amountInRaw: 100000000n,
       assetIn: USDC,
       assetOut: WETH,
-      slippage: 0.005,
+      amountOutMinRaw: AMOUNT_OUT_MIN,
       deadline: 1700000000,
       recipient: '0xrecipient' as Address,
       chainId: CHAIN_ID,
@@ -352,7 +472,7 @@ describe('encodeUniversalRouterSwap', () => {
       amountOutRaw: 500000000000000000n,
       assetIn: USDC,
       assetOut: WETH,
-      slippage: 0.005,
+      amountInMaxRaw: AMOUNT_IN_MAX,
       deadline: 1700000000,
       recipient: '0xrecipient' as Address,
       chainId: CHAIN_ID,
@@ -369,7 +489,7 @@ describe('encodeUniversalRouterSwap', () => {
       amountInRaw: 100000000n,
       assetIn: USDC,
       assetOut: WETH,
-      slippage: 0.005,
+      amountOutMinRaw: AMOUNT_OUT_MIN,
       deadline: 1700000000,
       recipient: '0xrecipient' as Address,
       chainId: CHAIN_ID,
@@ -383,7 +503,7 @@ describe('encodeUniversalRouterSwap', () => {
       amountOutRaw: 500000000000000000n,
       assetIn: USDC,
       assetOut: WETH,
-      slippage: 0.005,
+      amountInMaxRaw: AMOUNT_IN_MAX,
       deadline: 1700000000,
       recipient: '0xrecipient' as Address,
       chainId: CHAIN_ID,
@@ -396,12 +516,12 @@ describe('encodeUniversalRouterSwap', () => {
     expect(exactIn).not.toBe(exactOut)
   })
 
-  it('applies slippage to minimum output for exact-in', () => {
+  it('reflects a different min-out floor in exact-in calldata', () => {
     const noSlippage = encodeUniversalRouterSwap({
       amountInRaw: 100000000n,
       assetIn: USDC,
       assetOut: WETH,
-      slippage: 0,
+      amountOutMinRaw: 500000000000000000n, // 0% slippage → full quoted out
       deadline: 1700000000,
       recipient: '0xrecipient' as Address,
       chainId: CHAIN_ID,
@@ -415,7 +535,7 @@ describe('encodeUniversalRouterSwap', () => {
       amountInRaw: 100000000n,
       assetIn: USDC,
       assetOut: WETH,
-      slippage: 0.05, // 5%
+      amountOutMinRaw: 475000000000000000n, // 5% slippage
       deadline: 1700000000,
       recipient: '0xrecipient' as Address,
       chainId: CHAIN_ID,
@@ -425,7 +545,9 @@ describe('encodeUniversalRouterSwap', () => {
       tickSpacing: TICK_SPACING,
     })
 
-    // Different slippage should produce different calldata
+    // A lower floor must produce different calldata.
     expect(noSlippage).not.toBe(withSlippage)
+    expect(decodeMinAmountOut(noSlippage)).toBe(500000000000000000n)
+    expect(decodeMinAmountOut(withSlippage)).toBe(475000000000000000n)
   })
 })

--- a/packages/sdk/src/actions/swap/providers/uniswap/__tests__/sdk.test.ts
+++ b/packages/sdk/src/actions/swap/providers/uniswap/__tests__/sdk.test.ts
@@ -22,6 +22,7 @@ import {
   decodeRouterInput,
   expectHex,
   isReadonlyArray,
+  isRecord,
 } from './calldataTestUtils.js'
 
 const USDC: Asset = {
@@ -65,9 +66,6 @@ function createMockPublicClient(
     readContract: vi.fn().mockResolvedValue(MOCK_SQRT_PRICE),
   } as unknown as PublicClient
 }
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === 'object' && value !== null && !Array.isArray(value)
 
 function expectContractArgs(value: unknown): readonly unknown[] {
   if (!isRecord(value) || !isReadonlyArray(value.args)) {

--- a/packages/sdk/src/actions/swap/providers/uniswap/__tests__/sdk.test.ts
+++ b/packages/sdk/src/actions/swap/providers/uniswap/__tests__/sdk.test.ts
@@ -276,9 +276,7 @@ describe('encodeUniversalRouterSwap', () => {
     gasEstimate: 150000n,
   }
 
-  // Provider-derived bounds for baseQuote at 0.5% slippage:
-  //   amountOutMinRaw = 500000000000000000 * 9950/10000
-  //   amountInMaxRaw  = 100000000 + 100000000 * 50/10000
+  // Provider-derived bounds for baseQuote at 0.5% slippage.
   const AMOUNT_OUT_MIN = 497500000000000000n
   const AMOUNT_IN_MAX = 100500000n
 
@@ -382,7 +380,7 @@ describe('encodeUniversalRouterSwap', () => {
     expect(calldata.length).toBeGreaterThan(10)
   })
 
-  it('bakes the provider-derived bound into calldata without recomputing (F005)', () => {
+  it('bakes the provider-derived bound into calldata without recomputing', () => {
     const exactIn = encodeUniversalRouterSwap({
       amountInRaw: 100000000n,
       assetIn: USDC,

--- a/packages/sdk/src/actions/swap/providers/uniswap/__tests__/sdk.test.ts
+++ b/packages/sdk/src/actions/swap/providers/uniswap/__tests__/sdk.test.ts
@@ -2,6 +2,7 @@ import {
   type Address,
   decodeAbiParameters,
   decodeFunctionData,
+  type Hex,
   type PublicClient,
   zeroAddress,
 } from 'viem'
@@ -281,48 +282,66 @@ describe('encodeUniversalRouterSwap', () => {
   const AMOUNT_OUT_MIN = 497500000000000000n
   const AMOUNT_IN_MAX = 100500000n
 
-  /** Decode the amountOutMinimum baked into exact-in calldata. */
-  const decodeMinAmountOut = (calldata: `0x${string}`): bigint => {
-    const { args } = decodeFunctionData({
+  const isHex = (value: unknown): value is Hex =>
+    typeof value === 'string' && /^0x[0-9a-fA-F]*$/.test(value)
+
+  const isReadonlyArray = (value: unknown): value is readonly unknown[] =>
+    Array.isArray(value)
+
+  const isRecord = (value: unknown): value is Record<string, unknown> =>
+    typeof value === 'object' && value !== null && !Array.isArray(value)
+
+  const expectHex = (value: unknown, label: string): Hex => {
+    if (!isHex(value)) throw new Error(`${label} is not hex`)
+    return value
+  }
+
+  const expectBigInt = (value: unknown, label: string): bigint => {
+    if (typeof value !== 'bigint') throw new Error(`${label} is not bigint`)
+    return value
+  }
+
+  const decodeRouterInput = (calldata: Hex): Hex => {
+    const { functionName, args } = decodeFunctionData({
       abi: UNIVERSAL_ROUTER_ABI,
       data: calldata,
     })
-    const [, inputs] = args as readonly [
-      `0x${string}`,
-      ReadonlyArray<`0x${string}`>,
-      bigint,
-    ]
+    expect(functionName).toBe('execute')
+    if (!isReadonlyArray(args) || !isReadonlyArray(args[1])) {
+      throw new Error('execute args are malformed')
+    }
+    return expectHex(args[1][0], 'router input')
+  }
+
+  const decodeV4SwapParams = (calldata: Hex): readonly unknown[] => {
     const [, swapParams] = decodeAbiParameters(
       [{ type: 'bytes' }, { type: 'bytes[]' }],
-      inputs[0]!,
+      decodeRouterInput(calldata),
     )
+    if (!isReadonlyArray(swapParams)) {
+      throw new Error('V4 swap params are malformed')
+    }
+    return swapParams
+  }
+
+  /** Decode the amountOutMinimum baked into exact-in calldata. */
+  const decodeMinAmountOut = (calldata: Hex): bigint => {
     const [swap] = decodeAbiParameters(
       EXACT_INPUT_SINGLE_PARAMS,
-      (swapParams as ReadonlyArray<`0x${string}`>)[0]!,
+      expectHex(decodeV4SwapParams(calldata)[0], 'exact-in params'),
     )
-    return (swap as { amountOutMinimum: bigint }).amountOutMinimum
+    if (!isRecord(swap)) throw new Error('exact-in swap is malformed')
+    return expectBigInt(swap.amountOutMinimum, 'amountOutMinimum')
   }
 
   /** Decode the amountInMaximum baked into exact-out calldata. */
-  const decodeMaxAmountIn = (calldata: `0x${string}`): bigint => {
-    const { args } = decodeFunctionData({
-      abi: UNIVERSAL_ROUTER_ABI,
-      data: calldata,
-    })
-    const [, inputs] = args as readonly [
-      `0x${string}`,
-      ReadonlyArray<`0x${string}`>,
-      bigint,
-    ]
-    const [, swapParams] = decodeAbiParameters(
-      [{ type: 'bytes' }, { type: 'bytes[]' }],
-      inputs[0]!,
-    )
+  const decodeMaxAmountIn = (calldata: Hex): bigint => {
     const [swap] = decodeAbiParameters(
       EXACT_OUTPUT_SINGLE_PARAMS,
-      (swapParams as ReadonlyArray<`0x${string}`>)[0]!,
+      expectHex(decodeV4SwapParams(calldata)[0], 'exact-out params'),
     )
-    return (swap as { amountInMaximum: bigint }).amountInMaximum
+    if (!isRecord(swap)) throw new Error('exact-out swap is malformed')
+    return expectBigInt(swap.amountInMaximum, 'amountInMaximum')
   }
 
   it('encodes exact-in swap calldata', () => {
@@ -397,6 +416,7 @@ describe('encodeUniversalRouterSwap', () => {
 
   it('throws when the exact-in min-out floor is not supplied', () => {
     expect(() =>
+      // @ts-expect-error amountOutMinRaw is required for exact-input swaps.
       encodeUniversalRouterSwap({
         amountInRaw: 100000000n,
         assetIn: USDC,
@@ -414,6 +434,7 @@ describe('encodeUniversalRouterSwap', () => {
 
   it('throws when the exact-out max-in ceiling is not supplied', () => {
     expect(() =>
+      // @ts-expect-error amountInMaxRaw is required for exact-output swaps.
       encodeUniversalRouterSwap({
         amountOutRaw: 500000000000000000n,
         assetIn: USDC,
@@ -436,21 +457,12 @@ describe('encodeUniversalRouterSwap', () => {
     // bare-reverted on pool lookup. Correct codes:
     //   0x06 SWAP_EXACT_IN_SINGLE
     //   0x08 SWAP_EXACT_OUT_SINGLE
-    const decodeActions = (calldata: `0x${string}`): `0x${string}` => {
-      const { args } = decodeFunctionData({
-        abi: UNIVERSAL_ROUTER_ABI,
-        data: calldata,
-      })
-      const [, inputs] = args as readonly [
-        `0x${string}`,
-        ReadonlyArray<`0x${string}`>,
-        bigint,
-      ]
+    const decodeActions = (calldata: Hex): Hex => {
       const [actions] = decodeAbiParameters(
         [{ type: 'bytes' }, { type: 'bytes[]' }],
-        inputs[0]!,
+        decodeRouterInput(calldata),
       )
-      return actions as `0x${string}`
+      return expectHex(actions, 'actions')
     }
 
     const exactIn = encodeUniversalRouterSwap({

--- a/packages/sdk/src/actions/swap/providers/uniswap/encoding.ts
+++ b/packages/sdk/src/actions/swap/providers/uniswap/encoding.ts
@@ -17,6 +17,7 @@ import {
   UNIVERSAL_ROUTER_ABI,
 } from '@/actions/swap/providers/uniswap/abis.js'
 import type { SupportedChainId } from '@/constants/supportedChains.js'
+import { InvalidParamsError } from '@/core/error/errors.js'
 import type { Asset } from '@/types/asset.js'
 import type { SwapPrice, SwapRoute } from '@/types/swap/index.js'
 import { getAssetAddress, isNativeAsset } from '@/utils/assets.js'
@@ -196,7 +197,17 @@ export interface EncodeSwapParams {
   amountOutRaw?: bigint
   assetIn: Asset
   assetOut: Asset
-  slippage: number
+  /**
+   * Provider-derived minimum output floor (exact-in). Required for exact-input
+   * swaps. Passed in (not recomputed from slippage) so the displayed bound and
+   * the bound baked into calldata are the same number.
+   */
+  amountOutMinRaw?: bigint
+  /**
+   * Provider-derived maximum input ceiling (exact-out). Required for
+   * exact-output swaps. Passed in for the same single-source-of-truth reason.
+   */
+  amountInMaxRaw?: bigint
   deadline: number
   recipient: Address
   chainId: SupportedChainId
@@ -226,7 +237,8 @@ export function encodeUniversalRouterSwap(params: EncodeSwapParams): Hex {
     amountInRaw,
     assetIn,
     assetOut,
-    slippage,
+    amountOutMinRaw,
+    amountInMaxRaw,
     deadline,
     chainId,
     quote,
@@ -248,8 +260,13 @@ export function encodeUniversalRouterSwap(params: EncodeSwapParams): Hex {
   let actionParams: Hex[]
 
   if (isExactInput) {
-    const minAmountOut =
-      (quote.amountOutRaw * BigInt(Math.round((1 - slippage) * 10000))) / 10000n
+    if (amountOutMinRaw === undefined) {
+      throw new InvalidParamsError({
+        param: 'amountOutMinRaw',
+        expected: 'a provider-derived min-out floor for an exact-input swap',
+      })
+    }
+    const minAmountOut = amountOutMinRaw
 
     actions =
       `0x${[SWAP_EXACT_IN_SINGLE, SETTLE_ALL, TAKE_ALL].map((a) => a.toString(16).padStart(2, '0')).join('')}` as Hex
@@ -268,9 +285,13 @@ export function encodeUniversalRouterSwap(params: EncodeSwapParams): Hex {
       encodeAbiParameters(CURRENCY_AMOUNT_PARAMS, [tokenOut, minAmountOut]),
     ]
   } else {
-    const maxAmountIn =
-      quote.amountInRaw +
-      (quote.amountInRaw * BigInt(Math.round(slippage * 10000))) / 10000n
+    if (amountInMaxRaw === undefined) {
+      throw new InvalidParamsError({
+        param: 'amountInMaxRaw',
+        expected: 'a provider-derived max-in ceiling for an exact-output swap',
+      })
+    }
+    const maxAmountIn = amountInMaxRaw
 
     actions =
       `0x${[SWAP_EXACT_OUT_SINGLE, SETTLE_ALL, TAKE_ALL].map((a) => a.toString(16).padStart(2, '0')).join('')}` as Hex

--- a/packages/sdk/src/actions/swap/providers/uniswap/encoding.ts
+++ b/packages/sdk/src/actions/swap/providers/uniswap/encoding.ts
@@ -210,7 +210,10 @@ export type EncodeSwapParams =
   | (EncodeSwapBaseParams & {
       amountInRaw: bigint
       amountOutRaw?: undefined
-      /** Provider-derived min-out floor for exact-input swaps. */
+      /**
+       * Provider-derived minimum output floor for exact-input swaps. Passed in
+       * so displayed and enforced bounds are the same number.
+       */
       amountOutMinRaw: bigint
       amountInMaxRaw?: undefined
     })
@@ -218,7 +221,10 @@ export type EncodeSwapParams =
       amountInRaw?: undefined
       amountOutRaw: bigint
       amountOutMinRaw?: undefined
-      /** Provider-derived max-in ceiling for exact-output swaps. */
+      /**
+       * Provider-derived maximum input ceiling for exact-output swaps. Passed
+       * in so approvals, native value, and calldata use the same number.
+       */
       amountInMaxRaw: bigint
     })
 

--- a/packages/sdk/src/actions/swap/providers/uniswap/encoding.ts
+++ b/packages/sdk/src/actions/swap/providers/uniswap/encoding.ts
@@ -210,10 +210,7 @@ export type EncodeSwapParams =
   | (EncodeSwapBaseParams & {
       amountInRaw: bigint
       amountOutRaw?: undefined
-      /**
-       * Provider-derived minimum output floor for exact-input swaps. Passed in
-       * so displayed and enforced bounds are the same number.
-       */
+      /** Provider-derived min-out floor for exact-input swaps. */
       amountOutMinRaw: bigint
       amountInMaxRaw?: undefined
     })
@@ -221,10 +218,7 @@ export type EncodeSwapParams =
       amountInRaw?: undefined
       amountOutRaw: bigint
       amountOutMinRaw?: undefined
-      /**
-       * Provider-derived maximum input ceiling for exact-output swaps. Passed
-       * in so approvals, native value, and calldata use the same number.
-       */
+      /** Provider-derived max-in ceiling for exact-output swaps. */
       amountInMaxRaw: bigint
     })
 

--- a/packages/sdk/src/actions/swap/providers/uniswap/encoding.ts
+++ b/packages/sdk/src/actions/swap/providers/uniswap/encoding.ts
@@ -192,22 +192,9 @@ export async function getQuote(params: GetQuoteParams): Promise<SwapPrice> {
   }
 }
 
-export interface EncodeSwapParams {
-  amountInRaw?: bigint
-  amountOutRaw?: bigint
+interface EncodeSwapBaseParams {
   assetIn: Asset
   assetOut: Asset
-  /**
-   * Provider-derived minimum output floor (exact-in). Required for exact-input
-   * swaps. Passed in (not recomputed from slippage) so the displayed bound and
-   * the bound baked into calldata are the same number.
-   */
-  amountOutMinRaw?: bigint
-  /**
-   * Provider-derived maximum input ceiling (exact-out). Required for
-   * exact-output swaps. Passed in for the same single-source-of-truth reason.
-   */
-  amountInMaxRaw?: bigint
   deadline: number
   recipient: Address
   chainId: SupportedChainId
@@ -218,6 +205,28 @@ export interface EncodeSwapParams {
   /** Tick spacing for the pool */
   tickSpacing: number
 }
+
+export type EncodeSwapParams =
+  | (EncodeSwapBaseParams & {
+      amountInRaw: bigint
+      amountOutRaw?: undefined
+      /**
+       * Provider-derived minimum output floor for exact-input swaps. Passed in
+       * so displayed and enforced bounds are the same number.
+       */
+      amountOutMinRaw: bigint
+      amountInMaxRaw?: undefined
+    })
+  | (EncodeSwapBaseParams & {
+      amountInRaw?: undefined
+      amountOutRaw: bigint
+      amountOutMinRaw?: undefined
+      /**
+       * Provider-derived maximum input ceiling for exact-output swaps. Passed
+       * in so approvals, native value, and calldata use the same number.
+       */
+      amountInMaxRaw: bigint
+    })
 
 // V4 Universal Router command
 const V4_SWAP = 0x10

--- a/packages/sdk/src/core/error/errors.ts
+++ b/packages/sdk/src/core/error/errors.ts
@@ -132,7 +132,7 @@ export class InvalidAmountError extends ActionsError {
   amount: number
 
   constructor(amount: number) {
-    super('Amount must be positive', {
+    super('Amount must be a positive finite number', {
       metaMessages: [`Received: ${amount}`],
     })
     this.amount = amount
@@ -249,8 +249,10 @@ export class SlippageOutOfRangeError extends ActionsError {
   maxSlippage: number
 
   constructor(slippage: number, maxSlippage: number) {
+    const effectiveRange =
+      maxSlippage >= 1 ? '[0, 100%)' : `[0, ${maxSlippage * 100}%]`
     super(`Slippage ${slippage} is out of range`, {
-      metaMessages: [`Allowed range: [0, ${maxSlippage * 100}%]`],
+      metaMessages: [`Allowed range: finite ${effectiveRange}`],
     })
     this.slippage = slippage
     this.maxSlippage = maxSlippage

--- a/packages/sdk/src/types/swap/base.ts
+++ b/packages/sdk/src/types/swap/base.ts
@@ -217,10 +217,7 @@ export interface SwapQuote {
   amountOutMin: number
   /** Minimum output as raw bigint after slippage. Source of truth for on-chain execution. */
   amountOutMinRaw: bigint
-  /**
-   * Maximum input as raw bigint after slippage for exact-output swaps.
-   * Source of truth for approvals, native value, and on-chain execution.
-   */
+  /** Maximum input as raw bigint after slippage for exact-output swaps. */
   amountInMaxRaw?: bigint
 
   // ── Price (display approximations derived from number amounts) ──

--- a/packages/sdk/src/types/swap/base.ts
+++ b/packages/sdk/src/types/swap/base.ts
@@ -217,7 +217,10 @@ export interface SwapQuote {
   amountOutMin: number
   /** Minimum output as raw bigint after slippage. Source of truth for on-chain execution. */
   amountOutMinRaw: bigint
-  /** Maximum input as raw bigint after slippage for exact-output swaps. */
+  /**
+   * Maximum input as raw bigint after slippage for exact-output swaps.
+   * Source of truth for approvals, native value, and on-chain execution.
+   */
   amountInMaxRaw?: bigint
 
   // ── Price (display approximations derived from number amounts) ──

--- a/packages/sdk/src/types/swap/base.ts
+++ b/packages/sdk/src/types/swap/base.ts
@@ -217,6 +217,11 @@ export interface SwapQuote {
   amountOutMin: number
   /** Minimum output as raw bigint after slippage. Source of truth for on-chain execution. */
   amountOutMinRaw: bigint
+  /**
+   * Maximum input as raw bigint after slippage for exact-output swaps.
+   * Source of truth for approvals, native value, and on-chain execution.
+   */
+  amountInMaxRaw?: bigint
 
   // ── Price (display approximations derived from number amounts) ──
   /** Exchange rate: amountOut / amountIn. Display approximation. */

--- a/packages/sdk/src/utils/__tests__/validation.test.ts
+++ b/packages/sdk/src/utils/__tests__/validation.test.ts
@@ -84,6 +84,17 @@ describe('validateSlippage', () => {
     // misconfigured maxSlippage > 1 cannot admit a negative-floor slippage.
     expect(() => validateSlippage(1.5, 2.0)).toThrow(SlippageOutOfRangeError)
   })
+
+  it('reports the effective exclusive upper bound when maxSlippage is >= 1', () => {
+    try {
+      validateSlippage(1, 2)
+      throw new Error('Expected validateSlippage to throw')
+    } catch (error) {
+      expect(error).toBeInstanceOf(SlippageOutOfRangeError)
+      if (!(error instanceof SlippageOutOfRangeError)) throw error
+      expect(error.metaMessages).toContain('Allowed range: finite [0, 100%)')
+    }
+  })
 })
 
 describe('validateAmountPositiveIfExists', () => {
@@ -106,4 +117,10 @@ describe('validateAmountPositiveIfExists', () => {
       expect(() => validateAmountPositiveIfExists(amount)).not.toThrow()
     },
   )
+
+  it('reports that rejected amounts must be finite', () => {
+    expect(() => validateAmountPositiveIfExists(Infinity)).toThrow(
+      'Amount must be a positive finite number',
+    )
+  })
 })

--- a/packages/sdk/src/utils/__tests__/validation.test.ts
+++ b/packages/sdk/src/utils/__tests__/validation.test.ts
@@ -3,11 +3,15 @@ import { describe, expect, it } from 'vitest'
 
 import {
   AddressRequiredError,
+  InvalidAmountError,
   InvalidParamsError,
+  SlippageOutOfRangeError,
   ZeroAddressError,
 } from '@/core/error/errors.js'
 import {
   resolveSupportedChainIds,
+  validateAmountPositiveIfExists,
+  validateSlippage,
   validateWalletAddress,
 } from '@/utils/validation.js'
 
@@ -47,4 +51,59 @@ describe('validateWalletAddress', () => {
       validateWalletAddress('0x0000000000000000000000000000000000000000'),
     ).toThrow(ZeroAddressError)
   })
+})
+
+describe('validateSlippage', () => {
+  const maxSlippage = 0.5
+
+  it.each([NaN, Infinity, -Infinity, -0.1, 1.0, 1.5])(
+    'throws SlippageOutOfRangeError for %p',
+    (slippage) => {
+      expect(() => validateSlippage(slippage, maxSlippage)).toThrow(
+        SlippageOutOfRangeError,
+      )
+    },
+  )
+
+  it('throws when slippage exceeds maxSlippage', () => {
+    expect(() => validateSlippage(0.6, maxSlippage)).toThrow(
+      SlippageOutOfRangeError,
+    )
+  })
+
+  it.each([0, 0.005, 0.5])('accepts %p when within maxSlippage', (slippage) => {
+    expect(() => validateSlippage(slippage, maxSlippage)).not.toThrow()
+  })
+
+  it('accepts a value just under 1 when maxSlippage allows it', () => {
+    expect(() => validateSlippage(0.999, 1.0)).not.toThrow()
+  })
+
+  it('enforces the absolute >= 1 ceiling independent of maxSlippage', () => {
+    // 1.5 <= maxSlippage (2.0) but the absolute ceiling still rejects it, so a
+    // misconfigured maxSlippage > 1 cannot admit a negative-floor slippage.
+    expect(() => validateSlippage(1.5, 2.0)).toThrow(SlippageOutOfRangeError)
+  })
+})
+
+describe('validateAmountPositiveIfExists', () => {
+  it.each([NaN, Infinity, -Infinity, 0, -1])(
+    'throws InvalidAmountError for %p',
+    (amount) => {
+      expect(() => validateAmountPositiveIfExists(amount)).toThrow(
+        InvalidAmountError,
+      )
+    },
+  )
+
+  it('accepts undefined', () => {
+    expect(() => validateAmountPositiveIfExists(undefined)).not.toThrow()
+  })
+
+  it.each([0.000001, 1, 1_000_000])(
+    'accepts the positive finite number %p',
+    (amount) => {
+      expect(() => validateAmountPositiveIfExists(amount)).not.toThrow()
+    },
+  )
 })

--- a/packages/sdk/src/utils/__tests__/validation.test.ts
+++ b/packages/sdk/src/utils/__tests__/validation.test.ts
@@ -80,8 +80,7 @@ describe('validateSlippage', () => {
   })
 
   it('enforces the absolute >= 1 ceiling independent of maxSlippage', () => {
-    // 1.5 <= maxSlippage (2.0) but the absolute ceiling still rejects it, so a
-    // misconfigured maxSlippage > 1 cannot admit a negative-floor slippage.
+    // The absolute ceiling still rejects when maxSlippage exceeds 1.
     expect(() => validateSlippage(1.5, 2.0)).toThrow(SlippageOutOfRangeError)
   })
 

--- a/packages/sdk/src/utils/validation.ts
+++ b/packages/sdk/src/utils/validation.ts
@@ -108,16 +108,7 @@ export function validateWalletAddress(
   validateNotZeroAddress(walletAddress, label)
 }
 
-/**
- * Reject a slippage tolerance that cannot safely reach the bounds math.
- *
- * Enforces an absolute `[0, 1)` invariant in addition to the integrator's
- * relative `maxSlippage`. The `>= 1` ceiling is independent of `maxSlippage`
- * so a misconfigured `maxSlippage > 1` can no longer admit a value that drives
- * `computeSlippageBounds` to a negative (protection-disabling) `amountOutMinRaw`.
- * Non-finite values (`NaN` / `Infinity`) are rejected because the bare `<`/`>`
- * comparisons are silently `false` for `NaN`.
- */
+/** Reject non-finite slippage and enforce both `[0, 1)` bounds and `maxSlippage`. */
 export function validateSlippage(slippage: number, maxSlippage: number): void {
   if (
     !Number.isFinite(slippage) ||

--- a/packages/sdk/src/utils/validation.ts
+++ b/packages/sdk/src/utils/validation.ts
@@ -115,7 +115,7 @@ export function validateWalletAddress(
  * relative `maxSlippage`. The `>= 1` ceiling is independent of `maxSlippage`
  * so a misconfigured `maxSlippage > 1` can no longer admit a value that drives
  * `computeSlippageBounds` to a negative (protection-disabling) `amountOutMinRaw`.
- * Non-finite values (`NaN` / `±Infinity`) are rejected because the bare `<`/`>`
+ * Non-finite values (`NaN` / `Infinity`) are rejected because the bare `<`/`>`
  * comparisons are silently `false` for `NaN`.
  */
 export function validateSlippage(slippage: number, maxSlippage: number): void {

--- a/packages/sdk/src/utils/validation.ts
+++ b/packages/sdk/src/utils/validation.ts
@@ -34,7 +34,7 @@ export function validateAmountProvided(
 }
 
 export function validateAmountPositiveIfExists(amount?: number): void {
-  if (amount !== undefined && amount <= 0) {
+  if (amount !== undefined && (!Number.isFinite(amount) || amount <= 0)) {
     throw new InvalidAmountError(amount)
   }
 }
@@ -108,8 +108,23 @@ export function validateWalletAddress(
   validateNotZeroAddress(walletAddress, label)
 }
 
+/**
+ * Reject a slippage tolerance that cannot safely reach the bounds math.
+ *
+ * Enforces an absolute `[0, 1)` invariant in addition to the integrator's
+ * relative `maxSlippage`. The `>= 1` ceiling is independent of `maxSlippage`
+ * so a misconfigured `maxSlippage > 1` can no longer admit a value that drives
+ * `computeSlippageBounds` to a negative (protection-disabling) `amountOutMinRaw`.
+ * Non-finite values (`NaN` / `±Infinity`) are rejected because the bare `<`/`>`
+ * comparisons are silently `false` for `NaN`.
+ */
 export function validateSlippage(slippage: number, maxSlippage: number): void {
-  if (slippage < 0 || slippage > maxSlippage) {
+  if (
+    !Number.isFinite(slippage) ||
+    slippage < 0 ||
+    slippage >= 1 ||
+    slippage > maxSlippage
+  ) {
     throw new SlippageOutOfRangeError(slippage, maxSlippage)
   }
 }

--- a/packages/sdk/src/utils/validation.ts
+++ b/packages/sdk/src/utils/validation.ts
@@ -108,16 +108,7 @@ export function validateWalletAddress(
   validateNotZeroAddress(walletAddress, label)
 }
 
-/**
- * Reject a slippage tolerance that cannot safely reach the bounds math.
- *
- * Enforces an absolute `[0, 1)` invariant in addition to the integrator's
- * relative `maxSlippage`. The `>= 1` ceiling is independent of `maxSlippage`
- * so a misconfigured `maxSlippage > 1` can no longer admit a value that drives
- * `computeSlippageBounds` to a negative (protection-disabling) `amountOutMinRaw`.
- * Non-finite values (`NaN` / `Infinity`) are rejected because the bare `<`/`>`
- * comparisons are silently `false` for `NaN`.
- */
+/** Reject non-finite slippage and enforce the absolute [0, 1) bounds invariant. */
 export function validateSlippage(slippage: number, maxSlippage: number): void {
   if (
     !Number.isFinite(slippage) ||

--- a/packages/sdk/src/utils/validation.ts
+++ b/packages/sdk/src/utils/validation.ts
@@ -108,7 +108,16 @@ export function validateWalletAddress(
   validateNotZeroAddress(walletAddress, label)
 }
 
-/** Reject non-finite slippage and enforce the absolute [0, 1) bounds invariant. */
+/**
+ * Reject a slippage tolerance that cannot safely reach the bounds math.
+ *
+ * Enforces an absolute `[0, 1)` invariant in addition to the integrator's
+ * relative `maxSlippage`. The `>= 1` ceiling is independent of `maxSlippage`
+ * so a misconfigured `maxSlippage > 1` can no longer admit a value that drives
+ * `computeSlippageBounds` to a negative (protection-disabling) `amountOutMinRaw`.
+ * Non-finite values (`NaN` / `Infinity`) are rejected because the bare `<`/`>`
+ * comparisons are silently `false` for `NaN`.
+ */
 export function validateSlippage(slippage: number, maxSlippage: number): void {
   if (
     !Number.isFinite(slippage) ||


### PR DESCRIPTION
Closes #516

# Problem

- Swap quote/signing paths could admit non-finite or >=100% slippage, producing invalid min-out bounds in signed calldata.
- Uniswap calldata recomputed slippage bounds separately from provider-reported quote bounds.
- Exact-output quotes did not carry max input through calldata, approvals, and native value consistently.

# Solution

- Validate finite positive amounts and finite slippage in [0, 1) before quote generation and bounds math.
- Derive min-out/max-in bounds in the provider and pass them into Uniswap encoding.
- Add regression coverage for validation boundaries, quote guards, calldata parity, and exact-output approval/value parity.