### PR TITLE
fix: Privy UX issues

### DIFF
--- a/packages/demo/frontend/src/components/earn/EarnWithPrivyServerWallet.spec.tsx
+++ b/packages/demo/frontend/src/components/earn/EarnWithPrivyServerWallet.spec.tsx
@@ -1,0 +1,74 @@
+import { render, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const privyMocks = vi.hoisted(() => ({
+  addSessionSigners: vi.fn(),
+  walletsReady: false,
+}))
+
+vi.mock('@privy-io/react-auth', () => ({
+  useIdentityToken: () => ({ identityToken: 'identity-token' }),
+  useLogout: () => ({ logout: vi.fn() }),
+  usePrivy: () => ({
+    authenticated: true,
+    getAccessToken: vi.fn(),
+    ready: true,
+  }),
+  useSessionSigners: () => ({
+    addSessionSigners: privyMocks.addSessionSigners,
+  }),
+  useUser: () => ({
+    user: {
+      id: 'privy-user',
+      linkedAccounts: [
+        {
+          address: '0x0000000000000000000000000000000000000001',
+          chainType: 'ethereum',
+          delegated: false,
+          type: 'wallet',
+          walletClientType: 'privy',
+        },
+      ],
+    },
+  }),
+  useWallets: () => ({ ready: privyMocks.walletsReady, wallets: [] }),
+}))
+
+vi.mock('@/envVars', () => ({
+  env: { VITE_SESSION_SIGNER_ID: 'session-signer' },
+}))
+
+vi.mock('@/utils/analytics', () => ({
+  identifyUser: vi.fn(),
+  trackEvent: vi.fn(),
+}))
+
+vi.mock('./EarnWithServerWallet', () => ({
+  EarnWithServerWallet: () => null,
+}))
+
+import { EarnWithPrivyServerWallet } from './EarnWithPrivyServerWallet'
+
+describe('EarnWithPrivyServerWallet', () => {
+  beforeEach(() => {
+    privyMocks.addSessionSigners.mockReset().mockResolvedValue({})
+    privyMocks.walletsReady = false
+  })
+
+  it('waits for Privy wallets before adding session signers', async () => {
+    const { rerender } = render(<EarnWithPrivyServerWallet />)
+
+    expect(privyMocks.addSessionSigners).not.toHaveBeenCalled()
+
+    privyMocks.walletsReady = true
+    rerender(<EarnWithPrivyServerWallet />)
+
+    await waitFor(() =>
+      expect(privyMocks.addSessionSigners).toHaveBeenCalledWith({
+        address: '0x0000000000000000000000000000000000000001',
+        signers: [{ signerId: 'session-signer' }],
+      }),
+    )
+    expect(privyMocks.addSessionSigners).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/demo/frontend/src/components/earn/EarnWithPrivyServerWallet.tsx
+++ b/packages/demo/frontend/src/components/earn/EarnWithPrivyServerWallet.tsx
@@ -3,6 +3,7 @@ import {
   usePrivy,
   useSessionSigners,
   useUser,
+  useWallets,
   type WalletWithMetadata,
   useIdentityToken,
 } from '@privy-io/react-auth'
@@ -19,6 +20,7 @@ export function EarnWithPrivyServerWallet() {
   const { logout } = useLogout()
   const { user } = useUser()
   const { addSessionSigners } = useSessionSigners()
+  const { ready: walletsReady } = useWallets()
 
   // Track wallets that have signers added or are in progress
   const processedWallets = useRef(new Set<string>())
@@ -82,13 +84,15 @@ export function EarnWithPrivyServerWallet() {
 
   // Add session signers for undelegated wallets
   useEffect(() => {
+    if (!walletsReady) return
+
     const undelegatedEthereumEmbeddedWallets = ethereumEmbeddedWallets.filter(
       (wallet) => wallet.delegated !== true,
     )
     undelegatedEthereumEmbeddedWallets.forEach((wallet) => {
       addSessionSigner(wallet.address)
     })
-  }, [ethereumEmbeddedWallets, addSessionSigner])
+  }, [walletsReady, ethereumEmbeddedWallets, addSessionSigner])
 
   // Track successful login
   useEffect(() => {

--- a/packages/demo/frontend/src/components/earn/LoginWithPrivy.spec.tsx
+++ b/packages/demo/frontend/src/components/earn/LoginWithPrivy.spec.tsx
@@ -1,6 +1,10 @@
 import { render, screen, act } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+const { navigate } = vi.hoisted(() => ({ navigate: vi.fn() }))
+
+vi.mock('react-router-dom', () => ({ useNavigate: () => navigate }))
+
 // Capture the onError callback Privy would invoke on a failed login.
 let capturedOnError: ((code: string) => void) | undefined
 
@@ -17,6 +21,7 @@ import { LoginWithPrivy } from './LoginWithPrivy'
 describe('LoginWithPrivy', () => {
   beforeEach(() => {
     capturedOnError = undefined
+    navigate.mockReset()
   })
 
   it('logs the error code and surfaces the fallback message instead of swallowing it', () => {
@@ -32,17 +37,19 @@ describe('LoginWithPrivy', () => {
       '[LoginWithPrivy] Privy login failed:',
       'max_accounts_reached',
     )
+    expect(navigate).not.toHaveBeenCalled()
     errorSpy.mockRestore()
   })
 
-  it('surfaces the fallback message for any error code', () => {
+  it('does not surface an error when the user exits the auth flow', () => {
     vi.spyOn(console, 'error').mockImplementation(() => {})
     render(<LoginWithPrivy />)
 
     act(() => capturedOnError?.('exited_auth_flow'))
 
     expect(
-      screen.getByText(/Something went wrong signing in with Privy/i),
-    ).toBeInTheDocument()
+      screen.queryByText(/Something went wrong signing in with Privy/i),
+    ).not.toBeInTheDocument()
+    expect(navigate).toHaveBeenCalledWith('/earn', { replace: true })
   })
 })

--- a/packages/demo/frontend/src/components/earn/LoginWithPrivy.tsx
+++ b/packages/demo/frontend/src/components/earn/LoginWithPrivy.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useCallback, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { useLogin, usePrivy, type PrivyErrorCode } from '@privy-io/react-auth'
 import { ROUTES } from '@/constants/routes'
 import { CtaButton } from './CtaButton'
@@ -12,12 +13,21 @@ const FALLBACK_ERROR_MESSAGE =
  */
 export function LoginWithPrivy() {
   const [hasError, setHasError] = useState(false)
+  const navigate = useNavigate()
 
-  // Log and surface login failures instead of silently redirecting away.
-  const handleError = useCallback((error: PrivyErrorCode) => {
-    console.error('[LoginWithPrivy] Privy login failed:', error)
-    setHasError(true)
-  }, [])
+  // Surface login failures instead of silently redirecting away.
+  const handleError = useCallback(
+    (error: PrivyErrorCode) => {
+      if (error === 'exited_auth_flow') {
+        navigate(ROUTES.EARN, { replace: true })
+        return
+      }
+
+      console.error('[LoginWithPrivy] Privy login failed:', error)
+      setHasError(true)
+    },
+    [navigate],
+  )
 
   const { login } = useLogin({ onError: handleError })
   const { ready } = usePrivy()

--- a/packages/demo/frontend/src/main.tsx
+++ b/packages/demo/frontend/src/main.tsx
@@ -1,3 +1,4 @@
+import './polyfills'
 import 'reflect-metadata'
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'

--- a/packages/demo/frontend/src/polyfills.spec.ts
+++ b/packages/demo/frontend/src/polyfills.spec.ts
@@ -1,0 +1,14 @@
+import { Buffer } from 'buffer'
+import { describe, expect, it } from 'vitest'
+
+import { installBuffer } from './polyfills'
+
+describe('browser polyfills', () => {
+  it('defines Buffer when the browser does not provide it', () => {
+    const browserGlobal: { Buffer?: typeof Buffer } = {}
+
+    installBuffer(browserGlobal)
+
+    expect(browserGlobal.Buffer).toBe(Buffer)
+  })
+})

--- a/packages/demo/frontend/src/polyfills.ts
+++ b/packages/demo/frontend/src/polyfills.ts
@@ -1,0 +1,8 @@
+import { Buffer } from 'buffer'
+
+// Privy's authorization-signature path expects Node's global Buffer.
+export function installBuffer(target: { Buffer?: typeof Buffer }): void {
+  if (typeof target.Buffer === 'undefined') target.Buffer = Buffer
+}
+
+installBuffer(globalThis)


### PR DESCRIPTION
| Problem | Solution |
| --- | --- |
| New Privy users cannot delegate session signers because wallets created by the new local app use Privy's TEE authorization path, which calls `Buffer` in the browser; existing production wallets did not exercise this path. | Initialize the existing `buffer` dependency before the app loads. |
| Privy users can remain stuck on loading because signer setup starts before the embedded-wallet proxy is ready. | Wait for `useWallets().ready` before adding the session signer. |
| Privy users see “Unable to sign in” after intentionally closing the auth dialog because [#541](https://github.com/ethereum-optimism/actions/pull/541) treats `exited_auth_flow` as a failure. | Return cancellations to the wallet picker while preserving the error UI for genuine failures. |
