### PR TITLE
Fix Privy browser wallet initialization

### DIFF
--- a/packages/demo/frontend/src/main.tsx
+++ b/packages/demo/frontend/src/main.tsx
@@ -1,3 +1,4 @@
+import './polyfills'
 import 'reflect-metadata'
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'

--- a/packages/demo/frontend/src/polyfills.spec.ts
+++ b/packages/demo/frontend/src/polyfills.spec.ts
@@ -1,0 +1,14 @@
+import { Buffer } from 'buffer'
+import { describe, expect, it } from 'vitest'
+
+import { installBuffer } from './polyfills'
+
+describe('browser polyfills', () => {
+  it('defines Buffer when the browser does not provide it', () => {
+    const browserGlobal: { Buffer?: typeof Buffer } = {}
+
+    installBuffer(browserGlobal)
+
+    expect(browserGlobal.Buffer).toBe(Buffer)
+  })
+})

--- a/packages/demo/frontend/src/polyfills.ts
+++ b/packages/demo/frontend/src/polyfills.ts
@@ -1,0 +1,9 @@
+import { Buffer } from 'buffer'
+
+// Privy's wallet SDK expects Node's global `Buffer`, which the browser
+// production bundle does not define. Set it before any wallet code runs.
+export function installBuffer(target: { Buffer?: typeof Buffer }): void {
+  if (typeof target.Buffer === 'undefined') target.Buffer = Buffer
+}
+
+installBuffer(globalThis)


### PR DESCRIPTION
# Problem

Users cannot initialize Privy browser wallets because the SDK expects a global `Buffer`. Vite does not provide that global in browser bundles.

# Solution

Polyfill `Buffer` before wallet initialization.
