### PR TITLE
fix: getPosition() sometimes fails

### DIFF
--- a/packages/demo/frontend/src/api/actionsApi.spec.ts
+++ b/packages/demo/frontend/src/api/actionsApi.spec.ts
@@ -89,4 +89,27 @@ describe('ActionsApiClient', () => {
       }),
     )
   })
+
+  it('omits the JSON content type from authenticated GET requests', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ result: [] }),
+    })
+
+    await actionsApi.getPositions(undefined, {
+      Authorization: 'Bearer access-token',
+      'privy-id-token': 'identity-token',
+    })
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://api.test.com/wallet/lend/positions',
+      expect.objectContaining({
+        headers: {
+          Authorization: 'Bearer access-token',
+          'privy-id-token': 'identity-token',
+        },
+        method: 'GET',
+      }),
+    )
+  })
 })

--- a/packages/demo/frontend/src/api/apiClient.ts
+++ b/packages/demo/frontend/src/api/apiClient.ts
@@ -1,6 +1,6 @@
 /**
  * Shared HTTP foundation for the demo's API clients. `BaseApiClient.request`
- * is a `fetch` wrapper that adds the JSON content-type, applies a per-call
+ * is a `fetch` wrapper that marks request bodies as JSON, applies a per-call
  * timeout, and raises `ActionsApiError` on non-2xx.
  */
 
@@ -34,10 +34,11 @@ export class BaseApiClient {
     const combinedSignal = signal
       ? AbortSignal.any([signal, timeoutSignal])
       : timeoutSignal
+    const hasBody = rest.body !== undefined && rest.body !== null
 
     const response = await fetch(url, {
       headers: {
-        'Content-Type': 'application/json',
+        ...(hasBody ? { 'Content-Type': 'application/json' } : {}),
         ...headers,
       },
       ...rest,


### PR DESCRIPTION
| Problem | Solution |
| --- | --- |
| Users cannot load lending positions, borrow markets, or swap quotes because bodyless GETs advertise JSON, causing the backend to parse an empty body and return `400 Invalid JSON body`. [PR #465](https://github.com/ethereum-optimism/actions/pull/465) made advertised JSON parse failures fatal, and [PR #508](https://github.com/ethereum-optimism/actions/pull/508) later shipped the positions endpoint with this mismatch. | Add the JSON content type only when a request has a body, and cover authenticated position reads with a regression test. |