### PR TITLE
fix: encode Uniswap V4 recipients

### DIFF
--- a/.changeset/uniswap-recipient-take.md
+++ b/.changeset/uniswap-recipient-take.md
@@ -1,0 +1,5 @@
+---
+"@eth-optimism/actions-sdk": patch
+---
+
+Fix Uniswap universal router swaps to encode custom output recipients in V4 take actions.

--- a/packages/sdk/src/actions/swap/providers/uniswap/__tests__/calldataTestUtils.ts
+++ b/packages/sdk/src/actions/swap/providers/uniswap/__tests__/calldataTestUtils.ts
@@ -1,8 +1,16 @@
-import { decodeAbiParameters, decodeFunctionData, type Hex, isHex } from 'viem'
+import {
+  type Address,
+  decodeAbiParameters,
+  decodeFunctionData,
+  type Hex,
+  isAddress,
+  isHex,
+} from 'viem'
 
 import {
   EXACT_INPUT_SINGLE_PARAMS,
   EXACT_OUTPUT_SINGLE_PARAMS,
+  TAKE_PARAMS,
   UNIVERSAL_ROUTER_ABI,
 } from '@/actions/swap/providers/uniswap/abis.js'
 
@@ -19,6 +27,13 @@ export function expectHex(value: unknown, label: string): Hex {
 
 export function expectBigInt(value: unknown, label: string): bigint {
   if (typeof value !== 'bigint') throw new Error(`${label} is not bigint`)
+  return value
+}
+
+export function expectAddress(value: unknown, label: string): Address {
+  if (typeof value !== 'string' || !isAddress(value)) {
+    throw new Error(`${label} is not an address`)
+  }
   return value
 }
 
@@ -61,4 +76,21 @@ export function decodeMaxAmountIn(calldata: Hex): bigint {
   )
   if (!isRecord(swap)) throw new Error('exact-out swap is malformed')
   return expectBigInt(swap.amountInMaximum, 'amountInMaximum')
+}
+
+export function decodeTakeParams(calldata: Hex): {
+  currency: Address
+  recipient: Address
+  amount: bigint
+} {
+  const [currency, recipient, amount] = decodeAbiParameters(
+    TAKE_PARAMS,
+    expectHex(decodeV4SwapParams(calldata)[2], 'take params'),
+  )
+
+  return {
+    currency: expectAddress(currency, 'take currency'),
+    recipient: expectAddress(recipient, 'take recipient'),
+    amount: expectBigInt(amount, 'take amount'),
+  }
 }

--- a/packages/sdk/src/actions/swap/providers/uniswap/__tests__/sdk.test.ts
+++ b/packages/sdk/src/actions/swap/providers/uniswap/__tests__/sdk.test.ts
@@ -20,6 +20,7 @@ import {
   decodeMaxAmountIn,
   decodeMinAmountOut,
   decodeRouterInput,
+  decodeTakeParams,
   expectHex,
   isReadonlyArray,
   isRecord,
@@ -48,6 +49,8 @@ const POOL_MANAGER = '0x05E73354cFDd6745C338b50BcFDfA3Aa6fA03408' as Address
 const CHAIN_ID = 84532 as SupportedChainId
 const FEE = 100
 const TICK_SPACING = 2
+const CUSTOM_RECIPIENT = '0x3333333333333333333333333333333333333333' as Address
+const UNIVERSAL_ROUTER = '0x4444444444444444444444444444444444444444' as Address
 
 // Mock sqrtPriceX96 for a ~2000 USDC/WETH pool
 // sqrtPriceX96 = sqrt(price) * 2^96, where price = WETH/USDC adjusted for decimals
@@ -309,6 +312,14 @@ describe('encodeUniversalRouterSwap', () => {
   const AMOUNT_OUT_MIN = 497500000000000000n
   const AMOUNT_IN_MAX = 100500000n
 
+  const decodeActions = (calldata: Hex): Hex => {
+    const [actions] = decodeAbiParameters(
+      [{ type: 'bytes' }, { type: 'bytes[]' }],
+      decodeRouterInput(calldata),
+    )
+    return expectHex(actions, 'actions')
+  }
+
   it('encodes exact-in swap calldata', () => {
     const calldata = encodeUniversalRouterSwap({
       amountInRaw: 100000000n,
@@ -316,10 +327,10 @@ describe('encodeUniversalRouterSwap', () => {
       assetOut: WETH,
       amountOutMinRaw: AMOUNT_OUT_MIN,
       deadline: 1700000000,
-      recipient: '0xrecipient' as Address,
+      recipient: CUSTOM_RECIPIENT,
       chainId: CHAIN_ID,
       quote: baseQuote,
-      universalRouterAddress: '0xrouter' as Address,
+      universalRouterAddress: UNIVERSAL_ROUTER,
       fee: FEE,
       tickSpacing: TICK_SPACING,
     })
@@ -335,10 +346,10 @@ describe('encodeUniversalRouterSwap', () => {
       assetOut: WETH,
       amountInMaxRaw: AMOUNT_IN_MAX,
       deadline: 1700000000,
-      recipient: '0xrecipient' as Address,
+      recipient: CUSTOM_RECIPIENT,
       chainId: CHAIN_ID,
       quote: baseQuote,
-      universalRouterAddress: '0xrouter' as Address,
+      universalRouterAddress: UNIVERSAL_ROUTER,
       fee: FEE,
       tickSpacing: TICK_SPACING,
     })
@@ -354,10 +365,10 @@ describe('encodeUniversalRouterSwap', () => {
       assetOut: WETH,
       amountOutMinRaw: AMOUNT_OUT_MIN,
       deadline: 1700000000,
-      recipient: '0xrecipient' as Address,
+      recipient: CUSTOM_RECIPIENT,
       chainId: CHAIN_ID,
       quote: baseQuote,
-      universalRouterAddress: '0xrouter' as Address,
+      universalRouterAddress: UNIVERSAL_ROUTER,
       fee: FEE,
       tickSpacing: TICK_SPACING,
     })
@@ -369,10 +380,10 @@ describe('encodeUniversalRouterSwap', () => {
       assetOut: WETH,
       amountInMaxRaw: AMOUNT_IN_MAX,
       deadline: 1700000000,
-      recipient: '0xrecipient' as Address,
+      recipient: CUSTOM_RECIPIENT,
       chainId: CHAIN_ID,
       quote: baseQuote,
-      universalRouterAddress: '0xrouter' as Address,
+      universalRouterAddress: UNIVERSAL_ROUTER,
       fee: FEE,
       tickSpacing: TICK_SPACING,
     })
@@ -387,10 +398,10 @@ describe('encodeUniversalRouterSwap', () => {
         assetIn: USDC,
         assetOut: WETH,
         deadline: 1700000000,
-        recipient: '0xrecipient' as Address,
+        recipient: CUSTOM_RECIPIENT,
         chainId: CHAIN_ID,
         quote: baseQuote,
-        universalRouterAddress: '0xrouter' as Address,
+        universalRouterAddress: UNIVERSAL_ROUTER,
         fee: FEE,
         tickSpacing: TICK_SPACING,
       }),
@@ -405,10 +416,10 @@ describe('encodeUniversalRouterSwap', () => {
         assetIn: USDC,
         assetOut: WETH,
         deadline: 1700000000,
-        recipient: '0xrecipient' as Address,
+        recipient: CUSTOM_RECIPIENT,
         chainId: CHAIN_ID,
         quote: baseQuote,
-        universalRouterAddress: '0xrouter' as Address,
+        universalRouterAddress: UNIVERSAL_ROUTER,
         fee: FEE,
         tickSpacing: TICK_SPACING,
       }),
@@ -422,28 +433,20 @@ describe('encodeUniversalRouterSwap', () => {
     // bare-reverted on pool lookup. Correct codes:
     //   0x06 SWAP_EXACT_IN_SINGLE
     //   0x08 SWAP_EXACT_OUT_SINGLE
-    const decodeActions = (calldata: Hex): Hex => {
-      const [actions] = decodeAbiParameters(
-        [{ type: 'bytes' }, { type: 'bytes[]' }],
-        decodeRouterInput(calldata),
-      )
-      return expectHex(actions, 'actions')
-    }
-
     const exactIn = encodeUniversalRouterSwap({
       amountInRaw: 100000000n,
       assetIn: USDC,
       assetOut: WETH,
       amountOutMinRaw: AMOUNT_OUT_MIN,
       deadline: 1700000000,
-      recipient: '0xrecipient' as Address,
+      recipient: CUSTOM_RECIPIENT,
       chainId: CHAIN_ID,
       quote: baseQuote,
-      universalRouterAddress: '0xrouter' as Address,
+      universalRouterAddress: UNIVERSAL_ROUTER,
       fee: FEE,
       tickSpacing: TICK_SPACING,
     })
-    expect(decodeActions(exactIn)).toBe('0x060c0f')
+    expect(decodeActions(exactIn)).toBe('0x060c0e')
 
     const exactOut = encodeUniversalRouterSwap({
       amountOutRaw: 500000000000000000n,
@@ -451,14 +454,57 @@ describe('encodeUniversalRouterSwap', () => {
       assetOut: WETH,
       amountInMaxRaw: AMOUNT_IN_MAX,
       deadline: 1700000000,
-      recipient: '0xrecipient' as Address,
+      recipient: CUSTOM_RECIPIENT,
       chainId: CHAIN_ID,
       quote: baseQuote,
-      universalRouterAddress: '0xrouter' as Address,
+      universalRouterAddress: UNIVERSAL_ROUTER,
       fee: FEE,
       tickSpacing: TICK_SPACING,
     })
-    expect(decodeActions(exactOut)).toBe('0x080c0f')
+    expect(decodeActions(exactOut)).toBe('0x080c0e')
+  })
+
+  it.each([
+    [
+      'exact-in',
+      () =>
+        encodeUniversalRouterSwap({
+          amountInRaw: 100000000n,
+          assetIn: USDC,
+          assetOut: WETH,
+          amountOutMinRaw: AMOUNT_OUT_MIN,
+          deadline: 1700000000,
+          recipient: CUSTOM_RECIPIENT,
+          chainId: CHAIN_ID,
+          quote: baseQuote,
+          universalRouterAddress: UNIVERSAL_ROUTER,
+          fee: FEE,
+          tickSpacing: TICK_SPACING,
+        }),
+    ],
+    [
+      'exact-out',
+      () =>
+        encodeUniversalRouterSwap({
+          amountOutRaw: 500000000000000000n,
+          assetIn: USDC,
+          assetOut: WETH,
+          amountInMaxRaw: AMOUNT_IN_MAX,
+          deadline: 1700000000,
+          recipient: CUSTOM_RECIPIENT,
+          chainId: CHAIN_ID,
+          quote: baseQuote,
+          universalRouterAddress: UNIVERSAL_ROUTER,
+          fee: FEE,
+          tickSpacing: TICK_SPACING,
+        }),
+    ],
+  ])('encodes custom recipient in %s take action', (_label, buildCalldata) => {
+    const take = decodeTakeParams(buildCalldata())
+
+    expect(take.currency).toBe(WETH.address[CHAIN_ID])
+    expect(take.recipient).toBe(CUSTOM_RECIPIENT)
+    expect(take.amount).toBe(0n)
   })
 
   it('produces different calldata for exact-in vs exact-out', () => {
@@ -468,10 +514,10 @@ describe('encodeUniversalRouterSwap', () => {
       assetOut: WETH,
       amountOutMinRaw: AMOUNT_OUT_MIN,
       deadline: 1700000000,
-      recipient: '0xrecipient' as Address,
+      recipient: CUSTOM_RECIPIENT,
       chainId: CHAIN_ID,
       quote: baseQuote,
-      universalRouterAddress: '0xrouter' as Address,
+      universalRouterAddress: UNIVERSAL_ROUTER,
       fee: FEE,
       tickSpacing: TICK_SPACING,
     })
@@ -482,10 +528,10 @@ describe('encodeUniversalRouterSwap', () => {
       assetOut: WETH,
       amountInMaxRaw: AMOUNT_IN_MAX,
       deadline: 1700000000,
-      recipient: '0xrecipient' as Address,
+      recipient: CUSTOM_RECIPIENT,
       chainId: CHAIN_ID,
       quote: baseQuote,
-      universalRouterAddress: '0xrouter' as Address,
+      universalRouterAddress: UNIVERSAL_ROUTER,
       fee: FEE,
       tickSpacing: TICK_SPACING,
     })
@@ -500,10 +546,10 @@ describe('encodeUniversalRouterSwap', () => {
       assetOut: WETH,
       amountOutMinRaw: 500000000000000000n, // 0% slippage → full quoted out
       deadline: 1700000000,
-      recipient: '0xrecipient' as Address,
+      recipient: CUSTOM_RECIPIENT,
       chainId: CHAIN_ID,
       quote: baseQuote,
-      universalRouterAddress: '0xrouter' as Address,
+      universalRouterAddress: UNIVERSAL_ROUTER,
       fee: FEE,
       tickSpacing: TICK_SPACING,
     })
@@ -514,10 +560,10 @@ describe('encodeUniversalRouterSwap', () => {
       assetOut: WETH,
       amountOutMinRaw: 475000000000000000n, // 5% slippage
       deadline: 1700000000,
-      recipient: '0xrecipient' as Address,
+      recipient: CUSTOM_RECIPIENT,
       chainId: CHAIN_ID,
       quote: baseQuote,
-      universalRouterAddress: '0xrouter' as Address,
+      universalRouterAddress: UNIVERSAL_ROUTER,
       fee: FEE,
       tickSpacing: TICK_SPACING,
     })

--- a/packages/sdk/src/actions/swap/providers/uniswap/abis.ts
+++ b/packages/sdk/src/actions/swap/providers/uniswap/abis.ts
@@ -118,6 +118,13 @@ export const CURRENCY_AMOUNT_PARAMS = [
   { type: 'uint256' },
 ] as const
 
+/** ABI type for TAKE params */
+export const TAKE_PARAMS = [
+  { type: 'address' },
+  { type: 'address' },
+  { type: 'uint256' },
+] as const
+
 /**
  * PoolManager extsload ABI — reads arbitrary storage slots via SLOAD
  * @see https://docs.uniswap.org/contracts/v4/guides/read-pool-state

--- a/packages/sdk/src/actions/swap/providers/uniswap/encoding.ts
+++ b/packages/sdk/src/actions/swap/providers/uniswap/encoding.ts
@@ -237,6 +237,8 @@ const SWAP_EXACT_IN_SINGLE = 0x06
 const SWAP_EXACT_OUT_SINGLE = 0x08
 const SETTLE_ALL = 0x0c
 const TAKE = 0x0e
+// Mirrors Uniswap V4 ActionConstants.OPEN_DELTA. For TAKE, 0 resolves to
+// the full positive currency delta, the output credit owed by PoolManager.
 const OPEN_DELTA = 0n
 
 /**

--- a/packages/sdk/src/actions/swap/providers/uniswap/encoding.ts
+++ b/packages/sdk/src/actions/swap/providers/uniswap/encoding.ts
@@ -14,6 +14,7 @@ import {
   EXTSLOAD_ABI,
   POOL_KEY_ABI_TYPE,
   QUOTER_ABI,
+  TAKE_PARAMS,
   UNIVERSAL_ROUTER_ABI,
 } from '@/actions/swap/providers/uniswap/abis.js'
 import type { SupportedChainId } from '@/constants/supportedChains.js'
@@ -235,7 +236,8 @@ const V4_SWAP = 0x10
 const SWAP_EXACT_IN_SINGLE = 0x06
 const SWAP_EXACT_OUT_SINGLE = 0x08
 const SETTLE_ALL = 0x0c
-const TAKE_ALL = 0x0f
+const TAKE = 0x0e
+const OPEN_DELTA = 0n
 
 /**
  * Encode Universal Router V4 swap calldata
@@ -249,6 +251,7 @@ export function encodeUniversalRouterSwap(params: EncodeSwapParams): Hex {
     amountOutMinRaw,
     amountInMaxRaw,
     deadline,
+    recipient,
     chainId,
     quote,
     fee,
@@ -278,7 +281,7 @@ export function encodeUniversalRouterSwap(params: EncodeSwapParams): Hex {
     const minAmountOut = amountOutMinRaw
 
     actions =
-      `0x${[SWAP_EXACT_IN_SINGLE, SETTLE_ALL, TAKE_ALL].map((a) => a.toString(16).padStart(2, '0')).join('')}` as Hex
+      `0x${[SWAP_EXACT_IN_SINGLE, SETTLE_ALL, TAKE].map((a) => a.toString(16).padStart(2, '0')).join('')}` as Hex
 
     actionParams = [
       encodeAbiParameters(EXACT_INPUT_SINGLE_PARAMS, [
@@ -291,7 +294,7 @@ export function encodeUniversalRouterSwap(params: EncodeSwapParams): Hex {
         },
       ]),
       encodeAbiParameters(CURRENCY_AMOUNT_PARAMS, [tokenIn, amountInRaw]),
-      encodeAbiParameters(CURRENCY_AMOUNT_PARAMS, [tokenOut, minAmountOut]),
+      encodeAbiParameters(TAKE_PARAMS, [tokenOut, recipient, OPEN_DELTA]),
     ]
   } else {
     if (amountInMaxRaw === undefined) {
@@ -303,7 +306,7 @@ export function encodeUniversalRouterSwap(params: EncodeSwapParams): Hex {
     const maxAmountIn = amountInMaxRaw
 
     actions =
-      `0x${[SWAP_EXACT_OUT_SINGLE, SETTLE_ALL, TAKE_ALL].map((a) => a.toString(16).padStart(2, '0')).join('')}` as Hex
+      `0x${[SWAP_EXACT_OUT_SINGLE, SETTLE_ALL, TAKE].map((a) => a.toString(16).padStart(2, '0')).join('')}` as Hex
 
     actionParams = [
       encodeAbiParameters(EXACT_OUTPUT_SINGLE_PARAMS, [
@@ -316,10 +319,7 @@ export function encodeUniversalRouterSwap(params: EncodeSwapParams): Hex {
         },
       ]),
       encodeAbiParameters(CURRENCY_AMOUNT_PARAMS, [tokenIn, maxAmountIn]),
-      encodeAbiParameters(CURRENCY_AMOUNT_PARAMS, [
-        tokenOut,
-        quote.amountOutRaw,
-      ]),
+      encodeAbiParameters(TAKE_PARAMS, [tokenOut, recipient, OPEN_DELTA]),
     ]
   }
 


### PR DESCRIPTION
## Problem
Uniswap V4 swaps can send output tokens to a recipient chosen by the caller. The previous router encoding computed that recipient, but the final withdrawal action ignored it. As a result, swaps with a custom recipient could complete while sending the output to the wrong address.

## Solution
Encode the V4 withdrawal as a recipient-aware `TAKE` action so exact-in and exact-out swaps pay the resolved output recipient.

- The swap action still carries the slippage bound.
- The withdrawal now uses the full open output delta for the requested recipient.
- Regression coverage decodes the router action bytes and `TAKE` parameters.

## Related
- https://github.com/ethereum-optimism/actions/pull/500#discussion_r3484766092
