### PR TITLE
Fix Turnkey login and refresh

### DIFF
--- a/packages/demo/frontend/src/components/earn/EarnWithTurnkeyWallet.spec.tsx
+++ b/packages/demo/frontend/src/components/earn/EarnWithTurnkeyWallet.spec.tsx
@@ -1,0 +1,104 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  identifyUser: vi.fn(),
+  trackEvent: vi.fn(),
+  useTurnkey: vi.fn(),
+  useTurnkeyWallet: vi.fn(),
+}))
+
+vi.mock('@turnkey/react-wallet-kit', () => ({
+  AuthState: {
+    Authenticated: 'authenticated',
+    Unauthenticated: 'unauthenticated',
+  },
+  ClientState: { Loading: 'loading', Ready: 'ready' },
+  useTurnkey: mocks.useTurnkey,
+}))
+
+vi.mock('@/hooks/useTurnkeyWallet', () => ({
+  useTurnkeyWallet: mocks.useTurnkeyWallet,
+}))
+
+vi.mock('@/utils/analytics', () => ({
+  identifyUser: mocks.identifyUser,
+  trackEvent: mocks.trackEvent,
+}))
+
+vi.mock('./LoginWithTurnkey', () => ({
+  LoginWithTurnkey: () => <div>Sign in with Turnkey</div>,
+}))
+
+vi.mock('./EarnWithFrontendWallet', () => ({
+  EarnWithFrontendWallet: ({ wallet }: { wallet: unknown }) =>
+    wallet ? <div>Earn page</div> : <div>Loading...</div>,
+}))
+
+import { EarnWithTurnkeyWallet } from './EarnWithTurnkeyWallet'
+
+const logout = vi.fn()
+const user = { userId: 'turnkey-user', userName: 'Turnkey User' }
+const session = { organizationId: 'organization-id' }
+
+describe('EarnWithTurnkeyWallet', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.useTurnkeyWallet.mockReturnValue({ smartWallet: null })
+  })
+
+  it('keeps session restoration and wallet creation visually stable', () => {
+    mocks.useTurnkey.mockReturnValue({
+      authState: 'unauthenticated',
+      clientState: 'loading',
+      logout,
+      session: undefined,
+      user: undefined,
+    })
+    const { rerender } = render(<EarnWithTurnkeyWallet />)
+
+    expect(screen.queryByText('Loading...')).not.toBeInTheDocument()
+    expect(screen.queryByText('Sign in with Turnkey')).not.toBeInTheDocument()
+
+    mocks.useTurnkey.mockReturnValue({
+      authState: 'unauthenticated',
+      clientState: 'ready',
+      logout,
+      session,
+      user,
+    })
+    rerender(<EarnWithTurnkeyWallet />)
+
+    expect(screen.queryByText('Sign in with Turnkey')).not.toBeInTheDocument()
+
+    mocks.useTurnkey.mockReturnValue({
+      authState: 'authenticated',
+      clientState: 'ready',
+      logout,
+      session,
+      user,
+    })
+    rerender(<EarnWithTurnkeyWallet />)
+
+    expect(screen.queryByText('Loading...')).not.toBeInTheDocument()
+
+    mocks.useTurnkeyWallet.mockReturnValue({ smartWallet: {} })
+    rerender(<EarnWithTurnkeyWallet />)
+
+    expect(screen.getByText('Earn page')).toBeInTheDocument()
+  })
+
+  it('shows sign-in after an unauthenticated client is ready', () => {
+    mocks.useTurnkey.mockReturnValue({
+      authState: 'unauthenticated',
+      clientState: 'ready',
+      logout,
+      session: undefined,
+      user: undefined,
+    })
+
+    render(<EarnWithTurnkeyWallet />)
+
+    expect(screen.getByText('Sign in with Turnkey')).toBeInTheDocument()
+  })
+})

--- a/packages/demo/frontend/src/components/earn/EarnWithTurnkeyWallet.tsx
+++ b/packages/demo/frontend/src/components/earn/EarnWithTurnkeyWallet.tsx
@@ -3,17 +3,19 @@ import { AuthState, ClientState, useTurnkey } from '@turnkey/react-wallet-kit'
 import { EarnWithFrontendWallet } from './EarnWithFrontendWallet'
 import { WALLET_PROVIDERS } from '@/constants/walletProviders'
 import { LoginWithTurnkey } from './LoginWithTurnkey'
+import { WalletLoadingScreen } from './WalletLoadingScreen'
 import { useTurnkeyWallet } from '@/hooks/useTurnkeyWallet'
 import { trackEvent, identifyUser } from '@/utils/analytics'
 
 export function EarnWithTurnkeyWallet() {
   const { smartWallet } = useTurnkeyWallet()
-  const { clientState, authState, user, logout } = useTurnkey()
+  const { clientState, authState, session, user, logout } = useTurnkey()
 
   const isLoggedIn =
     clientState === ClientState.Ready &&
     authState === AuthState.Authenticated &&
-    user
+    Boolean(session) &&
+    Boolean(user)
 
   // Track successful login
   useEffect(() => {
@@ -27,6 +29,14 @@ export function EarnWithTurnkeyWallet() {
       })
     }
   }, [isLoggedIn, user])
+
+  const isRestoringSession =
+    clientState !== ClientState.Ready ||
+    Boolean(session) !== (authState === AuthState.Authenticated)
+
+  if (isRestoringSession || (isLoggedIn && !smartWallet)) {
+    return <WalletLoadingScreen />
+  }
 
   if (!isLoggedIn) {
     return <LoginWithTurnkey />

--- a/packages/demo/frontend/src/components/earn/LoginWithTurnkey.spec.tsx
+++ b/packages/demo/frontend/src/components/earn/LoginWithTurnkey.spec.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const turnkey = vi.hoisted(() => ({
+  handleLogin: vi.fn(),
+  loginWithPasskey: vi.fn(),
+  signUpWithPasskey: vi.fn(),
+}))
+
+vi.mock('@turnkey/react-wallet-kit', () => ({
+  ClientState: { Ready: 'ready' },
+  useTurnkey: () => ({
+    clientState: 'ready',
+    handleLogin: turnkey.handleLogin,
+    loginWithPasskey: turnkey.loginWithPasskey,
+    signUpWithPasskey: turnkey.signUpWithPasskey,
+  }),
+  useModal: () => ({ modalStack: [] }),
+}))
+
+import { LoginWithTurnkey } from './LoginWithTurnkey'
+
+describe('LoginWithTurnkey', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    turnkey.handleLogin.mockResolvedValue(undefined)
+    turnkey.loginWithPasskey.mockResolvedValue(undefined)
+    turnkey.signUpWithPasskey.mockResolvedValue(undefined)
+  })
+
+  it('waits for an explicit user action before opening authentication', () => {
+    render(<LoginWithTurnkey />)
+
+    expect(turnkey.handleLogin).not.toHaveBeenCalled()
+    expect(turnkey.loginWithPasskey).not.toHaveBeenCalled()
+    expect(turnkey.signUpWithPasskey).not.toHaveBeenCalled()
+  })
+
+  it('logs in with a passkey from the sign-in button', async () => {
+    const user = userEvent.setup()
+    render(<LoginWithTurnkey />)
+
+    await user.click(
+      screen.getByRole('button', { name: 'Log in with passkey' }),
+    )
+
+    expect(turnkey.loginWithPasskey).toHaveBeenCalledOnce()
+  })
+
+  it('handles a rejected passkey request and offers recovery', async () => {
+    const user = userEvent.setup()
+    turnkey.loginWithPasskey.mockRejectedValueOnce(
+      new DOMException('The request is not allowed', 'NotAllowedError'),
+    )
+    render(<LoginWithTurnkey />)
+
+    await user.click(
+      screen.getByRole('button', { name: 'Log in with passkey' }),
+    )
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Passkey authentication was canceled or is unavailable',
+    )
+    expect(
+      screen.getByRole('button', { name: 'Choose another wallet' }),
+    ).toBeInTheDocument()
+  })
+})

--- a/packages/demo/frontend/src/components/earn/LoginWithTurnkey.tsx
+++ b/packages/demo/frontend/src/components/earn/LoginWithTurnkey.tsx
@@ -1,41 +1,77 @@
-import { useTurnkey, useModal, ClientState } from '@turnkey/react-wallet-kit'
-import { useEffect, useRef } from 'react'
+import { ClientState, useTurnkey } from '@turnkey/react-wallet-kit'
+import { useState } from 'react'
 import { ROUTES } from '@/constants/routes'
+import { CtaButton } from './CtaButton'
+
+const PASSKEY_ERROR_MESSAGE =
+  'Passkey authentication was canceled or is unavailable in this browser. Try again or choose another wallet.'
 
 /**
- * Login component for Turnkey authentication
- * Displays a simple sign-in screen with the Turnkey login flow
+ * @description Displays explicit Turnkey passkey actions and handles browser rejections.
+ * @returns The Turnkey authentication screen.
  */
 export function LoginWithTurnkey() {
-  const { clientState, handleLogin } = useTurnkey()
-  const { modalStack } = useModal()
-  const hasTriggeredLogin = useRef(false)
-  const hasModalBeenOpened = useRef(false)
+  const { clientState, loginWithPasskey, signUpWithPasskey } = useTurnkey()
+  const [isAuthenticating, setIsAuthenticating] = useState(false)
+  const [hasError, setHasError] = useState(false)
+  const isReady = clientState === ClientState.Ready
 
-  useEffect(() => {
-    if (clientState === ClientState.Ready && !hasTriggeredLogin.current) {
-      hasTriggeredLogin.current = true
-      handleLogin()
+  const authenticate = async (action: () => Promise<unknown>) => {
+    setHasError(false)
+    setIsAuthenticating(true)
+    try {
+      await action()
+    } catch {
+      setHasError(true)
+    } finally {
+      setIsAuthenticating(false)
     }
-  }, [clientState, handleLogin])
-
-  useEffect(() => {
-    if (modalStack.length > 0) {
-      hasModalBeenOpened.current = true
-    }
-
-    if (modalStack.length === 0 && hasModalBeenOpened.current) {
-      window.location.href = ROUTES.EARN
-    }
-  }, [modalStack])
+  }
 
   return (
     <div
-      className="min-h-screen"
+      className="min-h-screen flex items-center justify-center"
       style={{
         backgroundColor: '#FFFFFF',
         fontFamily: 'Inter, system-ui, -apple-system, sans-serif',
       }}
-    ></div>
+    >
+      <div className="shadow-none rounded-3xl inline-flex flex-col items-center py-8 px-6 gap-5 border border-[#E0E2EB] w-[361px] text-center">
+        <div className="text-2xl font-semibold leading-8 text-black">
+          Sign in with Turnkey
+        </div>
+        <div className="text-base font-normal leading-6 text-[#404454]">
+          Use an existing passkey or create one for this device.
+        </div>
+        {hasError && (
+          <div role="alert" className="text-sm leading-5 text-[#B42318]">
+            {PASSKEY_ERROR_MESSAGE}
+          </div>
+        )}
+        <div className="flex flex-col gap-3 w-full">
+          <CtaButton
+            disabled={!isReady || isAuthenticating}
+            onClick={() => void authenticate(loginWithPasskey)}
+          >
+            {isAuthenticating
+              ? 'Waiting for passkey...'
+              : 'Log in with passkey'}
+          </CtaButton>
+          <button
+            disabled={!isReady || isAuthenticating}
+            onClick={() => void authenticate(signUpWithPasskey)}
+            className="w-full py-3 px-4 font-medium rounded-xl border border-[#E0E2EB] text-[#404454] cursor-pointer bg-transparent disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            Sign up with passkey
+          </button>
+          <button
+            onClick={() => (window.location.href = ROUTES.EARN)}
+            className="w-full py-2 px-4 font-medium text-[#404454] cursor-pointer bg-transparent border-0"
+          >
+            Choose another wallet
+          </button>
+        </div>
+      </div>
+    </div>
   )
 }

--- a/packages/demo/frontend/src/components/earn/WalletLoadingScreen.tsx
+++ b/packages/demo/frontend/src/components/earn/WalletLoadingScreen.tsx
@@ -1,0 +1,7 @@
+/**
+ * @description Keeps the wallet surface visually stable while provider state is restored.
+ * @returns A blank wallet loading surface.
+ */
+export function WalletLoadingScreen() {
+  return <div className="min-h-screen bg-white" aria-busy="true" />
+}

--- a/packages/demo/frontend/src/pages/EarnPage.tsx
+++ b/packages/demo/frontend/src/pages/EarnPage.tsx
@@ -2,6 +2,7 @@ import { lazy, Suspense } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { WALLET_PROVIDERS } from '@/constants/walletProviders'
 import { WelcomeWalletPicker } from '@/components/earn/WelcomeWalletPicker'
+import { WalletLoadingScreen } from '@/components/earn/WalletLoadingScreen'
 
 // Lazy load wallet providers to reduce bundle size and build memory
 const PrivyProvider = lazy(() =>
@@ -75,7 +76,7 @@ export function EarnPage() {
 
   if (walletProvider === WALLET_PROVIDERS.TURNKEY) {
     return (
-      <Suspense fallback={<LoadingFallback />}>
+      <Suspense fallback={<WalletLoadingScreen />}>
         <TurnkeyProvider>
           <EarnWithTurnkeyWallet />
         </TurnkeyProvider>


### PR DESCRIPTION
# Problem

Turnkey users see authentication screens flash during refresh. Passkey login starts without a user gesture, and the UI renders before wallet restoration completes.

# Solution

Require explicit passkey actions and wait for restored wallet state.
