### PR TITLE
Fix Dynamic login modal width

### DIFF
--- a/packages/demo/frontend/src/components/earn/LoginWithDynamic.spec.tsx
+++ b/packages/demo/frontend/src/components/earn/LoginWithDynamic.spec.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@dynamic-labs/sdk-react-core', () => ({
+  DynamicEmbeddedWidget: () => <div data-testid="dynamic-widget" />,
+  useDynamicContext: () => ({ sdkHasLoaded: true }),
+}))
+
+import { LoginWithDynamic } from './LoginWithDynamic'
+
+describe('LoginWithDynamic', () => {
+  it('shrink-wraps the modal around the embedded widget', () => {
+    render(<LoginWithDynamic />)
+
+    expect(screen.getByTestId('dynamic-widget').parentElement).toHaveStyle({
+      maxWidth: '90%',
+      width: 'fit-content',
+    })
+  })
+})

--- a/packages/demo/frontend/src/components/earn/LoginWithDynamic.tsx
+++ b/packages/demo/frontend/src/components/earn/LoginWithDynamic.tsx
@@ -44,8 +44,8 @@ export function LoginWithDynamic() {
                 zIndex: 1000,
                 backgroundColor: '#FFFFFF',
                 borderRadius: '16px',
-                maxWidth: '500px',
-                width: '90%',
+                maxWidth: '90%',
+                width: 'fit-content',
                 maxHeight: '90vh',
                 overflow: 'auto',
                 boxShadow:


### PR DESCRIPTION
# Problem

Users see a broken Dynamic login modal with empty space and a displaced close button. The demo wrapper is wider than the upgraded embedded widget.

# Solution

Shrink-wrap the wrapper to the widget with a responsive width cap.
