### PR TITLE
Show small ETH lend positions

### DIFF
--- a/packages/demo/frontend/src/utils/effectiveLendPositions.spec.ts
+++ b/packages/demo/frontend/src/utils/effectiveLendPositions.spec.ts
@@ -115,7 +115,7 @@ describe('buildEffectiveLendPositions', () => {
     expect(position.directDepositedAmount).toBeNull()
   })
 
-  it('does not double-count Aave collateral (lend deposit is the same aToken)', () => {
+  it('keeps small Aave ETH deposits without double-counting collateral', () => {
     const ethAsset = {
       type: 'native' as const,
       address: { 11155420: '0x4200000000000000000000000000000000000006' },
@@ -130,8 +130,8 @@ describe('buildEffectiveLendPositions', () => {
     }
     const aaveLend = buildMarketPosition({
       asset: ethAsset,
-      depositedAmount: '0.02',
-      directDepositedAmount: '0.02',
+      depositedAmount: '0.001000010679660547',
+      directDepositedAmount: '0.001000010679660547',
       marketId: aaveMarket.marketId,
       provider: 'aave',
     })
@@ -139,7 +139,7 @@ describe('buildEffectiveLendPositions', () => {
     const aaveBorrow = buildBorrowMarketPosition({
       marketId: { kind: 'aave-v3', marketId: '0xaave', chainId: 11155420 },
       collateralAsset: ethAsset,
-      collateralAmountFormatted: '0.02',
+      collateralAmountFormatted: '0.001000010679660547',
       borrowAmountFormatted: '14',
       borrowAmount: 14_000000n,
     })
@@ -148,7 +148,7 @@ describe('buildEffectiveLendPositions', () => {
       [aaveLend],
       [aaveBorrow],
     )
-    expect(position.depositedAmount).toBe('0.02')
+    expect(position.depositedAmount).toBe('0.0010')
     expect(position.pledgedCollateralAmount).toBeNull()
   })
 })

--- a/packages/demo/frontend/src/utils/effectiveLendPositions.ts
+++ b/packages/demo/frontend/src/utils/effectiveLendPositions.ts
@@ -6,6 +6,8 @@
 
 import type { MarketInfo } from '@/components/earn/MarketSelector'
 import type { BorrowPosition, MarketPosition } from '@/types/market'
+import { isEthSymbol } from '@/utils/assetUtils'
+import { floorToFixed } from '@/utils/tokenDisplay'
 
 function toAmount(value: string | null | undefined): number {
   if (!value) return 0
@@ -57,14 +59,12 @@ export function buildEffectiveLendPositions(
             directPosition?.pledgedCollateralAmount ??
             null)
           : null
-      // Floor (not round) to 2 dp: the displayed deposit doubles as withdraw Max, so rounding up could exceed actual collateral.
-      const totalDepositedAmount = (
-        Math.floor(
-          (toAmount(directDepositedAmount) +
-            toAmount(pledgedCollateralAmount)) *
-            100,
-        ) / 100
-      ).toFixed(2)
+      // Keep ETH's four-decimal display precision without rounding up withdraw Max.
+      const displayPrecision = isEthSymbol(market.asset.metadata.symbol) ? 4 : 2
+      const totalDepositedAmount = floorToFixed(
+        toAmount(directDepositedAmount) + toAmount(pledgedCollateralAmount),
+        displayPrecision,
+      )
 
       if (toAmount(totalDepositedAmount) <= 0) return null
 


### PR DESCRIPTION
# Problem

Users who lend small ETH amounts cannot see their position after a refresh. Two-decimal flooring turns `0.001 ETH` into zero before empty rows are filtered.

# Solution

Use four-decimal downward precision for ETH positions.
