### PR TITLE
Fix Aave reserve reads

### DIFF
--- a/.changeset/fix-aave-reserve-reads.md
+++ b/.changeset/fix-aave-reserve-reads.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/actions-sdk': patch
+---
+
+Read Aave lend reserves directly with viem to avoid UI data-provider ABI mismatches.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -56,13 +56,10 @@
   "author": "Optimism PBC",
   "license": "MIT",
   "dependencies": {
-    "@aave/contract-helpers": "^1.30.0",
-    "@aave/math-utils": "^1.30.0",
     "@eth-optimism/viem": "^0.4.13",
     "@morpho-org/blue-sdk": ">=4.13.1 <4.14.0",
     "@morpho-org/blue-sdk-viem": ">=3.2.0 <3.3.0",
     "@morpho-org/morpho-ts": ">=2.4.6 <2.5.0",
-    "ethers": "^5.7.2",
     "permissionless": ">=0.2.57 <0.3.0"
   },
   "peerDependencies": {

--- a/packages/sdk/src/actions/borrow/providers/aave/prices.ts
+++ b/packages/sdk/src/actions/borrow/providers/aave/prices.ts
@@ -1,0 +1,71 @@
+import type { Address, PublicClient } from 'viem'
+
+import {
+  ADDRESSES_PROVIDER_ABI,
+  ORACLE_ABI,
+} from '@/actions/shared/aave/abis/pool.js'
+import { getAaveAddresses } from '@/actions/shared/aave/addresses.js'
+import { ChainNotSupportedError } from '@/core/error/errors.js'
+import type { AaveBorrowMarketConfig } from '@/types/borrow/index.js'
+
+import type { AavePositionState, AaveReservePrices } from './presentation.js'
+import { fetchAavePositionState } from './state.js'
+
+/**
+ * @description Reads base-currency oracle prices for both configured reserves.
+ * @param client - Public client for the market chain.
+ * @param config - Aave borrow market configuration.
+ * @returns Collateral and debt prices in the pool's base currency.
+ * @throws ChainNotSupportedError when Aave is not configured for the chain.
+ */
+async function fetchAavePrices(
+  client: PublicClient,
+  config: AaveBorrowMarketConfig,
+): Promise<AaveReservePrices> {
+  const addresses = getAaveAddresses(config.chainId)
+  if (!addresses) throw new ChainNotSupportedError({ chainId: config.chainId })
+
+  const oracle = await client.readContract({
+    address: addresses.poolAddressesProvider,
+    abi: ADDRESSES_PROVIDER_ABI,
+    functionName: 'getPriceOracle',
+  })
+  const [collateralPrice, debtPrice] = await client.multicall({
+    allowFailure: false,
+    contracts: [
+      {
+        address: oracle,
+        abi: ORACLE_ABI,
+        functionName: 'getAssetPrice',
+        args: [config.aave.collateralReserve],
+      },
+      {
+        address: oracle,
+        abi: ORACLE_ABI,
+        functionName: 'getAssetPrice',
+        args: [config.aave.debtReserve],
+      },
+    ],
+  })
+  return { collateralPrice, debtPrice }
+}
+
+/**
+ * @description Reads a wallet position and both reserve prices concurrently.
+ * @param client - Public client for the market chain.
+ * @param config - Aave borrow market configuration.
+ * @param user - Wallet whose position should be read.
+ * @returns Current position state and reserve prices.
+ * @throws A viem contract error when a position or oracle read fails.
+ */
+export async function fetchAaveStateAndPrices(
+  client: PublicClient,
+  config: AaveBorrowMarketConfig,
+  user: Address,
+): Promise<{ current: AavePositionState; prices: AaveReservePrices }> {
+  const [current, prices] = await Promise.all([
+    fetchAavePositionState(client, config, user),
+    fetchAavePrices(client, config),
+  ])
+  return { current, prices }
+}

--- a/packages/sdk/src/actions/borrow/providers/aave/quote.ts
+++ b/packages/sdk/src/actions/borrow/providers/aave/quote.ts
@@ -8,7 +8,7 @@ import {
   type AssembleAaveQuoteArgs,
   projectAavePositionState,
 } from '@/actions/borrow/providers/aave/presentation.js'
-import { fetchAaveStateAndPrices } from '@/actions/borrow/providers/aave/state.js'
+import { fetchAaveStateAndPrices } from '@/actions/borrow/providers/aave/prices.js'
 import {
   buildAaveCollateralDeposit,
   buildAaveCollateralWithdraw,

--- a/packages/sdk/src/actions/borrow/providers/aave/state.ts
+++ b/packages/sdk/src/actions/borrow/providers/aave/state.ts
@@ -1,28 +1,15 @@
-import {
-  type Address,
-  type ContractFunctionReturnType,
-  erc20Abi,
-  type PublicClient,
-} from 'viem'
+import { type Address, erc20Abi, type PublicClient } from 'viem'
 
+import { POOL_ACCOUNT_ABI } from '@/actions/shared/aave/abis/pool.js'
+import { requireAavePoolAddress } from '@/actions/shared/aave/addresses.js'
 import {
-  ADDRESSES_PROVIDER_ABI,
-  ORACLE_ABI,
-  POOL_ACCOUNT_ABI,
-  POOL_GET_RESERVE_DATA_ABI,
-} from '@/actions/shared/aave/abis/pool.js'
-import {
-  getAaveAddresses,
-  requireAavePoolAddress,
-} from '@/actions/shared/aave/addresses.js'
-import { ChainNotSupportedError } from '@/core/error/errors.js'
+  aaveReserveDataCall,
+  decodeAaveReserveData,
+  type DecodedAaveReserveData,
+} from '@/actions/shared/aave/reserve.js'
 import type { AaveBorrowMarketConfig } from '@/types/borrow/index.js'
 
-import type {
-  AaveMarketState,
-  AavePositionState,
-  AaveReservePrices,
-} from './presentation.js'
+import type { AaveMarketState, AavePositionState } from './presentation.js'
 
 /**
  * Decode the packed Aave reserve `configuration.data` bitmap.
@@ -44,45 +31,6 @@ export function decodeReserveConfig(data: bigint): {
   }
 }
 
-type RawReserveData = ContractFunctionReturnType<
-  typeof POOL_GET_RESERVE_DATA_ABI,
-  'view',
-  'getReserveData'
->
-
-interface DecodedReserveData {
-  configData: bigint
-  variableBorrowRateRay: bigint
-  aToken: Address
-  variableDebtToken: Address
-}
-
-/**
- * `getReserveData` returns a flat tuple. Pull out the fields the borrow
- * provider needs by their documented positions: configuration bitmap (0),
- * variable borrow rate (4), aToken address (8), variable debt token (10).
- * Positions follow the `ReserveData` struct field order:
- * https://github.com/aave/aave-v3-core/blob/master/contracts/protocol/libraries/types/DataTypes.sol
- */
-function decodeReserveData(reserve: RawReserveData): DecodedReserveData {
-  return {
-    configData: reserve[0].data,
-    variableBorrowRateRay: reserve[4],
-    aToken: reserve[8],
-    variableDebtToken: reserve[10],
-  }
-}
-
-/** A `getReserveData(asset)` multicall contract spec against the pool. */
-function reserveDataCall(pool: Address, asset: Address) {
-  return {
-    address: pool,
-    abi: POOL_GET_RESERVE_DATA_ABI,
-    functionName: 'getReserveData',
-    args: [asset],
-  } as const
-}
-
 /**
  * Read and decode both the debt and collateral reserves' `getReserveData`
  * in one multicall. Shared by the reserve-only read paths; the position
@@ -92,17 +40,20 @@ async function readBothReserveData(
   client: PublicClient,
   pool: Address,
   config: AaveBorrowMarketConfig,
-): Promise<{ debt: DecodedReserveData; collateral: DecodedReserveData }> {
+): Promise<{
+  debt: DecodedAaveReserveData
+  collateral: DecodedAaveReserveData
+}> {
   const [debtRaw, collateralRaw] = await client.multicall({
     allowFailure: false,
     contracts: [
-      reserveDataCall(pool, config.aave.debtReserve),
-      reserveDataCall(pool, config.aave.collateralReserve),
+      aaveReserveDataCall(pool, config.aave.debtReserve),
+      aaveReserveDataCall(pool, config.aave.collateralReserve),
     ],
   })
   return {
-    debt: decodeReserveData(debtRaw),
-    collateral: decodeReserveData(collateralRaw),
+    debt: decodeAaveReserveData(debtRaw),
+    collateral: decodeAaveReserveData(collateralRaw),
   }
 }
 
@@ -163,8 +114,8 @@ export async function fetchAavePositionState(
     await client.multicall({
       allowFailure: false,
       contracts: [
-        reserveDataCall(pool, config.aave.debtReserve),
-        reserveDataCall(pool, config.aave.collateralReserve),
+        aaveReserveDataCall(pool, config.aave.debtReserve),
+        aaveReserveDataCall(pool, config.aave.collateralReserve),
         {
           address: pool,
           abi: POOL_ACCOUNT_ABI,
@@ -174,8 +125,8 @@ export async function fetchAavePositionState(
       ],
     })
 
-  const debtReserve = decodeReserveData(debtReserveRaw)
-  const collateralReserve = decodeReserveData(collateralReserveRaw)
+  const debtReserve = decodeAaveReserveData(debtReserveRaw)
+  const collateralReserve = decodeAaveReserveData(collateralReserveRaw)
   const collateralConfig = decodeReserveConfig(collateralReserve.configData)
 
   const [collateralAmount, debtAmount] = await client.multicall({
@@ -227,59 +178,4 @@ export async function fetchAaveReserveTokens(
     aToken: collateral.aToken,
     variableDebtToken: debt.variableDebtToken,
   }
-}
-
-/**
- * Read base-currency (USD) oracle prices for the collateral and debt reserves.
- * Resolves the oracle via the pool addresses provider, then reads both prices.
- * Used by the write path to project the resulting position's health factor.
- */
-async function fetchAavePrices(
-  client: PublicClient,
-  config: AaveBorrowMarketConfig,
-): Promise<AaveReservePrices> {
-  const addresses = getAaveAddresses(config.chainId)
-  if (!addresses) throw new ChainNotSupportedError({ chainId: config.chainId })
-
-  const oracle = await client.readContract({
-    address: addresses.poolAddressesProvider,
-    abi: ADDRESSES_PROVIDER_ABI,
-    functionName: 'getPriceOracle',
-  })
-
-  const [collateralPrice, debtPrice] = await client.multicall({
-    allowFailure: false,
-    contracts: [
-      {
-        address: oracle,
-        abi: ORACLE_ABI,
-        functionName: 'getAssetPrice',
-        args: [config.aave.collateralReserve],
-      },
-      {
-        address: oracle,
-        abi: ORACLE_ABI,
-        functionName: 'getAssetPrice',
-        args: [config.aave.debtReserve],
-      },
-    ],
-  })
-
-  return { collateralPrice, debtPrice }
-}
-
-/**
- * Read the caller's position and the reserve prices in parallel. Both feed
- * `projectAavePositionState`, so every write path fetches them together.
- */
-export async function fetchAaveStateAndPrices(
-  client: PublicClient,
-  config: AaveBorrowMarketConfig,
-  user: Address,
-): Promise<{ current: AavePositionState; prices: AaveReservePrices }> {
-  const [current, prices] = await Promise.all([
-    fetchAavePositionState(client, config, user),
-    fetchAavePrices(client, config),
-  ])
-  return { current, prices }
 }

--- a/packages/sdk/src/actions/lend/providers/aave/__tests__/sdk.test.ts
+++ b/packages/sdk/src/actions/lend/providers/aave/__tests__/sdk.test.ts
@@ -1,0 +1,136 @@
+import {
+  createPublicClient,
+  custom,
+  encodeFunctionResult,
+  erc20Abi,
+  type Hex,
+  multicall3Abi,
+  type PublicClient,
+  zeroAddress,
+} from 'viem'
+import { mainnet, optimismSepolia } from 'viem/chains'
+import { describe, expect, it } from 'vitest'
+
+import {
+  calculateApyBreakdown,
+  getReserve,
+} from '@/actions/lend/providers/aave/sdk.js'
+import { POOL_GET_RESERVE_DATA_ABI } from '@/actions/shared/aave/abis/pool.js'
+import { WETH } from '@/constants/assets.js'
+import { ChainManager } from '@/services/ChainManager.js'
+import type { LendProviderConfig } from '@/types/actions.js'
+import type { LendMarketConfig } from '@/types/lend/index.js'
+import { getAssetAddress } from '@/utils/assets.js'
+
+const LIQUIDITY_RATE_RAY = 70_000_000_000_000_000_000_000_000n
+const AVAILABLE_LIQUIDITY = 6_026_826_049_431_131_650n
+const A_TOKEN_SUPPLY = 292_100_687_278_031_065_961n
+const A_TOKEN = '0x23e4ed24c1b47491edbc64d4f905225c6ae4d0a1'
+
+const reserveData = [
+  { data: 0n },
+  0n,
+  LIQUIDITY_RATE_RAY,
+  0n,
+  0n,
+  0n,
+  0,
+  0,
+  A_TOKEN,
+  zeroAddress,
+  zeroAddress,
+  zeroAddress,
+  0n,
+  0n,
+  0n,
+] as const
+
+class TestChainManager extends ChainManager {
+  constructor(private readonly client: PublicClient) {
+    super([])
+  }
+
+  override getPublicClient(): PublicClient {
+    return this.client
+  }
+}
+
+function createAaveClient(results: Hex[]): PublicClient {
+  return createPublicClient({
+    chain: mainnet,
+    transport: custom({
+      request: async () => {
+        const result = results.shift()
+        if (!result) throw new Error('Unexpected RPC request')
+        return result
+      },
+    }),
+  })
+}
+
+function encodedReserveReads(): Hex[] {
+  const availableLiquidity = encodeFunctionResult({
+    abi: erc20Abi,
+    functionName: 'balanceOf',
+    result: AVAILABLE_LIQUIDITY,
+  })
+  const totalSupply = encodeFunctionResult({
+    abi: erc20Abi,
+    functionName: 'totalSupply',
+    result: A_TOKEN_SUPPLY,
+  })
+  return [
+    encodeFunctionResult({
+      abi: POOL_GET_RESERVE_DATA_ABI,
+      functionName: 'getReserveData',
+      result: reserveData,
+    }),
+    encodeFunctionResult({
+      abi: multicall3Abi,
+      functionName: 'aggregate3',
+      result: [
+        { success: true, returnData: availableLiquidity },
+        { success: true, returnData: totalSupply },
+      ],
+    }),
+  ]
+}
+
+const wethAddress = getAssetAddress(WETH, optimismSepolia.id)
+const market: LendMarketConfig = {
+  address: wethAddress,
+  chainId: optimismSepolia.id,
+  name: 'Aave WETH Optimism Sepolia',
+  asset: WETH,
+  lendProvider: 'aave',
+}
+const lendConfig: LendProviderConfig = { marketAllowlist: [market] }
+
+describe('calculateApyBreakdown', () => {
+  it('converts a ray-sized liquidity rate without integer overflow', () => {
+    const apy = calculateApyBreakdown(LIQUIDITY_RATE_RAY)
+
+    expect(apy.native).toBeCloseTo(Math.exp(0.07) - 1, 8)
+    expect(apy.total).toBe(apy.native)
+  })
+})
+
+describe('getReserve', () => {
+  it('reads reserve state directly without the UI provider tuple', async () => {
+    const chainManager = new TestChainManager(
+      createAaveClient(encodedReserveReads()),
+    )
+
+    const reserve = await getReserve({
+      marketId: { address: wethAddress, chainId: optimismSepolia.id },
+      chainManager,
+      lendConfig,
+    })
+
+    expect(reserve.supply).toEqual({
+      totalAssets: AVAILABLE_LIQUIDITY,
+      totalShares: A_TOKEN_SUPPLY,
+    })
+    expect(reserve.apy.native).toBeGreaterThan(0)
+  })
+})

--- a/packages/sdk/src/actions/lend/providers/aave/sdk.ts
+++ b/packages/sdk/src/actions/lend/providers/aave/sdk.ts
@@ -1,20 +1,11 @@
-import { UiPoolDataProvider } from '@aave/contract-helpers'
-import { formatReserves } from '@aave/math-utils'
-import { providers } from 'ethers'
-import type { Address } from 'viem'
+import { type Address, formatUnits } from 'viem'
 
 import { findMarketInAllowlist } from '@/actions/lend/utils/markets.js'
-import { POOL_GET_RESERVE_DATA_ABI } from '@/actions/shared/aave/abis/pool.js'
-import {
-  getAaveAddresses,
-  getPoolAddress,
-} from '@/actions/shared/aave/addresses.js'
+import { requireAavePoolAddress } from '@/actions/shared/aave/addresses.js'
+import { readAaveReserveData } from '@/actions/shared/aave/reserve.js'
 import { WETH } from '@/constants/assets.js'
 import type { SupportedChainId } from '@/constants/supportedChains.js'
-import {
-  ChainNotSupportedError,
-  MarketNotAllowedError,
-} from '@/core/error/errors.js'
+import { MarketNotAllowedError } from '@/core/error/errors.js'
 import type { ChainManager } from '@/services/ChainManager.js'
 import type { LendProviderConfig } from '@/types/actions.js'
 import type {
@@ -23,250 +14,151 @@ import type {
   LendMarketConfig,
   LendMarketId,
 } from '@/types/lend/index.js'
-import { getAssetAddress } from '@/utils/assets.js'
+import { getAssetAddress, isNativeAsset } from '@/utils/assets.js'
+import { SECONDS_PER_YEAR } from '@/utils/constants.js'
+import { validateNotZeroAddress } from '@/utils/validation.js'
 
-/**
- * Parameters for getReserve function
- */
+import {
+  type AaveLendReserveState,
+  fetchAaveLendReserveState,
+} from './state.js'
+
+const SECONDS_PER_YEAR_NUMBER = Number(SECONDS_PER_YEAR)
+
 interface GetReserveParams {
-  /** Market identifier (asset address and chainId) */
   marketId: LendMarketId
-  /** Chain manager instance */
   chainManager: ChainManager
-  /** Lend configuration containing market allowlist */
   lendConfig?: LendProviderConfig
 }
 
-/**
- * Parameters for getReserves function
- */
 interface GetReservesParams {
   chainManager: ChainManager
   lendConfig: LendProviderConfig
   markets: LendMarketConfig[]
 }
 
-/**
- * Calculate APY breakdown from reserve data
- * @param reserve - Formatted reserve data from Aave
- * @returns APY breakdown with native APY and rewards
- */
-export function calculateApyBreakdown(reserve: {
-  formattedReserve?: any
-}): ApyBreakdown {
-  // Get supply APY from formatted reserve data
-  const supplyApy = reserve.formattedReserve?.supplyAPY
-    ? parseFloat(reserve.formattedReserve.supplyAPY)
-    : 0
+interface BuildMarketParams {
+  marketId: LendMarketId
+  config: LendMarketConfig
+  pool: Address
+  state: AaveLendReserveState
+}
 
-  // Aave doesn't have vault-style performance fees
-  // Total APY = Supply APY + any rewards (to be added later)
+function requireMarketConfig(params: GetReserveParams): LendMarketConfig {
+  const config = findMarketInAllowlist(
+    params.lendConfig?.marketAllowlist,
+    params.marketId,
+  )
+  if (config) return config
+  throw new MarketNotAllowedError({
+    address: params.marketId.address,
+    chainId: params.marketId.chainId,
+    reason: 'Market not found in allowlist',
+  })
+}
+
+function resolveReserveAsset(config: LendMarketConfig): Address {
+  return isNativeAsset(config.asset)
+    ? getAssetAddress(WETH, config.chainId)
+    : getAssetAddress(config.asset, config.chainId)
+}
+
+/**
+ * @description Converts an Aave liquidity rate from ray units to compounded APY.
+ * @param liquidityRateRay - Annualized supply rate scaled by 1e27.
+ * @returns Native, reward, fee, and total APY components as decimal fractions.
+ */
+export function calculateApyBreakdown(liquidityRateRay: bigint): ApyBreakdown {
+  const annualRate = Number(formatUnits(liquidityRateRay, 27))
+  const supplyApy = Math.expm1(
+    SECONDS_PER_YEAR_NUMBER * Math.log1p(annualRate / SECONDS_PER_YEAR_NUMBER),
+  )
   return {
     total: supplyApy,
     native: supplyApy,
-    totalRewards: 0, // TODO: Fetch from incentives data provider if needed
-    performanceFee: 0, // Aave doesn't have performance fees
+    totalRewards: 0,
+    performanceFee: 0,
+  }
+}
+
+function buildMarket(params: BuildMarketParams): LendMarket {
+  const lastUpdate = Math.floor(Date.now() / 1000)
+  return {
+    marketId: params.marketId,
+    name: params.config.name,
+    asset: params.config.asset,
+    supply: {
+      totalAssets: params.state.availableLiquidity,
+      totalShares: params.state.totalSupply,
+    },
+    apy: calculateApyBreakdown(params.state.liquidityRateRay),
+    metadata: {
+      owner: params.pool,
+      curator: params.pool,
+      fee: 0,
+      lastUpdate,
+    },
   }
 }
 
 /**
- * Get detailed reserve (market) information from Aave
- * @param params - Named parameters object
- * @returns Promise resolving to detailed market information
+ * @description Gets one configured Aave lend market from onchain reserve state.
+ * @param params - Market identifier, chain manager, and lend configuration.
+ * @returns Detailed market liquidity, shares, APY, and metadata.
+ * @throws MarketNotAllowedError when the market is absent from the allowlist.
+ * @throws ChainNotSupportedError when Aave is not configured for the chain.
  */
 export async function getReserve(
   params: GetReserveParams,
 ): Promise<LendMarket> {
-  // Find market configuration in allowlist for metadata
-  const marketConfig = params.lendConfig?.marketAllowlist
-    ? findMarketInAllowlist(params.lendConfig.marketAllowlist, params.marketId)
-    : undefined
-
-  if (!marketConfig) {
-    throw new MarketNotAllowedError({
-      address: params.marketId.address,
-      chainId: params.marketId.chainId,
-      reason: 'Market not found in allowlist',
-    })
-  }
-
-  const addresses = getAaveAddresses(params.marketId.chainId)
-  if (!addresses) {
-    throw new ChainNotSupportedError({ chainId: params.marketId.chainId })
-  }
-
-  const poolAddress = addresses.pool
-  const uiPoolDataProviderAddress = addresses.uiPoolDataProvider
-  const poolAddressesProvider = addresses.poolAddressesProvider
-
-  try {
-    // Get viem public client for this chain
-    const publicClient = params.chainManager.getPublicClient(
-      params.marketId.chainId,
-    )
-
-    // Create ethers provider from viem's RPC URL
-    // Aave SDK requires ethers provider, not viem
-    const rpcUrl =
-      publicClient.chain?.rpcUrls.default.http[0] ||
-      publicClient.chain?.rpcUrls.public?.http[0]
-    if (!rpcUrl) {
-      throw new Error(
-        `No RPC URL available for chain ${params.marketId.chainId}`,
-      )
-    }
-    const ethersProvider = new providers.JsonRpcProvider(rpcUrl)
-
-    // Create UiPoolDataProvider instance
-    const uiPoolDataProvider = new UiPoolDataProvider({
-      uiPoolDataProviderAddress,
-      provider: ethersProvider,
-      chainId: params.marketId.chainId,
-    })
-
-    // Fetch reserve data
-    const reservesData = await uiPoolDataProvider.getReservesHumanized({
-      lendingPoolAddressProvider: poolAddressesProvider,
-    })
-
-    // Find the specific reserve for this asset
-    // For native ETH assets, use WETH address since Aave uses WETH internally
-    const assetAddress =
-      marketConfig.asset.type === 'native'
-        ? getAssetAddress(WETH, params.marketId.chainId)
-        : getAssetAddress(marketConfig.asset, params.marketId.chainId)
-
-    const reserve = reservesData.reservesData.find(
-      (r) => r.underlyingAsset.toLowerCase() === assetAddress.toLowerCase(),
-    )
-
-    if (!reserve) {
-      throw new Error(
-        `Reserve not found for asset ${assetAddress} on chain ${params.marketId.chainId}`,
-      )
-    }
-
-    // Format reserves using Aave math-utils
-    const currentTimestamp = Math.floor(Date.now() / 1000)
-    const formattedReserves = formatReserves({
-      reserves: [reserve],
-      currentTimestamp,
-      marketReferenceCurrencyDecimals:
-        reservesData.baseCurrencyData.marketReferenceCurrencyDecimals,
-      marketReferencePriceInUsd:
-        reservesData.baseCurrencyData.marketReferenceCurrencyPriceInUsd,
-    })
-
-    const formattedReserve = formattedReserves[0]
-
-    // Calculate APY breakdown
-    const apy = calculateApyBreakdown({
-      ...reserve,
-      formattedReserve,
-    })
-
-    // Return market information in our standard format
-    return {
-      marketId: params.marketId,
-      name: marketConfig.name,
-      asset: marketConfig.asset,
-      supply: {
-        totalAssets: BigInt(reserve.availableLiquidity),
-        totalShares: BigInt(reserve.totalScaledVariableDebt || '0'),
-      },
-      apy,
-      metadata: {
-        owner: poolAddress, // Use Pool as owner
-        curator: poolAddress, // No curator in Aave
-        fee: 0, // No performance fee in Aave
-        lastUpdate: currentTimestamp,
-      },
-    }
-  } catch (error) {
-    throw new Error(
-      `Failed to get reserve info for ${params.marketId.address}: ${
-        error instanceof Error ? error.message : 'Unknown error'
-      }`,
-    )
-  }
+  const config = requireMarketConfig(params)
+  const pool = requireAavePoolAddress(params.marketId.chainId)
+  const asset = resolveReserveAsset(config)
+  const client = params.chainManager.getPublicClient(params.marketId.chainId)
+  const state = await fetchAaveLendReserveState(client, pool, asset)
+  return buildMarket({ marketId: params.marketId, config, pool, state })
 }
 
 /**
- * Get multiple reserves (markets)
- * @param params - Parameters including markets to fetch
- * @returns Promise resolving to array of market information
+ * @description Gets all configured Aave lend markets concurrently.
+ * @param params - Markets, chain manager, and lend configuration.
+ * @returns Detailed market information in input order.
+ * @throws MarketNotAllowedError when a market is absent from the allowlist.
+ * @throws ChainNotSupportedError when Aave is not configured for a chain.
  */
 export async function getReserves(
   params: GetReservesParams,
 ): Promise<LendMarket[]> {
-  try {
-    const reservePromises = params.markets.map((marketConfig) => {
-      return getReserve({
-        marketId: {
-          address: marketConfig.address,
-          chainId: marketConfig.chainId,
-        },
+  return Promise.all(
+    params.markets.map((market) =>
+      getReserve({
+        marketId: { address: market.address, chainId: market.chainId },
         chainManager: params.chainManager,
         lendConfig: params.lendConfig,
-      })
-    })
-
-    return await Promise.all(reservePromises)
-  } catch (error) {
-    throw new Error(
-      `Failed to get reserves: ${
-        error instanceof Error ? error.message : 'Unknown error'
-      }`,
-    )
-  }
+      }),
+    ),
+  )
 }
 
 /**
- * Get aToken address for a given underlying asset
- * @param params - Parameters including asset address, chain ID, and chain manager
- * @returns Promise resolving to aToken address
- * @description Queries the Aave Pool to get the aToken address for the underlying asset
+ * @description Resolves an Aave reserve's aToken directly from the Pool.
+ * @param params - Underlying asset, chain ID, and chain manager.
+ * @returns The interest-bearing aToken address.
+ * @throws ChainNotSupportedError when Aave is not configured for the chain.
+ * @throws ZeroAddressError when the Pool has no reserve for the asset.
  */
 export async function getATokenAddress(params: {
   underlyingAsset: Address
   chainId: SupportedChainId
   chainManager: ChainManager
 }): Promise<Address> {
-  const poolAddress = getPoolAddress(params.chainId)
-  if (!poolAddress) {
-    throw new ChainNotSupportedError({ chainId: params.chainId })
-  }
-
-  try {
-    // Get viem public client for this chain
-    const publicClient = params.chainManager.getPublicClient(params.chainId)
-
-    // Query the Pool contract directly for reserve data
-    const reserveData = await publicClient.readContract({
-      address: poolAddress,
-      abi: POOL_GET_RESERVE_DATA_ABI,
-      functionName: 'getReserveData',
-      args: [params.underlyingAsset],
-    })
-
-    // The return is a tuple where index 8 is aTokenAddress
-    const aTokenAddress = reserveData[8]
-
-    if (
-      !aTokenAddress ||
-      aTokenAddress === '0x0000000000000000000000000000000000000000'
-    ) {
-      throw new Error(
-        `No aToken found for asset ${params.underlyingAsset} on chain ${params.chainId}`,
-      )
-    }
-
-    return aTokenAddress
-  } catch (error) {
-    throw new Error(
-      `Failed to get aToken address for ${params.underlyingAsset}: ${
-        error instanceof Error ? error.message : 'Unknown error'
-      }`,
-    )
-  }
+  const pool = requireAavePoolAddress(params.chainId)
+  const client = params.chainManager.getPublicClient(params.chainId)
+  const reserve = await readAaveReserveData(
+    client,
+    pool,
+    params.underlyingAsset,
+  )
+  validateNotZeroAddress(reserve.aToken, 'Aave aToken')
+  return reserve.aToken
 }

--- a/packages/sdk/src/actions/lend/providers/aave/state.ts
+++ b/packages/sdk/src/actions/lend/providers/aave/state.ts
@@ -1,0 +1,50 @@
+import { type Address, erc20Abi, type PublicClient } from 'viem'
+
+import { readAaveReserveData } from '@/actions/shared/aave/reserve.js'
+
+/** Aave reserve state needed by the lend market presentation. */
+export interface AaveLendReserveState {
+  /** Underlying liquidity currently held by the aToken contract. */
+  availableLiquidity: bigint
+  /** Total issued aToken shares. */
+  totalSupply: bigint
+  /** Current supply rate in ray units. */
+  liquidityRateRay: bigint
+}
+
+/**
+ * @description Reads one Aave reserve through Pool and ERC-20 calls.
+ * @param client - Public client for the reserve chain.
+ * @param pool - Aave Pool address.
+ * @param asset - Underlying reserve asset address.
+ * @returns Liquidity, share supply, and supply rate.
+ * @throws A viem contract error when a reserve or token read fails.
+ */
+export async function fetchAaveLendReserveState(
+  client: PublicClient,
+  pool: Address,
+  asset: Address,
+): Promise<AaveLendReserveState> {
+  const reserve = await readAaveReserveData(client, pool, asset)
+  const [availableLiquidity, totalSupply] = await client.multicall({
+    allowFailure: false,
+    contracts: [
+      {
+        address: asset,
+        abi: erc20Abi,
+        functionName: 'balanceOf',
+        args: [reserve.aToken],
+      },
+      {
+        address: reserve.aToken,
+        abi: erc20Abi,
+        functionName: 'totalSupply',
+      },
+    ],
+  })
+  return {
+    availableLiquidity,
+    totalSupply,
+    liquidityRateRay: reserve.liquidityRateRay,
+  }
+}

--- a/packages/sdk/src/actions/shared/aave/reserve.ts
+++ b/packages/sdk/src/actions/shared/aave/reserve.ts
@@ -1,0 +1,72 @@
+import type { Address, ContractFunctionReturnType, PublicClient } from 'viem'
+
+import { POOL_GET_RESERVE_DATA_ABI } from './abis/pool.js'
+
+type RawAaveReserveData = ContractFunctionReturnType<
+  typeof POOL_GET_RESERVE_DATA_ABI,
+  'view',
+  'getReserveData'
+>
+
+/** Decoded Aave reserve fields shared by lend and borrow providers. */
+export interface DecodedAaveReserveData {
+  /** Packed reserve configuration bitmap. */
+  configData: bigint
+  /** Current supply rate in ray units. */
+  liquidityRateRay: bigint
+  /** Current variable borrow rate in ray units. */
+  variableBorrowRateRay: bigint
+  /** Interest-bearing token address. */
+  aToken: Address
+  /** Variable debt token address. */
+  variableDebtToken: Address
+}
+
+/**
+ * @description Decodes the shared fields from an Aave Pool reserve tuple.
+ * @param reserve - Raw `getReserveData` return value.
+ * @returns Reserve configuration, rates, and token addresses.
+ */
+export function decodeAaveReserveData(
+  reserve: RawAaveReserveData,
+): DecodedAaveReserveData {
+  return {
+    configData: reserve[0].data,
+    liquidityRateRay: reserve[2],
+    variableBorrowRateRay: reserve[4],
+    aToken: reserve[8],
+    variableDebtToken: reserve[10],
+  }
+}
+
+/**
+ * @description Builds a typed Aave Pool `getReserveData` contract call.
+ * @param pool - Aave Pool address.
+ * @param asset - Underlying reserve asset address.
+ * @returns A viem contract-call descriptor.
+ */
+export function aaveReserveDataCall(pool: Address, asset: Address) {
+  return {
+    address: pool,
+    abi: POOL_GET_RESERVE_DATA_ABI,
+    functionName: 'getReserveData',
+    args: [asset],
+  } as const
+}
+
+/**
+ * @description Reads and decodes one reserve directly from the Aave Pool.
+ * @param client - Public client for the reserve chain.
+ * @param pool - Aave Pool address.
+ * @param asset - Underlying reserve asset address.
+ * @returns Decoded reserve configuration, rates, and token addresses.
+ * @throws A viem contract error when the Pool read fails.
+ */
+export async function readAaveReserveData(
+  client: PublicClient,
+  pool: Address,
+  asset: Address,
+): Promise<DecodedAaveReserveData> {
+  const reserve = await client.readContract(aaveReserveDataCall(pool, asset))
+  return decodeAaveReserveData(reserve)
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -297,12 +297,6 @@ importers:
 
   packages/sdk:
     dependencies:
-      '@aave/contract-helpers':
-        specifier: ^1.30.0
-        version: 1.38.0(bignumber.js@9.3.1)(encoding@0.1.13)(ethers@5.8.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(reflect-metadata@0.2.2)(tslib@2.8.1)
-      '@aave/math-utils':
-        specifier: ^1.30.0
-        version: 1.38.0(bignumber.js@9.3.1)(tslib@2.8.1)
       '@dynamic-labs/ethereum':
         specifier: '>=4.31.4 <5.0.0'
         version: 4.92.2(@dynamic-labs-wallet/primitives@1.0.48)(@types/react@18.3.31)(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@18.3.1))(utf-8-validate@6.0.6)(viem@2.33.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))(zod@3.25.76)
@@ -330,9 +324,6 @@ importers:
       '@privy-io/react-auth':
         specifier: '>=2.24.0 <3.0.0'
         version: 2.25.0(@solana-program/system@0.10.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)))(@solana-program/token@0.9.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)))(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))(@solana/spl-token@0.4.14(@solana/web3.js@1.98.1(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))(@solana/web3.js@1.98.1(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6))(@types/react@18.3.31)(bs58@6.0.0)(bufferutil@4.1.0)(css-to-react-native@3.2.0)(fastestsmallesttextencoderdecoder@1.0.22)(permissionless@0.2.57(ox@0.9.3(typescript@5.9.3)(zod@3.25.76))(viem@2.33.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@18.3.1))(utf-8-validate@6.0.6)(zod@3.25.76)
-      ethers:
-        specifier: ^5.7.2
-        version: 5.8.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       permissionless:
         specifier: '>=0.2.57 <0.3.0'
         version: 0.2.57(ox@0.9.3(typescript@5.9.3)(zod@3.25.76))(viem@2.33.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))
@@ -392,20 +383,6 @@ packages:
     peerDependencies:
       graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
       typescript: ^5.0.0 || ^6.0.0
-
-  '@aave/contract-helpers@1.38.0':
-    resolution: {integrity: sha512-Z0lGFcU77OH+NaAUP3REJ9iGws+Fjndg2xtSHmGCu/ZJUL6MZsEjKhw4U6pxJXVOnCPZQsgflcrANnLX8z/JjA==}
-    peerDependencies:
-      bignumber.js: ^9.x
-      ethers: ^5.x
-      reflect-metadata: ^0.1.x
-      tslib: ^2.4.x
-
-  '@aave/math-utils@1.38.0':
-    resolution: {integrity: sha512-Zeq2Dpflb5zst3OZKHA7UMVI4wcfpxbxA8tXZyVTmw313Q7oF1oOctrEF3JnfyjcyusmU91qdJRrCAXQrQtyXA==}
-    peerDependencies:
-      bignumber.js: ^9.x
-      tslib: ^2.4.x
 
   '@ably/msgpack-js@0.4.1':
     resolution: {integrity: sha512-Sjxj6SOr17hExAVrsycN7u6oV4PhZcK7Z2S8dM71CH/butgO47cSo/TL6FJPCXUyDAzKkOWjMUpJGyZkEpyu4Q==}
@@ -1692,12 +1669,6 @@ packages:
   '@ethersproject/hash@5.8.0':
     resolution: {integrity: sha512-ac/lBcTbEWW/VGJij0CNSw/wPcw9bSRgCB0AIBz8CvED/jfvDoV9hsIIiWfvWmFEi8RcXtlNwp2jv6ozWOsooA==}
 
-  '@ethersproject/hdnode@5.8.0':
-    resolution: {integrity: sha512-4bK1VF6E83/3/Im0ERnnUeWOY3P1BZml4ZD3wcH8Ys0/d1h1xaFt6Zc+Dh9zXf9TapGro0T4wvO71UTCp3/uoA==}
-
-  '@ethersproject/json-wallets@5.8.0':
-    resolution: {integrity: sha512-HxblNck8FVUtNxS3VTEYJAcwiKYsBIF77W15HufqlBF9gGfhmYOJtYZp8fSDZtn9y5EaXTE87zDwzxRoTFk11w==}
-
   '@ethersproject/keccak256@5.8.0':
     resolution: {integrity: sha512-A1pkKLZSz8pDaQ1ftutZoaN46I6+jvuqugx5KYNeQOPqq+JZ0Txm7dlWesCHB5cndJSu5vP2VKptKf7cksERng==}
 
@@ -1706,9 +1677,6 @@ packages:
 
   '@ethersproject/networks@5.8.0':
     resolution: {integrity: sha512-egPJh3aPVAzbHwq8DD7Po53J4OUSsA1MjQp8Vf/OZPav5rlmWUaFLiq8cvQiGK0Z5K6LYzm29+VA/p4RL1FzNg==}
-
-  '@ethersproject/pbkdf2@5.8.0':
-    resolution: {integrity: sha512-wuHiv97BrzCmfEaPbUFpMjlVg/IDkZThp9Ri88BpjRleg4iePJaj2SW8AIyE8cXn5V1tuAaMj6lzvsGJkGWskg==}
 
   '@ethersproject/properties@5.8.0':
     resolution: {integrity: sha512-PYuiEoQ+FMaZZNGrStmN7+lWjlsoufGIHdww7454FIaGdbe/p5rnaCXTr5MtBYl3NkeoVhHZuyzChPeGeKIpQw==}
@@ -1728,9 +1696,6 @@ packages:
   '@ethersproject/signing-key@5.8.0':
     resolution: {integrity: sha512-LrPW2ZxoigFi6U6aVkFN/fa9Yx/+4AtIUe4/HACTvKJdhm0eeb107EVCIQcrLZkxaSIgc/eCrX8Q1GtbH+9n3w==}
 
-  '@ethersproject/solidity@5.8.0':
-    resolution: {integrity: sha512-4CxFeCgmIWamOHwYN9d+QWGxye9qQLilpgTU0XhYs1OahkclF+ewO+3V1U0mvpiuQxm5EHHmv8f7ClVII8EHsA==}
-
   '@ethersproject/strings@5.8.0':
     resolution: {integrity: sha512-qWEAk0MAvl0LszjdfnZ2uC8xbR2wdv4cDabyHiBh3Cldq/T8dPH3V4BbBsAYJUeonwD+8afVXld274Ls+Y1xXg==}
 
@@ -1740,14 +1705,8 @@ packages:
   '@ethersproject/units@5.8.0':
     resolution: {integrity: sha512-lxq0CAnc5kMGIiWW4Mr041VT8IhNM+Pn5T3haO74XZWFulk7wH1Gv64HqE96hT4a7iiNMdOCFEBgaxWuk8ETKQ==}
 
-  '@ethersproject/wallet@5.8.0':
-    resolution: {integrity: sha512-G+jnzmgg6UxurVKRKvw27h0kvG75YKXZKdlLYmAHeF32TGUzHkOFd7Zn6QHOTYRFWnfjtSSFjBowKo7vfrXzPA==}
-
   '@ethersproject/web@5.8.0':
     resolution: {integrity: sha512-j7+Ksi/9KfGviws6Qtf9Q7KCqRhpwrYKQPs+JBA/rKVFF/yaWLHJEH3zfVP2plVu+eys0d2DlFmhoQJayFewcw==}
-
-  '@ethersproject/wordlists@5.8.0':
-    resolution: {integrity: sha512-2df9bbXicZws2Sb5S6ET493uJ0Z84Fjr3pC4tu/qlnZERibZCeUVuqdtt+7Tv9xxhUxHoIekIA7avrKUWHrezg==}
 
   '@evervault/wasm-attestation-bindings@0.3.1':
     resolution: {integrity: sha512-pJsbax/pEPdRXSnFKahzGZeq2CNTZ0skAPWpnEZK/8vdcvlan7LE7wMSOVr+Z+MqTBnVEnS7O80TKpXKU5Rsbw==}
@@ -4094,9 +4053,6 @@ packages:
     resolution: {integrity: sha512-4B/qKCfeE/ODUaAUpSwfzazo5x29WD4r3vXiWsB7I2mSDAihwEqKO+g8GELZUQSSAo5e1XTYh3ZVfLyxBc12nA==}
     engines: {node: '>= 10.0.0'}
 
-  aes-js@3.0.0:
-    resolution: {integrity: sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==}
-
   aes-js@4.0.0-beta.5:
     resolution: {integrity: sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==}
 
@@ -5093,9 +5049,6 @@ packages:
   ethereum-cryptography@2.2.1:
     resolution: {integrity: sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg==}
 
-  ethers@5.8.0:
-    resolution: {integrity: sha512-DUq+7fHrCg1aPDFCHx6UIPb3nmt2XMpM7Y/g2gLhsl3lIBqeAfOJIl1qEvRf2uq3BiKxmh6Fh5pfp2ieyek7Kg==}
-
   ethers@6.17.0:
     resolution: {integrity: sha512-BpyrpIPJ3ydEVow8zGaz1DuPS7YU8DcWxuBnY9a0UA/lvAPwrMr+EPXsfrul628SRaekPNeIM4UFh/91GWZang==}
     engines: {node: '>=14.0.0'}
@@ -5718,9 +5671,6 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
-
-  isomorphic-unfetch@3.1.0:
-    resolution: {integrity: sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==}
 
   isomorphic-ws@4.0.1:
     resolution: {integrity: sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==}
@@ -6916,9 +6866,6 @@ packages:
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
-  scrypt-js@3.0.1:
-    resolution: {integrity: sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==}
-
   secure-json-parse@2.7.0:
     resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
 
@@ -7412,9 +7359,6 @@ packages:
     resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
     engines: {node: '>=18.17'}
 
-  unfetch@4.2.0:
-    resolution: {integrity: sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==}
-
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
     engines: {node: '>=4'}
@@ -7899,21 +7843,6 @@ snapshots:
       '@gql.tada/internal': 1.2.1(graphql@16.14.2)(typescript@5.9.3)
       graphql: 16.14.2
       typescript: 5.9.3
-
-  '@aave/contract-helpers@1.38.0(bignumber.js@9.3.1)(encoding@0.1.13)(ethers@5.8.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(reflect-metadata@0.2.2)(tslib@2.8.1)':
-    dependencies:
-      bignumber.js: 9.3.1
-      ethers: 5.8.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      isomorphic-unfetch: 3.1.0(encoding@0.1.13)
-      reflect-metadata: 0.2.2
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - encoding
-
-  '@aave/math-utils@1.38.0(bignumber.js@9.3.1)(tslib@2.8.1)':
-    dependencies:
-      bignumber.js: 9.3.1
-      tslib: 2.8.1
 
   '@ably/msgpack-js@0.4.1':
     dependencies:
@@ -10165,37 +10094,6 @@ snapshots:
       '@ethersproject/properties': 5.8.0
       '@ethersproject/strings': 5.8.0
 
-  '@ethersproject/hdnode@5.8.0':
-    dependencies:
-      '@ethersproject/abstract-signer': 5.8.0
-      '@ethersproject/basex': 5.8.0
-      '@ethersproject/bignumber': 5.8.0
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      '@ethersproject/pbkdf2': 5.8.0
-      '@ethersproject/properties': 5.8.0
-      '@ethersproject/sha2': 5.8.0
-      '@ethersproject/signing-key': 5.8.0
-      '@ethersproject/strings': 5.8.0
-      '@ethersproject/transactions': 5.8.0
-      '@ethersproject/wordlists': 5.8.0
-
-  '@ethersproject/json-wallets@5.8.0':
-    dependencies:
-      '@ethersproject/abstract-signer': 5.8.0
-      '@ethersproject/address': 5.8.0
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/hdnode': 5.8.0
-      '@ethersproject/keccak256': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      '@ethersproject/pbkdf2': 5.8.0
-      '@ethersproject/properties': 5.8.0
-      '@ethersproject/random': 5.8.0
-      '@ethersproject/strings': 5.8.0
-      '@ethersproject/transactions': 5.8.0
-      aes-js: 3.0.0
-      scrypt-js: 3.0.1
-
   '@ethersproject/keccak256@5.8.0':
     dependencies:
       '@ethersproject/bytes': 5.8.0
@@ -10206,11 +10104,6 @@ snapshots:
   '@ethersproject/networks@5.8.0':
     dependencies:
       '@ethersproject/logger': 5.8.0
-
-  '@ethersproject/pbkdf2@5.8.0':
-    dependencies:
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/sha2': 5.8.0
 
   '@ethersproject/properties@5.8.0':
     dependencies:
@@ -10267,15 +10160,6 @@ snapshots:
       elliptic: 6.6.1
       hash.js: 1.1.7
 
-  '@ethersproject/solidity@5.8.0':
-    dependencies:
-      '@ethersproject/bignumber': 5.8.0
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/keccak256': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      '@ethersproject/sha2': 5.8.0
-      '@ethersproject/strings': 5.8.0
-
   '@ethersproject/strings@5.8.0':
     dependencies:
       '@ethersproject/bytes': 5.8.0
@@ -10300,36 +10184,10 @@ snapshots:
       '@ethersproject/constants': 5.8.0
       '@ethersproject/logger': 5.8.0
 
-  '@ethersproject/wallet@5.8.0':
-    dependencies:
-      '@ethersproject/abstract-provider': 5.8.0
-      '@ethersproject/abstract-signer': 5.8.0
-      '@ethersproject/address': 5.8.0
-      '@ethersproject/bignumber': 5.8.0
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/hash': 5.8.0
-      '@ethersproject/hdnode': 5.8.0
-      '@ethersproject/json-wallets': 5.8.0
-      '@ethersproject/keccak256': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      '@ethersproject/properties': 5.8.0
-      '@ethersproject/random': 5.8.0
-      '@ethersproject/signing-key': 5.8.0
-      '@ethersproject/transactions': 5.8.0
-      '@ethersproject/wordlists': 5.8.0
-
   '@ethersproject/web@5.8.0':
     dependencies:
       '@ethersproject/base64': 5.8.0
       '@ethersproject/bytes': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      '@ethersproject/properties': 5.8.0
-      '@ethersproject/strings': 5.8.0
-
-  '@ethersproject/wordlists@5.8.0':
-    dependencies:
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/hash': 5.8.0
       '@ethersproject/logger': 5.8.0
       '@ethersproject/properties': 5.8.0
       '@ethersproject/strings': 5.8.0
@@ -17216,8 +17074,6 @@ snapshots:
 
   address@1.2.2: {}
 
-  aes-js@3.0.0: {}
-
   aes-js@4.0.0-beta.5: {}
 
   agent-base@6.0.2:
@@ -18440,42 +18296,6 @@ snapshots:
       '@scure/bip32': 1.4.0
       '@scure/bip39': 1.3.0
 
-  ethers@5.8.0(bufferutil@4.1.0)(utf-8-validate@6.0.6):
-    dependencies:
-      '@ethersproject/abi': 5.8.0
-      '@ethersproject/abstract-provider': 5.8.0
-      '@ethersproject/abstract-signer': 5.8.0
-      '@ethersproject/address': 5.8.0
-      '@ethersproject/base64': 5.8.0
-      '@ethersproject/basex': 5.8.0
-      '@ethersproject/bignumber': 5.8.0
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/constants': 5.8.0
-      '@ethersproject/contracts': 5.8.0
-      '@ethersproject/hash': 5.8.0
-      '@ethersproject/hdnode': 5.8.0
-      '@ethersproject/json-wallets': 5.8.0
-      '@ethersproject/keccak256': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      '@ethersproject/networks': 5.8.0
-      '@ethersproject/pbkdf2': 5.8.0
-      '@ethersproject/properties': 5.8.0
-      '@ethersproject/providers': 5.8.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      '@ethersproject/random': 5.8.0
-      '@ethersproject/rlp': 5.8.0
-      '@ethersproject/sha2': 5.8.0
-      '@ethersproject/signing-key': 5.8.0
-      '@ethersproject/solidity': 5.8.0
-      '@ethersproject/strings': 5.8.0
-      '@ethersproject/transactions': 5.8.0
-      '@ethersproject/units': 5.8.0
-      '@ethersproject/wallet': 5.8.0
-      '@ethersproject/web': 5.8.0
-      '@ethersproject/wordlists': 5.8.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
   ethers@6.17.0(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
@@ -19114,13 +18934,6 @@ snapshots:
   isarray@2.0.5: {}
 
   isexe@2.0.0: {}
-
-  isomorphic-unfetch@3.1.0(encoding@0.1.13):
-    dependencies:
-      node-fetch: 2.7.0(encoding@0.1.13)
-      unfetch: 4.2.0
-    transitivePeerDependencies:
-      - encoding
 
   isomorphic-ws@4.0.1(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
     dependencies:
@@ -20466,8 +20279,6 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
-  scrypt-js@3.0.1: {}
-
   secure-json-parse@2.7.0: {}
 
   secure-json-parse@4.1.0: {}
@@ -21013,8 +20824,6 @@ snapshots:
     optional: true
 
   undici@6.27.0: {}
-
-  unfetch@4.2.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 


### PR DESCRIPTION
# Problem

Users cannot load Aave markets on Optimism Sepolia because reserve reads overflow. The Aave helper upgrade in [#530](https://github.com/ethereum-optimism/actions/pull/530) moved from 1.36.2 to 1.38.0, whose ABI cannot decode the older UI data provider still deployed there ([More details](https://gist.github.com/its-everdred/c6b71564f3195bb355c28eb4d3f93d6d)). We use Aave's packages only to aggregate and format lend-market reserve data while the rest of the provider already uses viem; version 1.38 retargeted the same `getReservesHumanized` helper to the V3.6+ tuple without a legacy or versioned method, so there is no newer SDK function compatible with Optimism Sepolia's older deployment.

# Solution

Read pool and reserve data directly with viem.
