### PR TITLE
Disable analytics in local development

### DIFF
--- a/packages/demo/frontend/src/utils/analytics.spec.ts
+++ b/packages/demo/frontend/src/utils/analytics.spec.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mixpanelMocks = vi.hoisted(() => ({
+  identify: vi.fn(),
+  init: vi.fn(),
+  peopleSet: vi.fn(),
+  reset: vi.fn(),
+  track: vi.fn(),
+}))
+
+vi.mock('mixpanel-browser', () => ({
+  default: {
+    identify: mixpanelMocks.identify,
+    init: mixpanelMocks.init,
+    people: { set: mixpanelMocks.peopleSet },
+    reset: mixpanelMocks.reset,
+    track: mixpanelMocks.track,
+  },
+}))
+
+vi.mock('@/envVars', () => ({
+  env: { VITE_MIXPANEL_TOKEN: 'test-token' },
+}))
+
+import { identifyUser, initAnalytics, resetUser, trackEvent } from './analytics'
+
+describe('analytics', () => {
+  beforeEach(() => vi.clearAllMocks())
+  afterEach(() => vi.unstubAllEnvs())
+
+  it('does not send analytics from local development', () => {
+    vi.stubEnv('PROD', false)
+
+    initAnalytics()
+    trackEvent('transaction_success')
+    identifyUser('user-1', { provider: 'dynamic' })
+    resetUser()
+
+    expect(mixpanelMocks.init).not.toHaveBeenCalled()
+    expect(mixpanelMocks.track).not.toHaveBeenCalled()
+    expect(mixpanelMocks.identify).not.toHaveBeenCalled()
+    expect(mixpanelMocks.peopleSet).not.toHaveBeenCalled()
+    expect(mixpanelMocks.reset).not.toHaveBeenCalled()
+  })
+
+  it('sends analytics from production builds', () => {
+    vi.stubEnv('PROD', true)
+
+    initAnalytics()
+    trackEvent('transaction_success')
+    identifyUser('user-1', { provider: 'dynamic' })
+    resetUser()
+
+    expect(mixpanelMocks.init).toHaveBeenCalledWith('test-token', {
+      track_pageview: true,
+      persistence: 'localStorage',
+    })
+    expect(mixpanelMocks.track).toHaveBeenCalledWith(
+      'transaction_success',
+      undefined,
+    )
+    expect(mixpanelMocks.identify).toHaveBeenCalledWith('user-1')
+    expect(mixpanelMocks.peopleSet).toHaveBeenCalledWith({
+      provider: 'dynamic',
+    })
+    expect(mixpanelMocks.reset).toHaveBeenCalled()
+  })
+})

--- a/packages/demo/frontend/src/utils/analytics.ts
+++ b/packages/demo/frontend/src/utils/analytics.ts
@@ -2,12 +2,16 @@ import mixpanel from 'mixpanel-browser'
 
 import { env } from '@/envVars'
 
-export const initAnalytics = () => {
-  if (!env.VITE_MIXPANEL_TOKEN) {
-    return
-  }
+function getMixpanelToken(): string | null {
+  if (!import.meta.env.PROD) return null
+  return env.VITE_MIXPANEL_TOKEN ?? null
+}
 
-  mixpanel.init(env.VITE_MIXPANEL_TOKEN, {
+export const initAnalytics = () => {
+  const token = getMixpanelToken()
+  if (!token) return
+
+  mixpanel.init(token, {
     track_pageview: true,
     persistence: 'localStorage',
   })
@@ -17,7 +21,7 @@ export const trackEvent = (
   eventName: string,
   properties?: Record<string, unknown>,
 ) => {
-  if (!env.VITE_MIXPANEL_TOKEN) return
+  if (!getMixpanelToken()) return
   mixpanel.track(eventName, properties)
 }
 
@@ -25,7 +29,7 @@ export const identifyUser = (
   userId: string,
   properties?: Record<string, unknown>,
 ) => {
-  if (!env.VITE_MIXPANEL_TOKEN) return
+  if (!getMixpanelToken()) return
   mixpanel.identify(userId)
   if (properties) {
     mixpanel.people.set(properties)
@@ -33,6 +37,6 @@ export const identifyUser = (
 }
 
 export const resetUser = () => {
-  if (!env.VITE_MIXPANEL_TOKEN) return
+  if (!getMixpanelToken()) return
   mixpanel.reset()
 }


### PR DESCRIPTION
# Problem

Users running the demo locally see repeated Mixpanel CORS warnings in Firefox. A configured token sends analytics that Enhanced Tracking Protection blocks.

# Solution

Send Mixpanel analytics only from production builds.
