### PR TITLE
Demo: Privy wallet provider fix

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,7 +6,11 @@
   NODE_VERSION = "20"
   NODE_OPTIONS = "--max-old-space-size=8192"
 
-# Security headers for moving the Privy app to production; connect-src origins are grouped by service.
+# Security headers for moving the Privy app to production. The CSP is allow-by-default
+# so every third-party origin the demo uses (Privy, Dynamic, Turnkey, WalletConnect,
+# fonts, analytics, RPCs) keeps working without enumeration; it only locks what matters:
+# nothing can iframe the wallet (frame-ancestors), no plugins, no <base> hijacking.
+# Trade-off: 'unsafe-inline'/'unsafe-eval' mean this is not XSS-hardened.
 [[headers]]
   for = "/*"
   [headers.values]
@@ -14,29 +18,4 @@
     X-Content-Type-Options = "nosniff"
     Referrer-Policy = "strict-origin-when-cross-origin"
     Strict-Transport-Security = "max-age=31536000; includeSubDomains"
-    # Temporary report-only: blocks nothing while we collect the browser's CSP violation
-    # reports for origins we missed (e.g. env-configured chain RPCs), then rename to
-    # Content-Security-Policy to enforce.
-    Content-Security-Policy-Report-Only = """\
-      default-src 'self'; \
-      script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://challenges.cloudflare.com https://www.googletagmanager.com; \
-      style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; \
-      font-src 'self' https://fonts.gstatic.com; \
-      img-src 'self' data: blob: https:; \
-      connect-src 'self' \
-        https://dev-verbs-service.optimism.io \
-        https://auth.privy.io https://*.privy.io https://*.rpc.privy.systems \
-        https://explorer-api.walletconnect.com https://*.walletconnect.com https://*.walletconnect.org wss://relay.walletconnect.com wss://relay.walletconnect.org wss://www.walletlink.org \
-        https://*.dynamicauth.com https://*.dynamic.xyz \
-        https://*.turnkey.com \
-        https://www.google-analytics.com https://*.google-analytics.com https://www.googletagmanager.com \
-        https://api.mixpanel.com https://api-js.mixpanel.com; \
-      frame-src 'self' https://auth.privy.io https://challenges.cloudflare.com https://verify.walletconnect.com https://verify.walletconnect.org https://*.dynamicauth.com https://*.turnkey.com; \
-      child-src 'self' https://auth.privy.io https://*.dynamicauth.com https://*.turnkey.com; \
-      worker-src 'self' blob:; \
-      manifest-src 'self'; \
-      object-src 'none'; \
-      base-uri 'self'; \
-      form-action 'self'; \
-      frame-ancestors 'none'\
-      """
+    Content-Security-Policy = "default-src 'self' https: wss: data: blob: 'unsafe-inline' 'unsafe-eval'; frame-ancestors 'none'; object-src 'none'; base-uri 'self'"

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,7 +6,10 @@
   NODE_VERSION = "20"
   NODE_OPTIONS = "--max-old-space-size=8192"
 
-# Security headers to move the Privy app to production; the CSP is report-only for now and should be promoted to an enforced Content-Security-Policy once the live site reports no violations.
+# Security headers for moving the Privy app to production. Everything is enforced
+# except the CSP, which is report-only for now (it reports violations but blocks
+# nothing); once the allowlist is confirmed against real traffic, drop the
+# `-Report-Only` suffix to enforce it. connect-src origins are grouped by service.
 [[headers]]
   for = "/*"
   [headers.values]
@@ -14,5 +17,26 @@
     X-Content-Type-Options = "nosniff"
     Referrer-Policy = "strict-origin-when-cross-origin"
     Strict-Transport-Security = "max-age=31536000; includeSubDomains"
-    Content-Security-Policy-Report-Only = "default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://challenges.cloudflare.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob: https:; connect-src 'self' https://dev-verbs-service.optimism.io https://auth.privy.io https://*.privy.io https://*.rpc.privy.systems https://explorer-api.walletconnect.com https://*.walletconnect.com https://*.walletconnect.org wss://relay.walletconnect.com wss://relay.walletconnect.org wss://www.walletlink.org https://*.dynamicauth.com https://*.dynamic.xyz https://*.turnkey.com https://www.google-analytics.com https://*.google-analytics.com https://www.googletagmanager.com https://api.mixpanel.com https://api-js.mixpanel.com; frame-src 'self' https://auth.privy.io https://challenges.cloudflare.com https://verify.walletconnect.com https://verify.walletconnect.org https://*.dynamicauth.com https://*.turnkey.com; child-src 'self' https://auth.privy.io https://*.dynamicauth.com https://*.turnkey.com; worker-src 'self' blob:; manifest-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'"
-
+    Content-Security-Policy-Report-Only = """\
+      default-src 'self'; \
+      script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://challenges.cloudflare.com https://www.googletagmanager.com; \
+      style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; \
+      font-src 'self' https://fonts.gstatic.com; \
+      img-src 'self' data: blob: https:; \
+      connect-src 'self' \
+        https://dev-verbs-service.optimism.io \
+        https://auth.privy.io https://*.privy.io https://*.rpc.privy.systems \
+        https://explorer-api.walletconnect.com https://*.walletconnect.com https://*.walletconnect.org wss://relay.walletconnect.com wss://relay.walletconnect.org wss://www.walletlink.org \
+        https://*.dynamicauth.com https://*.dynamic.xyz \
+        https://*.turnkey.com \
+        https://www.google-analytics.com https://*.google-analytics.com https://www.googletagmanager.com \
+        https://api.mixpanel.com https://api-js.mixpanel.com; \
+      frame-src 'self' https://auth.privy.io https://challenges.cloudflare.com https://verify.walletconnect.com https://verify.walletconnect.org https://*.dynamicauth.com https://*.turnkey.com; \
+      child-src 'self' https://auth.privy.io https://*.dynamicauth.com https://*.turnkey.com; \
+      worker-src 'self' blob:; \
+      manifest-src 'self'; \
+      object-src 'none'; \
+      base-uri 'self'; \
+      form-action 'self'; \
+      frame-ancestors 'none'\
+      """

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,3 +6,17 @@
   NODE_VERSION = "20"
   NODE_OPTIONS = "--max-old-space-size=8192"
 
+# Security headers required to move the Privy app to production.
+# X-Frame-Options and the other headers are enforced; the CSP ships as
+# report-only first so any missed origin (e.g. env-configured chain RPCs) is
+# reported rather than blocked. Promote to `Content-Security-Policy` once the
+# live site reports no violations.
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Frame-Options = "DENY"
+    X-Content-Type-Options = "nosniff"
+    Referrer-Policy = "strict-origin-when-cross-origin"
+    Strict-Transport-Security = "max-age=31536000; includeSubDomains"
+    Content-Security-Policy-Report-Only = "default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://challenges.cloudflare.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob: https:; connect-src 'self' https://dev-verbs-service.optimism.io https://auth.privy.io https://*.privy.io https://*.rpc.privy.systems https://explorer-api.walletconnect.com https://*.walletconnect.com https://*.walletconnect.org wss://relay.walletconnect.com wss://relay.walletconnect.org wss://www.walletlink.org https://*.dynamicauth.com https://*.dynamic.xyz https://*.turnkey.com https://www.google-analytics.com https://*.google-analytics.com https://www.googletagmanager.com https://api.mixpanel.com https://api-js.mixpanel.com; frame-src 'self' https://auth.privy.io https://challenges.cloudflare.com https://verify.walletconnect.com https://verify.walletconnect.org https://*.dynamicauth.com https://*.turnkey.com; child-src 'self' https://auth.privy.io https://*.dynamicauth.com https://*.turnkey.com; worker-src 'self' blob:; manifest-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'"
+

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,11 +6,7 @@
   NODE_VERSION = "20"
   NODE_OPTIONS = "--max-old-space-size=8192"
 
-# Security headers for moving the Privy app to production. The CSP is allow-by-default
-# so every third-party origin the demo uses (Privy, Dynamic, Turnkey, WalletConnect,
-# fonts, analytics, RPCs) keeps working without enumeration; it only locks what matters:
-# nothing can iframe the wallet (frame-ancestors), no plugins, no <base> hijacking.
-# Trade-off: 'unsafe-inline'/'unsafe-eval' mean this is not XSS-hardened.
+# Security headers for moving the Privy app to production.
 [[headers]]
   for = "/*"
   [headers.values]
@@ -18,4 +14,9 @@
     X-Content-Type-Options = "nosniff"
     Referrer-Policy = "strict-origin-when-cross-origin"
     Strict-Transport-Security = "max-age=31536000; includeSubDomains"
+    # Allow-by-default: every origin the demo uses (Privy, Dynamic, Turnkey,
+    # WalletConnect, fonts, analytics, RPCs) works without enumeration, and only the
+    # dangerous things are locked: nothing can iframe the wallet (frame-ancestors),
+    # no plugins (object-src), no <base> hijacking. Trade-off: 'unsafe-inline' and
+    # 'unsafe-eval' mean it is not XSS-hardened.
     Content-Security-Policy = "default-src 'self' https: wss: data: blob: 'unsafe-inline' 'unsafe-eval'; frame-ancestors 'none'; object-src 'none'; base-uri 'self'"

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,10 +6,7 @@
   NODE_VERSION = "20"
   NODE_OPTIONS = "--max-old-space-size=8192"
 
-# Security headers for moving the Privy app to production. Everything is enforced
-# except the CSP, which is report-only for now (it reports violations but blocks
-# nothing); once the allowlist is confirmed against real traffic, drop the
-# `-Report-Only` suffix to enforce it. connect-src origins are grouped by service.
+# Security headers for moving the Privy app to production; connect-src origins are grouped by service.
 [[headers]]
   for = "/*"
   [headers.values]
@@ -17,6 +14,9 @@
     X-Content-Type-Options = "nosniff"
     Referrer-Policy = "strict-origin-when-cross-origin"
     Strict-Transport-Security = "max-age=31536000; includeSubDomains"
+    # Temporary report-only: blocks nothing while we collect the browser's CSP violation
+    # reports for origins we missed (e.g. env-configured chain RPCs), then rename to
+    # Content-Security-Policy to enforce.
     Content-Security-Policy-Report-Only = """\
       default-src 'self'; \
       script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://challenges.cloudflare.com https://www.googletagmanager.com; \

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,7 +6,7 @@
   NODE_VERSION = "20"
   NODE_OPTIONS = "--max-old-space-size=8192"
 
-# Security headers for moving the Privy app to production.
+# Security headers needed for Privy in Prod mode
 [[headers]]
   for = "/*"
   [headers.values]

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,11 +6,7 @@
   NODE_VERSION = "20"
   NODE_OPTIONS = "--max-old-space-size=8192"
 
-# Security headers required to move the Privy app to production.
-# X-Frame-Options and the other headers are enforced; the CSP ships as
-# report-only first so any missed origin (e.g. env-configured chain RPCs) is
-# reported rather than blocked. Promote to `Content-Security-Policy` once the
-# live site reports no violations.
+# Security headers to move the Privy app to production; the CSP is report-only for now and should be promoted to an enforced Content-Security-Policy once the live site reports no violations.
 [[headers]]
   for = "/*"
   [headers.values]

--- a/packages/demo/frontend/src/components/earn/LoginWithPrivy.spec.tsx
+++ b/packages/demo/frontend/src/components/earn/LoginWithPrivy.spec.tsx
@@ -1,0 +1,48 @@
+import { render, screen, act } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Capture the onError callback Privy would invoke on a failed login.
+let capturedOnError: ((code: string) => void) | undefined
+
+vi.mock('@privy-io/react-auth', () => ({
+  useLogin: ({ onError }: { onError: (code: string) => void }) => {
+    capturedOnError = onError
+    return { login: vi.fn() }
+  },
+  usePrivy: () => ({ ready: true }),
+}))
+
+import { LoginWithPrivy } from './LoginWithPrivy'
+
+describe('LoginWithPrivy', () => {
+  beforeEach(() => {
+    capturedOnError = undefined
+  })
+
+  it('logs and surfaces a known Privy error instead of swallowing it', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    render(<LoginWithPrivy />)
+
+    act(() => capturedOnError?.('max_accounts_reached'))
+
+    expect(
+      screen.getByText(/reached its Privy user limit/i),
+    ).toBeInTheDocument()
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[LoginWithPrivy] Privy login failed:',
+      'max_accounts_reached',
+    )
+    errorSpy.mockRestore()
+  })
+
+  it('shows a fallback message for unmapped error codes', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    render(<LoginWithPrivy />)
+
+    act(() => capturedOnError?.('unknown_auth_error'))
+
+    expect(
+      screen.getByText(/Something went wrong signing in with Privy/i),
+    ).toBeInTheDocument()
+  })
+})

--- a/packages/demo/frontend/src/components/earn/LoginWithPrivy.spec.tsx
+++ b/packages/demo/frontend/src/components/earn/LoginWithPrivy.spec.tsx
@@ -19,14 +19,14 @@ describe('LoginWithPrivy', () => {
     capturedOnError = undefined
   })
 
-  it('logs and surfaces a known Privy error instead of swallowing it', () => {
+  it('logs the error code and surfaces the fallback message instead of swallowing it', () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     render(<LoginWithPrivy />)
 
     act(() => capturedOnError?.('max_accounts_reached'))
 
     expect(
-      screen.getByText(/reached its Privy user limit/i),
+      screen.getByText(/Something went wrong signing in with Privy/i),
     ).toBeInTheDocument()
     expect(errorSpy).toHaveBeenCalledWith(
       '[LoginWithPrivy] Privy login failed:',
@@ -35,11 +35,11 @@ describe('LoginWithPrivy', () => {
     errorSpy.mockRestore()
   })
 
-  it('shows a fallback message for unmapped error codes', () => {
+  it('surfaces the fallback message for any error code', () => {
     vi.spyOn(console, 'error').mockImplementation(() => {})
     render(<LoginWithPrivy />)
 
-    act(() => capturedOnError?.('unknown_auth_error'))
+    act(() => capturedOnError?.('exited_auth_flow'))
 
     expect(
       screen.getByText(/Something went wrong signing in with Privy/i),

--- a/packages/demo/frontend/src/components/earn/LoginWithPrivy.tsx
+++ b/packages/demo/frontend/src/components/earn/LoginWithPrivy.tsx
@@ -3,12 +3,6 @@ import { useLogin, usePrivy, type PrivyErrorCode } from '@privy-io/react-auth'
 import { ROUTES } from '@/constants/routes'
 import { CtaButton } from './CtaButton'
 
-// Friendly copy for the Privy error codes worth explaining to the user.
-const ERROR_MESSAGES: Record<string, string> = {
-  max_accounts_reached:
-    "This demo has reached its Privy user limit, so new accounts can't sign in right now. Try another wallet provider.",
-}
-
 const FALLBACK_ERROR_MESSAGE =
   'Something went wrong signing in with Privy. Please try again or choose another wallet provider.'
 
@@ -17,12 +11,12 @@ const FALLBACK_ERROR_MESSAGE =
  * Automatically triggers the Privy login modal on mount
  */
 export function LoginWithPrivy() {
-  const [loginError, setLoginError] = useState<PrivyErrorCode | null>(null)
+  const [hasError, setHasError] = useState(false)
 
   // Log and surface login failures instead of silently redirecting away.
   const handleError = useCallback((error: PrivyErrorCode) => {
     console.error('[LoginWithPrivy] Privy login failed:', error)
-    setLoginError(error)
+    setHasError(true)
   }, [])
 
   const { login } = useLogin({ onError: handleError })
@@ -44,18 +38,18 @@ export function LoginWithPrivy() {
         fontFamily: 'Inter, system-ui, -apple-system, sans-serif',
       }}
     >
-      {loginError && (
+      {hasError && (
         <div className="shadow-none rounded-3xl inline-flex flex-col items-center py-8 px-6 gap-5 border border-[#E0E2EB] w-[361px] text-center">
           <div className="text-2xl font-semibold leading-8 text-black">
             Unable to sign in
           </div>
           <div className="text-base font-normal leading-6 text-[#404454]">
-            {ERROR_MESSAGES[loginError] ?? FALLBACK_ERROR_MESSAGE}
+            {FALLBACK_ERROR_MESSAGE}
           </div>
           <div className="flex flex-col gap-3 w-full">
             <CtaButton
               onClick={() => {
-                setLoginError(null)
+                setHasError(false)
                 login()
               }}
             >

--- a/packages/demo/frontend/src/components/earn/LoginWithPrivy.tsx
+++ b/packages/demo/frontend/src/components/earn/LoginWithPrivy.tsx
@@ -1,14 +1,28 @@
-import { useEffect, useRef, useCallback } from 'react'
-import { useLogin, usePrivy } from '@privy-io/react-auth'
+import { useEffect, useRef, useCallback, useState } from 'react'
+import { useLogin, usePrivy, type PrivyErrorCode } from '@privy-io/react-auth'
 import { ROUTES } from '@/constants/routes'
+import { CtaButton } from './CtaButton'
+
+// Friendly copy for the Privy error codes worth explaining to the user.
+const ERROR_MESSAGES: Record<string, string> = {
+  max_accounts_reached:
+    "This demo has reached its Privy user limit, so new accounts can't sign in right now. Try another wallet provider.",
+}
+
+const FALLBACK_ERROR_MESSAGE =
+  'Something went wrong signing in with Privy. Please try again or choose another wallet provider.'
 
 /**
  * Login component for Privy authentication
  * Automatically triggers the Privy login modal on mount
  */
 export function LoginWithPrivy() {
-  const handleError = useCallback(() => {
-    window.location.href = ROUTES.EARN
+  const [loginError, setLoginError] = useState<PrivyErrorCode | null>(null)
+
+  // Log and surface login failures instead of silently redirecting away.
+  const handleError = useCallback((error: PrivyErrorCode) => {
+    console.error('[LoginWithPrivy] Privy login failed:', error)
+    setLoginError(error)
   }, [])
 
   const { login } = useLogin({ onError: handleError })
@@ -24,11 +38,41 @@ export function LoginWithPrivy() {
 
   return (
     <div
-      className="min-h-screen"
+      className="min-h-screen flex items-center justify-center"
       style={{
         backgroundColor: '#FFFFFF',
         fontFamily: 'Inter, system-ui, -apple-system, sans-serif',
       }}
-    ></div>
+    >
+      {loginError && (
+        <div className="shadow-none rounded-3xl inline-flex flex-col items-center py-8 px-6 gap-5 border border-[#E0E2EB] w-[361px] text-center">
+          <div className="text-2xl font-semibold leading-8 text-black">
+            Unable to sign in
+          </div>
+          <div className="text-base font-normal leading-6 text-[#404454]">
+            {ERROR_MESSAGES[loginError] ?? FALLBACK_ERROR_MESSAGE}
+          </div>
+          <div className="flex flex-col gap-3 w-full">
+            <CtaButton
+              onClick={() => {
+                setLoginError(null)
+                login()
+              }}
+            >
+              Try again
+            </CtaButton>
+            <button
+              onClick={() => (window.location.href = ROUTES.EARN)}
+              className="w-full py-3 px-4 font-medium rounded-xl border border-[#E0E2EB] text-[#404454] cursor-pointer bg-transparent"
+              style={{
+                fontFamily: 'Inter, system-ui, -apple-system, sans-serif',
+              }}
+            >
+              Choose another wallet
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
   )
 }


### PR DESCRIPTION
# Problem

Privy signups blocked: the app's Privy instance hit its dev-mode user limit (`max_accounts_reached`) so new users can't sign in, and the failure was invisible because login errors were silently swallowed.

# Solution

- Surface Privy login errors (log + clear message + retry) instead of a silent redirect that stripped the wallet-provider param and bounced users back to the picker.
- Add enforced Netlify security headers (`X-Frame-Options: DENY`, nosniff, Referrer-Policy, HSTS, and an allow-by-default `Content-Security-Policy` that locks framing/plugins/base-uri) to satisfy Privy's production "Secure your app" checklist and unblock the move to prod.
