### PR TITLE
Prevent Turnkey refresh flashes

### DIFF
--- a/packages/demo/frontend/src/components/earn/EarnWithTurnkeyWallet.spec.tsx
+++ b/packages/demo/frontend/src/components/earn/EarnWithTurnkeyWallet.spec.tsx
@@ -1,0 +1,104 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  identifyUser: vi.fn(),
+  trackEvent: vi.fn(),
+  useTurnkey: vi.fn(),
+  useTurnkeyWallet: vi.fn(),
+}))
+
+vi.mock('@turnkey/react-wallet-kit', () => ({
+  AuthState: {
+    Authenticated: 'authenticated',
+    Unauthenticated: 'unauthenticated',
+  },
+  ClientState: { Loading: 'loading', Ready: 'ready' },
+  useTurnkey: mocks.useTurnkey,
+}))
+
+vi.mock('@/hooks/useTurnkeyWallet', () => ({
+  useTurnkeyWallet: mocks.useTurnkeyWallet,
+}))
+
+vi.mock('@/utils/analytics', () => ({
+  identifyUser: mocks.identifyUser,
+  trackEvent: mocks.trackEvent,
+}))
+
+vi.mock('./LoginWithTurnkey', () => ({
+  LoginWithTurnkey: () => <div>Sign in with Turnkey</div>,
+}))
+
+vi.mock('./EarnWithFrontendWallet', () => ({
+  EarnWithFrontendWallet: ({ wallet }: { wallet: unknown }) =>
+    wallet ? <div>Earn page</div> : <div>Loading...</div>,
+}))
+
+import { EarnWithTurnkeyWallet } from './EarnWithTurnkeyWallet'
+
+const logout = vi.fn()
+const user = { userId: 'turnkey-user', userName: 'Turnkey User' }
+const session = { organizationId: 'organization-id' }
+
+describe('EarnWithTurnkeyWallet', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.useTurnkeyWallet.mockReturnValue({ smartWallet: null })
+  })
+
+  it('keeps session restoration and wallet creation visually stable', () => {
+    mocks.useTurnkey.mockReturnValue({
+      authState: 'unauthenticated',
+      clientState: 'loading',
+      logout,
+      session: undefined,
+      user: undefined,
+    })
+    const { rerender } = render(<EarnWithTurnkeyWallet />)
+
+    expect(screen.queryByText('Loading...')).not.toBeInTheDocument()
+    expect(screen.queryByText('Sign in with Turnkey')).not.toBeInTheDocument()
+
+    mocks.useTurnkey.mockReturnValue({
+      authState: 'unauthenticated',
+      clientState: 'ready',
+      logout,
+      session,
+      user,
+    })
+    rerender(<EarnWithTurnkeyWallet />)
+
+    expect(screen.queryByText('Sign in with Turnkey')).not.toBeInTheDocument()
+
+    mocks.useTurnkey.mockReturnValue({
+      authState: 'authenticated',
+      clientState: 'ready',
+      logout,
+      session,
+      user,
+    })
+    rerender(<EarnWithTurnkeyWallet />)
+
+    expect(screen.queryByText('Loading...')).not.toBeInTheDocument()
+
+    mocks.useTurnkeyWallet.mockReturnValue({ smartWallet: {} })
+    rerender(<EarnWithTurnkeyWallet />)
+
+    expect(screen.getByText('Earn page')).toBeInTheDocument()
+  })
+
+  it('shows sign-in after an unauthenticated client is ready', () => {
+    mocks.useTurnkey.mockReturnValue({
+      authState: 'unauthenticated',
+      clientState: 'ready',
+      logout,
+      session: undefined,
+      user: undefined,
+    })
+
+    render(<EarnWithTurnkeyWallet />)
+
+    expect(screen.getByText('Sign in with Turnkey')).toBeInTheDocument()
+  })
+})

--- a/packages/demo/frontend/src/components/earn/EarnWithTurnkeyWallet.tsx
+++ b/packages/demo/frontend/src/components/earn/EarnWithTurnkeyWallet.tsx
@@ -3,17 +3,19 @@ import { AuthState, ClientState, useTurnkey } from '@turnkey/react-wallet-kit'
 import { EarnWithFrontendWallet } from './EarnWithFrontendWallet'
 import { WALLET_PROVIDERS } from '@/constants/walletProviders'
 import { LoginWithTurnkey } from './LoginWithTurnkey'
+import { WalletLoadingScreen } from './WalletLoadingScreen'
 import { useTurnkeyWallet } from '@/hooks/useTurnkeyWallet'
 import { trackEvent, identifyUser } from '@/utils/analytics'
 
 export function EarnWithTurnkeyWallet() {
   const { smartWallet } = useTurnkeyWallet()
-  const { clientState, authState, user, logout } = useTurnkey()
+  const { clientState, authState, session, user, logout } = useTurnkey()
 
   const isLoggedIn =
     clientState === ClientState.Ready &&
     authState === AuthState.Authenticated &&
-    user
+    Boolean(session) &&
+    Boolean(user)
 
   // Track successful login
   useEffect(() => {
@@ -27,6 +29,14 @@ export function EarnWithTurnkeyWallet() {
       })
     }
   }, [isLoggedIn, user])
+
+  const isRestoringSession =
+    clientState !== ClientState.Ready ||
+    Boolean(session) !== (authState === AuthState.Authenticated)
+
+  if (isRestoringSession || (isLoggedIn && !smartWallet)) {
+    return <WalletLoadingScreen />
+  }
 
   if (!isLoggedIn) {
     return <LoginWithTurnkey />

--- a/packages/demo/frontend/src/components/earn/WalletLoadingScreen.tsx
+++ b/packages/demo/frontend/src/components/earn/WalletLoadingScreen.tsx
@@ -1,0 +1,7 @@
+/**
+ * @description Keeps the wallet surface visually stable while provider state is restored.
+ * @returns A blank wallet loading surface.
+ */
+export function WalletLoadingScreen() {
+  return <div className="min-h-screen bg-white" aria-busy="true" />
+}

--- a/packages/demo/frontend/src/pages/EarnPage.tsx
+++ b/packages/demo/frontend/src/pages/EarnPage.tsx
@@ -2,6 +2,7 @@ import { lazy, Suspense } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { WALLET_PROVIDERS } from '@/constants/walletProviders'
 import { WelcomeWalletPicker } from '@/components/earn/WelcomeWalletPicker'
+import { WalletLoadingScreen } from '@/components/earn/WalletLoadingScreen'
 
 // Lazy load wallet providers to reduce bundle size and build memory
 const PrivyProvider = lazy(() =>
@@ -75,7 +76,7 @@ export function EarnPage() {
 
   if (walletProvider === WALLET_PROVIDERS.TURNKEY) {
     return (
-      <Suspense fallback={<LoadingFallback />}>
+      <Suspense fallback={<WalletLoadingScreen />}>
         <TurnkeyProvider>
           <EarnWithTurnkeyWallet />
         </TurnkeyProvider>


### PR DESCRIPTION
# Problem

This fix is now part of the combined Turnkey authentication PR. Keeping both PRs open would duplicate the refresh changes.

# Solution

Superseded by #551.
