### PR TITLE
Consolidate the Anvil fork-test harness

### DIFF
--- a/.changeset/anvil-network-harness.md
+++ b/.changeset/anvil-network-harness.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/actions-sdk': patch
+---
+
+Consolidate the SDK Anvil fork-test harness behind one network test utility surface.

--- a/packages/sdk/src/actions/borrow/providers/morpho/__tests__/MorphoBorrowProvider.network.test.ts
+++ b/packages/sdk/src/actions/borrow/providers/morpho/__tests__/MorphoBorrowProvider.network.test.ts
@@ -16,27 +16,23 @@ import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 
 import { blueAbi } from '@morpho-org/blue-sdk-viem'
-import {
-  type Address,
-  createPublicClient,
-  decodeFunctionData,
-  erc20Abi,
-  type Hex,
-  http,
-  type PublicClient,
-} from 'viem'
+import { type Address, decodeFunctionData, erc20Abi, type Hex } from 'viem'
 import { baseSepolia } from 'viem/chains'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
 import { MorphoBorrowProvider } from '@/actions/borrow/providers/morpho/MorphoBorrowProvider.js'
 import type { SupportedChainId } from '@/constants/supportedChains.js'
-import type { ChainManager } from '@/services/ChainManager.js'
 import type { Asset } from '@/types/asset.js'
 import type {
   MorphoBorrowMarketConfig,
   MorphoMarketParams,
 } from '@/types/borrow/index.js'
-import { type AnvilFork, startAnvilFork, stopAnvilFork } from '@/utils/test.js'
+import {
+  type AnvilFork,
+  createForkChainManager,
+  startAnvilFork,
+  stopAnvilFork,
+} from '@/utils/test.js'
 
 const BASE_SEPOLIA_ID = baseSepolia.id as SupportedChainId
 
@@ -101,21 +97,6 @@ function readDeployedBorrowMarket(): DeployedBorrowMarket | null {
   }
 }
 
-function createForkChainManager(rpcUrl: string): {
-  chainManager: ChainManager
-  client: PublicClient
-} {
-  const client = createPublicClient({
-    chain: baseSepolia,
-    transport: http(rpcUrl),
-  })
-  const chainManager = {
-    getPublicClient: () => client,
-    getSupportedChains: () => [BASE_SEPOLIA_ID],
-  } as unknown as ChainManager
-  return { chainManager, client: client as PublicClient }
-}
-
 function buildMarketConfig(
   deploy: DeployedBorrowMarket,
 ): MorphoBorrowMarketConfig {
@@ -158,7 +139,7 @@ describeOrSkip('MorphoBorrowProvider network fork tests', () => {
   beforeAll(async () => {
     if (!deployed) return
     const rpc = process.env.BASE_SEPOLIA_RPC ?? 'https://sepolia.base.org'
-    fork = await startAnvilFork(rpc, 18547)
+    fork = await startAnvilFork(rpc, BASE_SEPOLIA_ID)
     market = buildMarketConfig(deployed)
   }, 60_000)
 
@@ -171,7 +152,7 @@ describeOrSkip('MorphoBorrowProvider network fork tests', () => {
     expect(market.marketId.toLowerCase()).toBe(deployed.marketId.toLowerCase())
     // Constructor would throw BorrowMarketParamsMismatchError if these
     // disagreed; instantiating below is the assertion.
-    const { chainManager } = createForkChainManager(fork.rpcUrl)
+    const chainManager = createForkChainManager(fork.rpcUrl, BASE_SEPOLIA_ID)
     expect(
       () =>
         new MorphoBorrowProvider({ marketAllowlist: [market] }, chainManager),
@@ -180,7 +161,7 @@ describeOrSkip('MorphoBorrowProvider network fork tests', () => {
 
   it('getMarket returns coherent values for the deployed market', async () => {
     if (!deployed) return
-    const { chainManager } = createForkChainManager(fork.rpcUrl)
+    const chainManager = createForkChainManager(fork.rpcUrl, BASE_SEPOLIA_ID)
     const provider = new MorphoBorrowProvider(
       { marketAllowlist: [market] },
       chainManager,
@@ -200,7 +181,7 @@ describeOrSkip('MorphoBorrowProvider network fork tests', () => {
 
   it('getPosition returns an empty position for a fresh wallet', async () => {
     if (!deployed) return
-    const { chainManager } = createForkChainManager(fork.rpcUrl)
+    const chainManager = createForkChainManager(fork.rpcUrl, BASE_SEPOLIA_ID)
     const provider = new MorphoBorrowProvider(
       { marketAllowlist: [market] },
       chainManager,
@@ -221,7 +202,7 @@ describeOrSkip('MorphoBorrowProvider network fork tests', () => {
 
   it('openPosition emits a [approve, supplyCollateral, borrow] bundle', async () => {
     if (!deployed) return
-    const { chainManager } = createForkChainManager(fork.rpcUrl)
+    const chainManager = createForkChainManager(fork.rpcUrl, BASE_SEPOLIA_ID)
     const provider = new MorphoBorrowProvider(
       { marketAllowlist: [market] },
       chainManager,

--- a/packages/sdk/src/actions/swap/providers/velodrome/__tests__/VelodromeSwapProvider.network.test.ts
+++ b/packages/sdk/src/actions/swap/providers/velodrome/__tests__/VelodromeSwapProvider.network.test.ts
@@ -8,7 +8,6 @@
  * Requires: anvil (from foundry) and network access
  */
 import type { Address } from 'viem'
-import { createPublicClient, http } from 'viem'
 import { base, optimism } from 'viem/chains'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
@@ -17,7 +16,12 @@ import { VelodromeSwapProvider } from '@/actions/swap/providers/velodrome/Velodr
 import type { SupportedChainId } from '@/constants/supportedChains.js'
 import type { ChainManager } from '@/services/ChainManager.js'
 import type { Asset } from '@/types/asset.js'
-import { type AnvilFork, startAnvilFork, stopAnvilFork } from '@/utils/test.js'
+import {
+  type AnvilFork,
+  createForkChainManager,
+  startAnvilFork,
+  stopAnvilFork,
+} from '@/utils/test.js'
 
 // ── Real mainnet assets ──
 
@@ -61,17 +65,6 @@ const BASE_WETH: Asset = {
   metadata: { name: 'Wrapped Ether', symbol: 'WETH', decimals: 18 },
 }
 
-function createForkChainManager(
-  rpcUrl: string,
-  chain: typeof optimism | typeof base,
-): ChainManager {
-  const client = createPublicClient({ chain, transport: http(rpcUrl) })
-  return {
-    getPublicClient: () => client,
-    getSupportedChains: () => [chain.id],
-  } as unknown as ChainManager
-}
-
 function createProvider(
   chainId: SupportedChainId,
   chainManager: ChainManager,
@@ -94,8 +87,8 @@ describe('VelodromeSwapProvider network fork tests', () => {
     const baseRpc = process.env.BASE_MAINNET_RPC || 'https://mainnet.base.org'
 
     ;[opFork, baseFork] = await Promise.all([
-      startAnvilFork(opRpc, 18545),
-      startAnvilFork(baseRpc, 18546),
+      startAnvilFork(opRpc, optimism.id),
+      startAnvilFork(baseRpc, base.id),
     ])
   }, 60_000)
 
@@ -106,7 +99,7 @@ describe('VelodromeSwapProvider network fork tests', () => {
 
   describe('Optimism — v2 router', () => {
     it('getQuote returns valid quote for USDC/OP volatile pool', async () => {
-      const chainManager = createForkChainManager(opFork.rpcUrl, optimism)
+      const chainManager = createForkChainManager(opFork.rpcUrl, optimism.id)
       const provider = createProvider(
         optimism.id as SupportedChainId,
         chainManager,
@@ -139,7 +132,7 @@ describe('VelodromeSwapProvider network fork tests', () => {
     })
 
     it('getQuote returns valid quote for USDC/WETH volatile pool', async () => {
-      const chainManager = createForkChainManager(opFork.rpcUrl, optimism)
+      const chainManager = createForkChainManager(opFork.rpcUrl, optimism.id)
       const provider = createProvider(
         optimism.id as SupportedChainId,
         chainManager,
@@ -169,7 +162,7 @@ describe('VelodromeSwapProvider network fork tests', () => {
 
   describe('Base — v2 router (Aerodrome)', () => {
     it('getQuote returns valid quote for USDC/WETH volatile pool', async () => {
-      const chainManager = createForkChainManager(baseFork.rpcUrl, base)
+      const chainManager = createForkChainManager(baseFork.rpcUrl, base.id)
       const provider = createProvider(
         base.id as SupportedChainId,
         chainManager,
@@ -199,7 +192,7 @@ describe('VelodromeSwapProvider network fork tests', () => {
 
   describe('Optimism — CL/Slipstream pool', () => {
     it('getQuote returns valid quote for WETH/USDC CL pool', async () => {
-      const chainManager = createForkChainManager(opFork.rpcUrl, optimism)
+      const chainManager = createForkChainManager(opFork.rpcUrl, optimism.id)
       const provider = createProvider(
         optimism.id as SupportedChainId,
         chainManager,
@@ -231,7 +224,7 @@ describe('VelodromeSwapProvider network fork tests', () => {
 
   describe('Base — CL/Slipstream pool (Aerodrome)', () => {
     it('getQuote returns valid quote for USDC/WETH CL pool', async () => {
-      const chainManager = createForkChainManager(baseFork.rpcUrl, base)
+      const chainManager = createForkChainManager(baseFork.rpcUrl, base.id)
       const provider = createProvider(
         base.id as SupportedChainId,
         chainManager,
@@ -260,7 +253,7 @@ describe('VelodromeSwapProvider network fork tests', () => {
     })
 
     it('execute(quote) produces valid transaction data', async () => {
-      const chainManager = createForkChainManager(baseFork.rpcUrl, base)
+      const chainManager = createForkChainManager(baseFork.rpcUrl, base.id)
       const provider = createProvider(
         base.id as SupportedChainId,
         chainManager,

--- a/packages/sdk/src/actions/swap/providers/velodrome/__tests__/VelodromeSwapProvider.network.test.ts
+++ b/packages/sdk/src/actions/swap/providers/velodrome/__tests__/VelodromeSwapProvider.network.test.ts
@@ -97,7 +97,7 @@ describe('VelodromeSwapProvider network fork tests', () => {
     if (baseFork) stopAnvilFork(baseFork)
   })
 
-  describe('Optimism — v2 router', () => {
+  describe('Optimism - v2 router', () => {
     it('getQuote returns valid quote for USDC/OP volatile pool', async () => {
       const chainManager = createForkChainManager(opFork.rpcUrl, optimism.id)
       const provider = createProvider(
@@ -160,7 +160,7 @@ describe('VelodromeSwapProvider network fork tests', () => {
     })
   })
 
-  describe('Base — v2 router (Aerodrome)', () => {
+  describe('Base - v2 router (Aerodrome)', () => {
     it('getQuote returns valid quote for USDC/WETH volatile pool', async () => {
       const chainManager = createForkChainManager(baseFork.rpcUrl, base.id)
       const provider = createProvider(
@@ -190,7 +190,7 @@ describe('VelodromeSwapProvider network fork tests', () => {
     })
   })
 
-  describe('Optimism — CL/Slipstream pool', () => {
+  describe('Optimism - CL/Slipstream pool', () => {
     it('getQuote returns valid quote for WETH/USDC CL pool', async () => {
       const chainManager = createForkChainManager(opFork.rpcUrl, optimism.id)
       const provider = createProvider(
@@ -222,7 +222,7 @@ describe('VelodromeSwapProvider network fork tests', () => {
     })
   })
 
-  describe('Base — CL/Slipstream pool (Aerodrome)', () => {
+  describe('Base - CL/Slipstream pool (Aerodrome)', () => {
     it('getQuote returns valid quote for USDC/WETH CL pool', async () => {
       const chainManager = createForkChainManager(baseFork.rpcUrl, base.id)
       const provider = createProvider(

--- a/packages/sdk/src/test/network/__tests__/funding.spec.ts
+++ b/packages/sdk/src/test/network/__tests__/funding.spec.ts
@@ -1,7 +1,29 @@
 import { base } from 'viem/chains'
 import { describe, expect, it } from 'vitest'
 
-import { fundWallet } from '@/test/network/funding.js'
+import { assertFundingLanded, fundWallet } from '@/test/network/funding.js'
+
+describe('assertFundingLanded', () => {
+  it('passes when the balance moved by exactly the requested amount', () => {
+    expect(() =>
+      assertFundingLanded(1000n, 1000n + 1_234_000_000n, 1_234_000_000n),
+    ).not.toThrow()
+  })
+
+  it('throws fail-loud when the balance did not move by the requested amount', () => {
+    // The headline fund-safety property: a short/zero delta never passes
+    // silently. Underfunded by 1 unit here.
+    expect(() =>
+      assertFundingLanded(0n, 1_233_999_999n, 1_234_000_000n),
+    ).toThrow(/expected balance to increase by 1234000000, got 1233999999/)
+  })
+
+  it('throws when nothing landed at all (zero delta)', () => {
+    expect(() => assertFundingLanded(500n, 500n, 1_000_000n)).toThrow(
+      /USDC funding did not land/,
+    )
+  })
+})
 
 describe('fundWallet', () => {
   it('throws when USDC funding is requested for a chain with no whale entry', async () => {

--- a/packages/sdk/src/test/network/__tests__/funding.spec.ts
+++ b/packages/sdk/src/test/network/__tests__/funding.spec.ts
@@ -11,8 +11,7 @@ describe('assertFundingLanded', () => {
   })
 
   it('throws fail-loud when the balance did not move by the requested amount', () => {
-    // The headline fund-safety property: a short/zero delta never passes
-    // silently. Underfunded by 1 unit here.
+    // A short or zero funding delta must fail loudly.
     expect(() =>
       assertFundingLanded(0n, 1_233_999_999n, 1_234_000_000n),
     ).toThrow(/expected balance to increase by 1234000000, got 1233999999/)
@@ -27,9 +26,7 @@ describe('assertFundingLanded', () => {
 
 describe('fundWallet', () => {
   it('throws when USDC funding is requested for a chain with no whale entry', async () => {
-    // `base` (8453) is intentionally absent from the per-chain whale map. The
-    // whale lookup happens before any RPC call, so this fails loud (and offline)
-    // rather than logging and proceeding against a zero balance.
+    // Missing whale config fails loudly before any RPC call.
     await expect(
       fundWallet({
         // Never contacted: the missing-whale guard throws first.

--- a/packages/sdk/src/test/network/__tests__/funding.spec.ts
+++ b/packages/sdk/src/test/network/__tests__/funding.spec.ts
@@ -1,0 +1,21 @@
+import { base } from 'viem/chains'
+import { describe, expect, it } from 'vitest'
+
+import { fundWallet } from '@/test/network/funding.js'
+
+describe('fundWallet', () => {
+  it('throws when USDC funding is requested for a chain with no whale entry', async () => {
+    // `base` (8453) is intentionally absent from the per-chain whale map. The
+    // whale lookup happens before any RPC call, so this fails loud (and offline)
+    // rather than logging and proceeding against a zero balance.
+    await expect(
+      fundWallet({
+        // Never contacted: the missing-whale guard throws first.
+        rpcUrl: 'http://127.0.0.1:1',
+        chain: base,
+        targetAddress: '0x000000000000000000000000000000000000dEaD',
+        fundUsdc: true,
+      }),
+    ).rejects.toThrow(/no USDC whale configured for chainId 8453/)
+  })
+})

--- a/packages/sdk/src/test/network/anvil.ts
+++ b/packages/sdk/src/test/network/anvil.ts
@@ -72,8 +72,7 @@ async function probeChainId(rpcUrl: string): Promise<number | null> {
     })
     if (!res.ok) return null
     const json = (await res.json()) as { result?: unknown }
-    // A JSON-RPC error body (or an unforked node returning HTML) lacks a
-    // hex-string `result`; treat anything else as "not ready".
+    // Treat any non-hex result as "not ready".
     if (typeof json.result !== 'string') return null
     const chainId = Number.parseInt(json.result, 16)
     return Number.isInteger(chainId) && chainId > 0 ? chainId : null
@@ -104,9 +103,7 @@ export async function startAnvilFork(
     { stdio: 'ignore' },
   )
 
-  // Surface a missing `anvil` binary (ENOENT) or an early exit (e.g. a port
-  // collision the ephemeral allocation lost the race on) as a loud, specific
-  // error instead of an opaque "did not start in time" after the full timeout.
+  // Surface spawn failures and early exits instead of a generic readiness timeout.
   let spawnFailure: Error | null = null
   proc.on('error', (err) => {
     spawnFailure = new Error(`Failed to spawn anvil: ${err.message}`)

--- a/packages/sdk/src/test/network/anvil.ts
+++ b/packages/sdk/src/test/network/anvil.ts
@@ -2,8 +2,9 @@
  * Anvil fork lifecycle helpers for network tests.
  *
  * The single fork-harness entry point. Allocates an OS-assigned ephemeral
- * port (no hard-coded port literals, so concurrent fork suites never
- * collide on `EADDRINUSE`) and validates the fork's `eth_chainId` against the
+ * port (no hard-coded port literals, which makes `EADDRINUSE` collisions
+ * between concurrent fork suites vanishingly unlikely rather than guaranteed
+ * by manual bookkeeping) and validates the fork's `eth_chainId` against the
  * expected chain before declaring the node ready — a bare HTTP 200 from an
  * unforked or wrong-chain node fails loudly instead of passing.
  */
@@ -100,8 +101,27 @@ export async function startAnvilFork(
     { stdio: 'ignore' },
   )
 
+  // Surface a missing `anvil` binary (ENOENT) or an early exit (e.g. a port
+  // collision the ephemeral allocation lost the race on) as a loud, specific
+  // error instead of an opaque "did not start in time" after the full timeout.
+  let spawnFailure: Error | null = null
+  proc.on('error', (err) => {
+    spawnFailure = new Error(`Failed to spawn anvil: ${err.message}`)
+  })
+  proc.on('exit', (code, signal) => {
+    if (spawnFailure === null && signal === null) {
+      spawnFailure = new Error(
+        `anvil on port ${port} exited early with code ${code}`,
+      )
+    }
+  })
+
   const rpcUrl = `http://127.0.0.1:${port}`
   for (let i = 0; i < 60; i++) {
+    if (spawnFailure !== null) {
+      proc.kill()
+      throw spawnFailure
+    }
     const chainId = await probeChainId(rpcUrl)
     if (chainId !== null) {
       if (chainId !== expectedChainId) {

--- a/packages/sdk/src/test/network/anvil.ts
+++ b/packages/sdk/src/test/network/anvil.ts
@@ -1,0 +1,128 @@
+/**
+ * Anvil fork lifecycle helpers for network tests.
+ *
+ * The single fork-harness entry point. Allocates an OS-assigned ephemeral
+ * port (no hard-coded port literals, so concurrent fork suites never
+ * collide on `EADDRINUSE`) and validates the fork's `eth_chainId` against the
+ * expected chain before declaring the node ready — a bare HTTP 200 from an
+ * unforked or wrong-chain node fails loudly instead of passing.
+ */
+import type { ChildProcess } from 'node:child_process'
+import { spawn } from 'node:child_process'
+import { createServer } from 'node:net'
+
+/**
+ * Running Anvil fork process.
+ * @description Used by network tests that need a local fork of a public RPC.
+ */
+export interface AnvilFork {
+  /** OS-assigned local port the Anvil JSON-RPC server is bound to. */
+  port: number
+  /** Spawned Anvil child process. */
+  process: ChildProcess
+  /** Local JSON-RPC URL for the fork. */
+  rpcUrl: string
+  /** `eth_chainId` reported by the fork, validated at startup. */
+  chainId: number
+}
+
+/**
+ * Allocate a free TCP port from the OS.
+ * @returns A port number that was free at allocation time.
+ */
+async function allocateEphemeralPort(): Promise<number> {
+  return new Promise<number>((resolve, reject) => {
+    const server = createServer()
+    server.unref()
+    server.on('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address()
+      if (address && typeof address === 'object') {
+        const { port } = address
+        server.close(() => resolve(port))
+      } else {
+        server.close(() =>
+          reject(new Error('Failed to allocate an ephemeral port')),
+        )
+      }
+    })
+  })
+}
+
+/**
+ * Probe a node's `eth_chainId`.
+ * @param rpcUrl - JSON-RPC URL to probe.
+ * @returns The numeric chain id, or null when the node is not ready or the
+ * response is not a valid JSON-RPC result.
+ */
+async function probeChainId(rpcUrl: string): Promise<number | null> {
+  try {
+    const res = await fetch(rpcUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'eth_chainId',
+        params: [],
+        id: 1,
+      }),
+    })
+    if (!res.ok) return null
+    const json = (await res.json()) as { result?: unknown }
+    // A JSON-RPC error body (or an unforked node returning HTML) lacks a
+    // hex-string `result` — treat anything else as "not ready".
+    if (typeof json.result !== 'string') return null
+    const chainId = Number.parseInt(json.result, 16)
+    return Number.isInteger(chainId) && chainId > 0 ? chainId : null
+  } catch {
+    // Anvil is still starting, or the URL is unreachable.
+    return null
+  }
+}
+
+/**
+ * Start an Anvil fork on an ephemeral port and wait until it serves the
+ * expected chain.
+ * @param forkUrl - Upstream RPC URL to fork.
+ * @param expectedChainId - Chain id the fork must report from `eth_chainId`.
+ * @returns Fork metadata including process handle, bound port, and local RPC URL.
+ * @throws Error when the fork does not become ready in time, or reports a
+ * chain id other than `expectedChainId` (wrong fork URL / unforked node).
+ */
+export async function startAnvilFork(
+  forkUrl: string,
+  expectedChainId: number,
+): Promise<AnvilFork> {
+  const port = await allocateEphemeralPort()
+  const proc = spawn(
+    'anvil',
+    ['--fork-url', forkUrl, '--port', String(port), '--silent'],
+    { stdio: 'ignore' },
+  )
+
+  const rpcUrl = `http://127.0.0.1:${port}`
+  for (let i = 0; i < 60; i++) {
+    const chainId = await probeChainId(rpcUrl)
+    if (chainId !== null) {
+      if (chainId !== expectedChainId) {
+        proc.kill()
+        throw new Error(
+          `Anvil fork on port ${port} reports chainId ${chainId}, expected ${expectedChainId}`,
+        )
+      }
+      return { port, process: proc, rpcUrl, chainId }
+    }
+    await new Promise((r) => setTimeout(r, 500))
+  }
+  proc.kill()
+  throw new Error(`Anvil fork on port ${port} did not start in time`)
+}
+
+/**
+ * Stop a running Anvil fork process.
+ * @param fork - Fork process returned by `startAnvilFork`.
+ * @returns Nothing.
+ */
+export function stopAnvilFork(fork: AnvilFork): void {
+  fork.process.kill()
+}

--- a/packages/sdk/src/test/network/anvil.ts
+++ b/packages/sdk/src/test/network/anvil.ts
@@ -5,7 +5,7 @@
  * port (no hard-coded port literals, which makes `EADDRINUSE` collisions
  * between concurrent fork suites vanishingly unlikely rather than guaranteed
  * by manual bookkeeping) and validates the fork's `eth_chainId` against the
- * expected chain before declaring the node ready — a bare HTTP 200 from an
+ * expected chain before declaring the node ready. A bare HTTP 200 from an
  * unforked or wrong-chain node fails loudly instead of passing.
  */
 import type { ChildProcess } from 'node:child_process'
@@ -29,6 +29,7 @@ export interface AnvilFork {
 
 /**
  * Allocate a free TCP port from the OS.
+ * @description Asks the OS for an available local port for a short-lived fork.
  * @returns A port number that was free at allocation time.
  */
 async function allocateEphemeralPort(): Promise<number> {
@@ -52,6 +53,7 @@ async function allocateEphemeralPort(): Promise<number> {
 
 /**
  * Probe a node's `eth_chainId`.
+ * @description Reads and validates a JSON-RPC `eth_chainId` response.
  * @param rpcUrl - JSON-RPC URL to probe.
  * @returns The numeric chain id, or null when the node is not ready or the
  * response is not a valid JSON-RPC result.
@@ -71,7 +73,7 @@ async function probeChainId(rpcUrl: string): Promise<number | null> {
     if (!res.ok) return null
     const json = (await res.json()) as { result?: unknown }
     // A JSON-RPC error body (or an unforked node returning HTML) lacks a
-    // hex-string `result` — treat anything else as "not ready".
+    // hex-string `result`; treat anything else as "not ready".
     if (typeof json.result !== 'string') return null
     const chainId = Number.parseInt(json.result, 16)
     return Number.isInteger(chainId) && chainId > 0 ? chainId : null
@@ -84,6 +86,7 @@ async function probeChainId(rpcUrl: string): Promise<number | null> {
 /**
  * Start an Anvil fork on an ephemeral port and wait until it serves the
  * expected chain.
+ * @description Starts a local Anvil fork and validates its chain before use.
  * @param forkUrl - Upstream RPC URL to fork.
  * @param expectedChainId - Chain id the fork must report from `eth_chainId`.
  * @returns Fork metadata including process handle, bound port, and local RPC URL.
@@ -140,6 +143,7 @@ export async function startAnvilFork(
 
 /**
  * Stop a running Anvil fork process.
+ * @description Terminates the child process for a fork created by this harness.
  * @param fork - Fork process returned by `startAnvilFork`.
  * @returns Nothing.
  */

--- a/packages/sdk/src/test/network/chainManager.ts
+++ b/packages/sdk/src/test/network/chainManager.ts
@@ -1,0 +1,24 @@
+/**
+ * Real `ChainManager` wiring for network fork tests.
+ *
+ * Replaces the per-file `{ ... } as unknown as ChainManager` fakes that
+ * satisfied the type checker while bypassing the real client wiring the
+ * signing path uses. One helper, one chain-wiring path.
+ */
+import type { SupportedChainId } from '@/constants/supportedChains.js'
+import { ChainManager } from '@/services/ChainManager.js'
+
+/**
+ * Build a real `ChainManager` whose public client for `chainId` is bound to
+ * the Anvil fork RPC.
+ * @param rpcUrl - Local Anvil fork JSON-RPC URL.
+ * @param chainId - Chain the fork serves; the wallet/provider under test must
+ * use this same chain.
+ * @returns A `ChainManager` instance backed by the fork RPC.
+ */
+export function createForkChainManager(
+  rpcUrl: string,
+  chainId: SupportedChainId,
+): ChainManager {
+  return new ChainManager([{ chainId, rpcUrls: [rpcUrl] }])
+}

--- a/packages/sdk/src/test/network/chainManager.ts
+++ b/packages/sdk/src/test/network/chainManager.ts
@@ -11,6 +11,7 @@ import { ChainManager } from '@/services/ChainManager.js'
 /**
  * Build a real `ChainManager` whose public client for `chainId` is bound to
  * the Anvil fork RPC.
+ * @description Creates the concrete chain wiring network tests exercise.
  * @param rpcUrl - Local Anvil fork JSON-RPC URL.
  * @param chainId - Chain the fork serves; the wallet/provider under test must
  * use this same chain.

--- a/packages/sdk/src/test/network/funding.ts
+++ b/packages/sdk/src/test/network/funding.ts
@@ -1,0 +1,168 @@
+/**
+ * Fork wallet funding for network tests.
+ *
+ * Funds ETH via `anvil_setBalance` and (optionally) USDC via whale
+ * impersonation, resolving the USDC token + whale per `chainId`. A requested
+ * USDC transfer that cannot be satisfied — no whale entry for the chain, or a
+ * post-transfer balance that does not move by the requested amount — throws
+ * loudly rather than logging and continuing, so a test never proceeds against
+ * a zero balance (dead-on-arrival / false-green).
+ */
+import {
+  type Address,
+  type Chain,
+  createPublicClient,
+  createTestClient,
+  createWalletClient,
+  erc20Abi,
+  http,
+  parseEther,
+  parseUnits,
+} from 'viem'
+import { optimism, unichain } from 'viem/chains'
+
+import type { SupportedChainId } from '@/constants/supportedChains.js'
+
+/** Per-chain USDC token + a whale holding enough USDC to fund tests. */
+const USDC_FUNDING: Partial<
+  Record<SupportedChainId, { usdc: Address; whale: Address }>
+> = {
+  // OP-first: native USDC on Optimism, funded from the Aave V3 aToken
+  // reserve (~1.6M USDC at time of writing).
+  [optimism.id]: {
+    usdc: '0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85',
+    whale: '0x38d693cE1dF5AaDF7bC62595A37D667aD57922e5',
+  },
+  // Unichain pair retained for the supersim funding path.
+  [unichain.id]: {
+    usdc: '0x078d782b760474a361dda0af3839290b0ef57ad6',
+    whale: '0x5752e57DcfA070e3822d69498185B706c293C792',
+  },
+}
+
+/**
+ * Configuration for wallet funding.
+ */
+export interface FundWalletConfig {
+  /** RPC URL for the fork. */
+  rpcUrl: string
+  /** Chain configuration; `chain.id` selects the USDC whale entry. */
+  chain: Chain
+  /** Target wallet address to fund. */
+  targetAddress: Address
+  /** Amount to fund in ETH (default: '10'). */
+  amount?: string
+  /** Whether to also fund with USDC (default: false). */
+  fundUsdc?: boolean
+  /** Amount of USDC to fund (default: '1000'). */
+  usdcAmount?: string
+}
+
+/**
+ * Read a wallet's USDC balance.
+ * @param publicClient - Client bound to the fork.
+ * @param usdc - USDC token address.
+ * @param owner - Address whose balance to read.
+ * @returns Raw USDC balance (6 decimals).
+ */
+async function readUsdcBalance(
+  publicClient: ReturnType<typeof createPublicClient>,
+  usdc: Address,
+  owner: Address,
+): Promise<bigint> {
+  return publicClient.readContract({
+    address: usdc,
+    abi: erc20Abi,
+    functionName: 'balanceOf',
+    args: [owner],
+  })
+}
+
+/**
+ * Fund a wallet with ETH and optionally USDC on an Anvil fork.
+ * @param config - Wallet funding configuration.
+ * @returns Promise that resolves when funding is complete and verified.
+ * @throws Error when USDC funding is requested for a chain with no whale
+ * entry, or when the post-transfer USDC balance does not increase by the
+ * requested amount.
+ */
+export async function fundWallet(config: FundWalletConfig): Promise<void> {
+  const {
+    rpcUrl,
+    chain,
+    targetAddress,
+    amount = '10',
+    fundUsdc = false,
+    usdcAmount = '1000',
+  } = config
+  const chainId = chain.id as SupportedChainId
+
+  // Resolve the whale up-front so an unsupported chain fails loudly before any
+  // RPC call (and so the failure is deterministically testable offline).
+  let funding: { usdc: Address; whale: Address } | undefined
+  if (fundUsdc) {
+    funding = USDC_FUNDING[chainId]
+    if (!funding) {
+      throw new Error(
+        `fundWallet: no USDC whale configured for chainId ${chainId}; cannot fund USDC`,
+      )
+    }
+  }
+
+  const testClient = createTestClient({
+    chain,
+    mode: 'anvil',
+    transport: http(rpcUrl),
+  })
+  const publicClient = createPublicClient({ chain, transport: http(rpcUrl) })
+
+  await testClient.setBalance({
+    address: targetAddress,
+    value: parseEther(amount),
+  })
+
+  if (fundUsdc && funding) {
+    const amountUnits = parseUnits(usdcAmount, 6)
+    const before = await readUsdcBalance(
+      publicClient,
+      funding.usdc,
+      targetAddress,
+    )
+
+    await testClient.impersonateAccount({ address: funding.whale })
+    // The whale may be a contract (e.g. an aToken reserve) with USDC but no
+    // ETH; give it gas money so the impersonated transfer can be mined.
+    await testClient.setBalance({
+      address: funding.whale,
+      value: parseEther('1'),
+    })
+    try {
+      const whaleClient = createWalletClient({
+        account: funding.whale,
+        chain,
+        transport: http(rpcUrl),
+      })
+      const hash = await whaleClient.writeContract({
+        address: funding.usdc,
+        abi: erc20Abi,
+        functionName: 'transfer',
+        args: [targetAddress, amountUnits],
+      })
+      await publicClient.waitForTransactionReceipt({ hash })
+    } finally {
+      await testClient.stopImpersonatingAccount({ address: funding.whale })
+    }
+
+    const after = await readUsdcBalance(
+      publicClient,
+      funding.usdc,
+      targetAddress,
+    )
+    if (after - before !== amountUnits) {
+      throw new Error(
+        `fundWallet: USDC funding did not land on chainId ${chainId}: ` +
+          `expected balance to increase by ${amountUnits}, got ${after - before}`,
+      )
+    }
+  }
+}

--- a/packages/sdk/src/test/network/funding.ts
+++ b/packages/sdk/src/test/network/funding.ts
@@ -2,11 +2,11 @@
  * Fork wallet funding for network tests.
  *
  * Funds ETH via `anvil_setBalance` and (optionally) USDC via whale
- * impersonation, resolving the USDC token + whale per `chainId`. A requested
- * USDC transfer that cannot be satisfied — no whale entry for the chain, or a
- * post-transfer balance that does not move by the requested amount — throws
- * loudly rather than logging and continuing, so a test never proceeds against
- * a zero balance (dead-on-arrival / false-green).
+ * impersonation, resolving the USDC token + whale per `chainId`. When no
+ * whale entry exists for the chain or the post-transfer balance does not move
+ * by the requested amount, funding throws loudly rather than logging and
+ * continuing, so a test never proceeds against a zero balance
+ * (dead-on-arrival / false-green).
  */
 import {
   type Address,
@@ -42,6 +42,7 @@ const USDC_FUNDING: Partial<
 
 /**
  * Configuration for wallet funding.
+ * @description Describes ETH and optional USDC funding for a forked wallet.
  */
 export interface FundWalletConfig {
   /** RPC URL for the fork. */
@@ -60,6 +61,7 @@ export interface FundWalletConfig {
 
 /**
  * Read a wallet's USDC balance.
+ * @description Reads the raw token balance used to verify fork funding.
  * @param publicClient - Client bound to the fork.
  * @param usdc - USDC token address.
  * @param owner - Address whose balance to read.
@@ -80,6 +82,7 @@ async function readUsdcBalance(
 
 /**
  * Assert that a funding transfer moved exactly the requested amount.
+ * @description Fails loudly when USDC funding does not land exactly.
  * @param before - Target balance before the transfer.
  * @param after - Target balance after the transfer.
  * @param expected - Raw amount the transfer was supposed to move.
@@ -100,6 +103,7 @@ export function assertFundingLanded(
 
 /**
  * Fund a wallet with ETH and optionally USDC on an Anvil fork.
+ * @description Funds a fork-local wallet and verifies requested balances.
  * @param config - Wallet funding configuration.
  * @returns Promise that resolves when funding is complete and verified.
  * @throws Error when USDC funding is requested for a chain with no whale
@@ -170,7 +174,7 @@ export async function fundWallet(config: FundWalletConfig): Promise<void> {
       })
       // `waitForTransactionReceipt` resolves for reverted txs too; USDC's
       // `transfer` returns a bool that viem does not check, so assert the
-      // receipt status directly — a reverted/failed transfer fails loud here.
+      // receipt status directly. A reverted/failed transfer fails loud here.
       const receipt = await publicClient.waitForTransactionReceipt({ hash })
       if (receipt.status !== 'success') {
         throw new Error(

--- a/packages/sdk/src/test/network/funding.ts
+++ b/packages/sdk/src/test/network/funding.ts
@@ -79,6 +79,26 @@ async function readUsdcBalance(
 }
 
 /**
+ * Assert that a funding transfer moved exactly the requested amount.
+ * @param before - Target balance before the transfer.
+ * @param after - Target balance after the transfer.
+ * @param expected - Raw amount the transfer was supposed to move.
+ * @throws Error when the balance did not increase by exactly `expected`.
+ */
+export function assertFundingLanded(
+  before: bigint,
+  after: bigint,
+  expected: bigint,
+): void {
+  if (after - before !== expected) {
+    throw new Error(
+      `fundWallet: USDC funding did not land: ` +
+        `expected balance to increase by ${expected}, got ${after - before}`,
+    )
+  }
+}
+
+/**
  * Fund a wallet with ETH and optionally USDC on an Anvil fork.
  * @param config - Wallet funding configuration.
  * @returns Promise that resolves when funding is complete and verified.
@@ -148,7 +168,15 @@ export async function fundWallet(config: FundWalletConfig): Promise<void> {
         functionName: 'transfer',
         args: [targetAddress, amountUnits],
       })
-      await publicClient.waitForTransactionReceipt({ hash })
+      // `waitForTransactionReceipt` resolves for reverted txs too; USDC's
+      // `transfer` returns a bool that viem does not check, so assert the
+      // receipt status directly — a reverted/failed transfer fails loud here.
+      const receipt = await publicClient.waitForTransactionReceipt({ hash })
+      if (receipt.status !== 'success') {
+        throw new Error(
+          `fundWallet: USDC transfer reverted on chainId ${chainId} (status ${receipt.status})`,
+        )
+      }
     } finally {
       await testClient.stopImpersonatingAccount({ address: funding.whale })
     }
@@ -158,11 +186,6 @@ export async function fundWallet(config: FundWalletConfig): Promise<void> {
       funding.usdc,
       targetAddress,
     )
-    if (after - before !== amountUnits) {
-      throw new Error(
-        `fundWallet: USDC funding did not land on chainId ${chainId}: ` +
-          `expected balance to increase by ${amountUnits}, got ${after - before}`,
-      )
-    }
+    assertFundingLanded(before, after, amountUnits)
   }
 }

--- a/packages/sdk/src/test/network/funding.ts
+++ b/packages/sdk/src/test/network/funding.ts
@@ -28,8 +28,7 @@ interface UsdcFunding {
 
 /** Per-chain USDC token + a whale holding enough USDC to fund tests. */
 const USDC_FUNDING: Readonly<Partial<Record<number, UsdcFunding>>> = {
-  // OP-first: native USDC on Optimism, funded from the Aave V3 aToken
-  // reserve (~1.6M USDC at time of writing).
+  // Optimism native USDC funded from the Aave V3 aToken reserve.
   [optimism.id]: {
     usdc: '0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85',
     whale: '0x38d693cE1dF5AaDF7bC62595A37D667aD57922e5',
@@ -122,8 +121,7 @@ export async function fundWallet(config: FundWalletConfig): Promise<void> {
   } = config
   const chainId = chain.id
 
-  // Resolve the whale up-front so an unsupported chain fails loudly before any
-  // RPC call (and so the failure is deterministically testable offline).
+  // Resolve the whale before RPC so unsupported chains fail loudly and offline.
   let funding: UsdcFunding | undefined
   if (fundUsdc) {
     funding = USDC_FUNDING[chainId]
@@ -155,8 +153,7 @@ export async function fundWallet(config: FundWalletConfig): Promise<void> {
     )
 
     await testClient.impersonateAccount({ address: funding.whale })
-    // The whale may be a contract (e.g. an aToken reserve) with USDC but no
-    // ETH; give it gas money so the impersonated transfer can be mined.
+    // Contract whales may hold USDC but no ETH, so fund gas before transfer.
     await testClient.setBalance({
       address: funding.whale,
       value: parseEther('1'),
@@ -173,9 +170,7 @@ export async function fundWallet(config: FundWalletConfig): Promise<void> {
         functionName: 'transfer',
         args: [targetAddress, amountUnits],
       })
-      // `waitForTransactionReceipt` resolves for reverted txs too; USDC's
-      // `transfer` returns a bool that viem does not check, so assert the
-      // receipt status directly. A reverted/failed transfer fails loud here.
+      // waitForTransactionReceipt resolves for reverts, so assert status directly.
       const receipt = await publicClient.waitForTransactionReceipt({ hash })
       if (receipt.status !== 'success') {
         throw new Error(

--- a/packages/sdk/src/test/network/funding.ts
+++ b/packages/sdk/src/test/network/funding.ts
@@ -26,17 +26,34 @@ interface UsdcFunding {
   whale: Address
 }
 
+type PublicForkClient = ReturnType<typeof createPublicClient>
+type TestForkClient = ReturnType<typeof createTestClient>
+
+interface ForkClients {
+  publicClient: PublicForkClient
+  testClient: TestForkClient
+}
+
+const DEFAULT_ETH_AMOUNT = '10'
+const DEFAULT_USDC_AMOUNT = '1000'
+const USDC_DECIMALS = 6
+const WHALE_GAS_AMOUNT = '1'
+
+const OPTIMISM_USDC = '0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85'
+const OPTIMISM_AAVE_V3_USDC_ATOKEN =
+  '0x38d693cE1dF5AaDF7bC62595A37D667aD57922e5'
+const UNICHAIN_USDC = '0x078d782b760474a361dda0af3839290b0ef57ad6'
+const UNICHAIN_USDC_WHALE = '0x5752e57DcfA070e3822d69498185B706c293C792'
+
 /** Per-chain USDC token + a whale holding enough USDC to fund tests. */
 const USDC_FUNDING: Readonly<Partial<Record<number, UsdcFunding>>> = {
-  // Optimism native USDC funded from the Aave V3 aToken reserve.
   [optimism.id]: {
-    usdc: '0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85',
-    whale: '0x38d693cE1dF5AaDF7bC62595A37D667aD57922e5',
+    usdc: OPTIMISM_USDC,
+    whale: OPTIMISM_AAVE_V3_USDC_ATOKEN,
   },
-  // Unichain pair retained for the supersim funding path.
   [unichain.id]: {
-    usdc: '0x078d782b760474a361dda0af3839290b0ef57ad6',
-    whale: '0x5752e57DcfA070e3822d69498185B706c293C792',
+    usdc: UNICHAIN_USDC,
+    whale: UNICHAIN_USDC_WHALE,
   },
 }
 
@@ -68,7 +85,7 @@ export interface FundWalletConfig {
  * @returns Raw USDC balance (6 decimals).
  */
 async function readUsdcBalance(
-  publicClient: ReturnType<typeof createPublicClient>,
+  publicClient: PublicForkClient,
   usdc: Address,
   owner: Address,
 ): Promise<bigint> {
@@ -101,6 +118,109 @@ export function assertFundingLanded(
   }
 }
 
+function resolveUsdcFunding(chainId: number): UsdcFunding {
+  const funding = USDC_FUNDING[chainId]
+  if (!funding) {
+    throw new Error(
+      `fundWallet: no USDC whale configured for chainId ${chainId}; cannot fund USDC`,
+    )
+  }
+  return funding
+}
+
+function createForkClients(rpcUrl: string, chain: Chain): ForkClients {
+  const transport = http(rpcUrl)
+  return {
+    publicClient: createPublicClient({ chain, transport }),
+    testClient: createTestClient({ chain, mode: 'anvil', transport }),
+  }
+}
+
+async function setEthBalance(
+  testClient: TestForkClient,
+  address: Address,
+  amount: string,
+): Promise<void> {
+  await testClient.setBalance({ address, value: parseEther(amount) })
+}
+
+async function transferUsdcFromWhale(params: {
+  chain: Chain
+  chainId: number
+  funding: UsdcFunding
+  publicClient: PublicForkClient
+  rpcUrl: string
+  targetAddress: Address
+  amount: bigint
+}): Promise<void> {
+  const {
+    chain,
+    chainId,
+    funding,
+    publicClient,
+    rpcUrl,
+    targetAddress,
+    amount,
+  } = params
+  const whaleClient = createWalletClient({
+    account: funding.whale,
+    chain,
+    transport: http(rpcUrl),
+  })
+  const hash = await whaleClient.writeContract({
+    address: funding.usdc,
+    abi: erc20Abi,
+    functionName: 'transfer',
+    args: [targetAddress, amount],
+  })
+  const receipt = await publicClient.waitForTransactionReceipt({ hash })
+  if (receipt.status !== 'success') {
+    throw new Error(
+      `fundWallet: USDC transfer reverted on chainId ${chainId} (status ${receipt.status})`,
+    )
+  }
+}
+
+async function fundUsdcBalance(params: {
+  chain: Chain
+  funding: UsdcFunding
+  publicClient: PublicForkClient
+  rpcUrl: string
+  targetAddress: Address
+  testClient: TestForkClient
+  usdcAmount: string
+}): Promise<void> {
+  const {
+    chain,
+    funding,
+    publicClient,
+    targetAddress,
+    testClient,
+    usdcAmount,
+  } = params
+  const amountUnits = parseUnits(usdcAmount, USDC_DECIMALS)
+  const before = await readUsdcBalance(
+    publicClient,
+    funding.usdc,
+    targetAddress,
+  )
+
+  await testClient.impersonateAccount({ address: funding.whale })
+  await setEthBalance(testClient, funding.whale, WHALE_GAS_AMOUNT)
+  try {
+    await transferUsdcFromWhale({
+      ...params,
+      chainId: chain.id,
+      amount: amountUnits,
+    })
+  } finally {
+    await testClient.stopImpersonatingAccount({ address: funding.whale })
+  }
+
+  const after = await readUsdcBalance(publicClient, funding.usdc, targetAddress)
+  assertFundingLanded(before, after, amountUnits)
+}
+
 /**
  * Fund a wallet with ETH and optionally USDC on an Anvil fork.
  * @description Funds a fork-local wallet and verifies requested balances.
@@ -115,77 +235,23 @@ export async function fundWallet(config: FundWalletConfig): Promise<void> {
     rpcUrl,
     chain,
     targetAddress,
-    amount = '10',
-    fundUsdc = false,
-    usdcAmount = '1000',
+    amount = DEFAULT_ETH_AMOUNT,
+    fundUsdc: shouldFundUsdc = false,
+    usdcAmount = DEFAULT_USDC_AMOUNT,
   } = config
-  const chainId = chain.id
+  const funding = shouldFundUsdc ? resolveUsdcFunding(chain.id) : undefined
+  const { publicClient, testClient } = createForkClients(rpcUrl, chain)
 
-  // Resolve the whale before RPC so unsupported chains fail loudly and offline.
-  let funding: UsdcFunding | undefined
-  if (fundUsdc) {
-    funding = USDC_FUNDING[chainId]
-    if (!funding) {
-      throw new Error(
-        `fundWallet: no USDC whale configured for chainId ${chainId}; cannot fund USDC`,
-      )
-    }
-  }
+  await setEthBalance(testClient, targetAddress, amount)
+  if (!funding) return
 
-  const testClient = createTestClient({
+  await fundUsdcBalance({
     chain,
-    mode: 'anvil',
-    transport: http(rpcUrl),
+    funding,
+    publicClient,
+    rpcUrl,
+    targetAddress,
+    testClient,
+    usdcAmount,
   })
-  const publicClient = createPublicClient({ chain, transport: http(rpcUrl) })
-
-  await testClient.setBalance({
-    address: targetAddress,
-    value: parseEther(amount),
-  })
-
-  if (fundUsdc && funding) {
-    const amountUnits = parseUnits(usdcAmount, 6)
-    const before = await readUsdcBalance(
-      publicClient,
-      funding.usdc,
-      targetAddress,
-    )
-
-    await testClient.impersonateAccount({ address: funding.whale })
-    // Contract whales may hold USDC but no ETH, so fund gas before transfer.
-    await testClient.setBalance({
-      address: funding.whale,
-      value: parseEther('1'),
-    })
-    try {
-      const whaleClient = createWalletClient({
-        account: funding.whale,
-        chain,
-        transport: http(rpcUrl),
-      })
-      const hash = await whaleClient.writeContract({
-        address: funding.usdc,
-        abi: erc20Abi,
-        functionName: 'transfer',
-        args: [targetAddress, amountUnits],
-      })
-      // waitForTransactionReceipt resolves for reverts, so assert status directly.
-      const receipt = await publicClient.waitForTransactionReceipt({ hash })
-      if (receipt.status !== 'success') {
-        throw new Error(
-          `fundWallet: USDC transfer reverted on chainId ${chainId} (status ${receipt.status})`,
-        )
-      }
-    } finally {
-      await testClient.stopImpersonatingAccount({ address: funding.whale })
-    }
-
-    const after = await readUsdcBalance(
-      publicClient,
-      funding.usdc,
-      targetAddress,
-    )
-    assertFundingLanded(before, after, amountUnits)
-  }
 }

--- a/packages/sdk/src/test/network/funding.ts
+++ b/packages/sdk/src/test/network/funding.ts
@@ -21,12 +21,13 @@ import {
 } from 'viem'
 import { optimism, unichain } from 'viem/chains'
 
-import type { SupportedChainId } from '@/constants/supportedChains.js'
+interface UsdcFunding {
+  usdc: Address
+  whale: Address
+}
 
 /** Per-chain USDC token + a whale holding enough USDC to fund tests. */
-const USDC_FUNDING: Partial<
-  Record<SupportedChainId, { usdc: Address; whale: Address }>
-> = {
+const USDC_FUNDING: Readonly<Partial<Record<number, UsdcFunding>>> = {
   // OP-first: native USDC on Optimism, funded from the Aave V3 aToken
   // reserve (~1.6M USDC at time of writing).
   [optimism.id]: {
@@ -119,11 +120,11 @@ export async function fundWallet(config: FundWalletConfig): Promise<void> {
     fundUsdc = false,
     usdcAmount = '1000',
   } = config
-  const chainId = chain.id as SupportedChainId
+  const chainId = chain.id
 
   // Resolve the whale up-front so an unsupported chain fails loudly before any
   // RPC call (and so the failure is deterministically testable offline).
-  let funding: { usdc: Address; whale: Address } | undefined
+  let funding: UsdcFunding | undefined
   if (fundUsdc) {
     funding = USDC_FUNDING[chainId]
     if (!funding) {

--- a/packages/sdk/src/test/network/index.ts
+++ b/packages/sdk/src/test/network/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Consolidated Anvil fork-test harness — the single foundation all network
+ * fork tests build on: ephemeral-port forks with `chainId`-validated
+ * readiness, a real `ChainManager` bound to the fork RPC, and fail-loud
+ * per-chain wallet funding.
+ */
+export { type AnvilFork, startAnvilFork, stopAnvilFork } from './anvil.js'
+export { createForkChainManager } from './chainManager.js'
+export { fundWallet, type FundWalletConfig } from './funding.js'

--- a/packages/sdk/src/test/network/index.ts
+++ b/packages/sdk/src/test/network/index.ts
@@ -1,5 +1,5 @@
 /**
- * Consolidated Anvil fork-test harness — the single foundation all network
+ * Consolidated Anvil fork-test harness, the single foundation all network
  * fork tests build on: ephemeral-port forks with `chainId`-validated
  * readiness, a real `ChainManager` bound to the fork RPC, and fail-loud
  * per-chain wallet funding.

--- a/packages/sdk/src/utils/test.ts
+++ b/packages/sdk/src/utils/test.ts
@@ -9,8 +9,8 @@ import { createPublicClient, http } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 
 // Imported separately for internal use by `setupSupersimTest` below.
-import type { FundWalletConfig } from '../test/network/index.js'
-import { fundWallet } from '../test/network/index.js'
+import type { FundWalletConfig } from '@/test/network/index.js'
+import { fundWallet } from '@/test/network/index.js'
 
 // Re-exported from the consolidated fork harness for back-compat: there is one
 // fork-harness entry point (`src/test/network`), surfaced here too so existing
@@ -22,7 +22,7 @@ export {
   type FundWalletConfig,
   startAnvilFork,
   stopAnvilFork,
-} from '../test/network/index.js'
+} from '@/test/network/index.js'
 
 /**
  * Standard anvil/foundry test accounts with predictable private keys

--- a/packages/sdk/src/utils/test.ts
+++ b/packages/sdk/src/utils/test.ts
@@ -4,9 +4,25 @@
 
 import type { ChildProcess } from 'child_process'
 import { spawn } from 'child_process'
-import type { Chain, PublicClient } from 'viem'
-import { createPublicClient, createWalletClient, http, parseEther } from 'viem'
+import type { PublicClient } from 'viem'
+import { createPublicClient, http } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
+
+// Imported separately for internal use by `setupSupersimTest` below.
+import type { FundWalletConfig } from '../test/network/index.js'
+import { fundWallet } from '../test/network/index.js'
+
+// Re-exported from the consolidated fork harness for back-compat: there is one
+// fork-harness entry point (`src/test/network`), surfaced here too so existing
+// importers keep working.
+export {
+  type AnvilFork,
+  createForkChainManager,
+  fundWallet,
+  type FundWalletConfig,
+  startAnvilFork,
+  stopAnvilFork,
+} from '../test/network/index.js'
 
 /**
  * Standard anvil/foundry test accounts with predictable private keys
@@ -53,65 +69,6 @@ export const externalTest = () => process.env.EXTERNAL_TEST === 'true'
  * ```
  */
 export const supersimTest = () => process.env.SUPERSIM_TEST === 'true'
-
-/**
- * Running Anvil fork process.
- * @description Used by network tests that need a local fork of a public RPC.
- */
-export interface AnvilFork {
-  port: number
-  process: ChildProcess
-  rpcUrl: string
-}
-
-/**
- * Start an Anvil fork and wait until it accepts JSON-RPC requests.
- * @param forkUrl - Upstream RPC URL to fork.
- * @param port - Local port for the Anvil JSON-RPC server.
- * @returns Fork metadata including process handle and local RPC URL.
- * @throws Error when the fork does not become ready in time.
- */
-export async function startAnvilFork(
-  forkUrl: string,
-  port: number,
-): Promise<AnvilFork> {
-  const proc = spawn(
-    'anvil',
-    ['--fork-url', forkUrl, '--port', String(port), '--silent'],
-    { stdio: 'ignore' },
-  )
-
-  const rpcUrl = `http://127.0.0.1:${port}`
-  for (let i = 0; i < 30; i++) {
-    try {
-      const res = await fetch(rpcUrl, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          jsonrpc: '2.0',
-          method: 'eth_blockNumber',
-          params: [],
-          id: 1,
-        }),
-      })
-      if (res.ok) return { port, process: proc, rpcUrl }
-    } catch {
-      // Anvil is still starting.
-    }
-    await new Promise((r) => setTimeout(r, 500))
-  }
-  proc.kill()
-  throw new Error(`Anvil fork on port ${port} did not start in time`)
-}
-
-/**
- * Stop a running Anvil fork process.
- * @param fork - Fork process returned by `startAnvilFork`.
- * @returns Nothing.
- */
-export function stopAnvilFork(fork: AnvilFork): void {
-  fork.process.kill()
-}
 
 /**
  * Configuration for supersim test setup
@@ -256,140 +213,6 @@ export async function stopSupersim(
     })
   }
   console.log('Supersim stopped')
-}
-
-/**
- * Configuration for wallet funding
- */
-export interface FundWalletConfig {
-  /** RPC URL for the chain */
-  rpcUrl: string
-  /** Chain configuration */
-  chain: Chain
-  /** Target wallet address to fund */
-  targetAddress: `0x${string}`
-  /** Amount to fund in ETH (default: '10') */
-  amount?: string
-  /** Funder private key (default: ANVIL_ACCOUNTS.ACCOUNT_1) */
-  funderPrivateKey?: `0x${string}`
-  /** Whether to also fund with USDC (default: false) */
-  fundUsdc?: boolean
-  /** Amount of USDC to fund (default: '1000') */
-  usdcAmount?: string
-}
-
-/**
- * Fund a wallet with ETH and optionally USDC using a funder account
- * @param config - Wallet funding configuration
- * @returns Promise that resolves when funding is complete
- */
-export async function fundWallet(config: FundWalletConfig): Promise<void> {
-  const {
-    rpcUrl,
-    chain,
-    targetAddress,
-    amount = '10',
-    funderPrivateKey = ANVIL_ACCOUNTS.ACCOUNT_1, // Use anvil account #1 as default funder
-    fundUsdc = false,
-    usdcAmount = '1000',
-  } = config
-
-  console.log('Funding test wallet...')
-
-  // Create public client for waiting for transaction receipt
-  const publicClient = createPublicClient({
-    chain,
-    transport: http(rpcUrl),
-  })
-
-  // Create funder account and wallet client
-  const funderAccount = privateKeyToAccount(funderPrivateKey)
-  const funderClient = createWalletClient({
-    account: funderAccount,
-    chain,
-    transport: http(rpcUrl),
-  }) as any // Type assertion to avoid viem version compatibility issue
-
-  // Send ETH funding transaction
-  const fundingTx = await funderClient.sendTransaction({
-    to: targetAddress,
-    value: parseEther(amount),
-  })
-
-  // Wait for transaction confirmation
-  await publicClient.waitForTransactionReceipt({ hash: fundingTx })
-  console.log(`Test wallet funded with ${amount} ETH at ${targetAddress}`)
-
-  // Fund with USDC if requested using whale impersonation
-  if (fundUsdc) {
-    try {
-      console.log(
-        `Attempting to fund ${usdcAmount} USDC using whale impersonation...`,
-      )
-
-      // USDC whale address with large balance
-      const usdcWhale = '0x5752e57DcfA070e3822d69498185B706c293C792'
-
-      // Impersonate the whale account
-      console.log(`Impersonating whale account: ${usdcWhale}`)
-      await publicClient.request({
-        method: 'anvil_impersonateAccount' as any,
-        params: [usdcWhale],
-      })
-
-      // USDC contract address on Unichain (from vault config)
-      const usdcAddress = '0x078d782b760474a361dda0af3839290b0ef57ad6'
-
-      // Create whale wallet client (for impersonated account, we use the address directly)
-      const whaleClient = createWalletClient({
-        account: usdcWhale as `0x${string}`,
-        chain,
-        transport: http(rpcUrl),
-      })
-
-      // Transfer USDC from whale to target
-      const usdcAmountWei = BigInt(parseFloat(usdcAmount) * 1e6) // USDC has 6 decimals
-
-      console.log(
-        `Transferring ${usdcAmount} USDC (${usdcAmountWei} units) from whale to ${targetAddress}`,
-      )
-
-      const transferTx = await whaleClient.writeContract({
-        address: usdcAddress as `0x${string}`,
-        abi: [
-          {
-            name: 'transfer',
-            type: 'function',
-            stateMutability: 'nonpayable',
-            inputs: [
-              { name: 'to', type: 'address' },
-              { name: 'amount', type: 'uint256' },
-            ],
-            outputs: [{ name: '', type: 'bool' }],
-          },
-        ],
-        functionName: 'transfer',
-        args: [targetAddress, usdcAmountWei],
-      })
-
-      // Wait for transaction confirmation
-      await publicClient.waitForTransactionReceipt({ hash: transferTx })
-      console.log(
-        `✅ Successfully funded ${usdcAmount} USDC to ${targetAddress}`,
-      )
-
-      // Stop impersonating the account
-      await publicClient.request({
-        method: 'anvil_stopImpersonatingAccount' as any,
-        params: [usdcWhale],
-      })
-    } catch (error) {
-      console.log(
-        `❌ Failed to fund USDC: ${error instanceof Error ? error.message : 'Unknown error'}`,
-      )
-      console.log(`   This may cause lending tests to fail if USDC is required`)
-    }
-  }
 }
 
 /**

--- a/packages/sdk/src/utils/test.ts
+++ b/packages/sdk/src/utils/test.ts
@@ -12,9 +12,7 @@ import { privateKeyToAccount } from 'viem/accounts'
 import type { FundWalletConfig } from '@/test/network/index.js'
 import { fundWallet } from '@/test/network/index.js'
 
-// Re-exported from the consolidated fork harness for back-compat: there is one
-// fork-harness entry point (`src/test/network`), surfaced here too so existing
-// importers keep working.
+// Re-export the consolidated fork harness for backward compatibility.
 export {
   type AnvilFork,
   createForkChainManager,


### PR DESCRIPTION
Closes #332

# Problem

Fork network tests used duplicated Anvil setup, fixed ports, and fake `ChainManager` wiring, making the harness brittle under parallel runs and harder to reuse.

# Solution

- Add shared Anvil, funding, and fork-bound `ChainManager` helpers under `packages/sdk/src/test/network/`.
- Use OS-assigned ports and fail-loud `eth_chainId` readiness checks.
- Move the Velodrome and Morpho fork tests onto the shared harness.
- Fund ETH and USDC through per-chain fixtures with balance-delta assertions.
- Add SDK test coverage and a changeset.

# Note

Today only a few fork tests benefit from this harness, but it is the prerequisite for the planned end-to-end aiur test suite tracked in https://github.com/ethereum-optimism/actions/issues/335.