### PR TITLE
fix: resolve remaining demo regressions

### DIFF
--- a/.changeset/fix-aave-reserve-reads.md
+++ b/.changeset/fix-aave-reserve-reads.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/actions-sdk': patch
+---
+
+Read Aave lend reserves directly with viem to avoid UI data-provider ABI mismatches.

--- a/packages/demo/backend/src/controllers/borrow.routes.spec.ts
+++ b/packages/demo/backend/src/controllers/borrow.routes.spec.ts
@@ -62,8 +62,9 @@ vi.mock('@/middleware/actions.js', () => ({
 const MARKET_ID = {
   kind: 'morpho-blue' as const,
   chainId: 84532,
-  marketId: '0x' + 'a'.repeat(64),
-}
+  marketId:
+    '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+} as const
 const WALLET = '0xaabbccddeeff00112233445566778899aabbccdd'
 
 beforeEach(async () => {
@@ -164,6 +165,36 @@ describe('borrow routes', () => {
         body: JSON.stringify({ nothing: 'here' }),
       })
       expect(res.status).toBe(400)
+    })
+  })
+
+  describe('POST /borrow/position/deposit-collateral', () => {
+    it('forwards max deposits to the borrow service', async () => {
+      vi.mocked(borrowService.depositCollateral).mockResolvedValue({
+        action: 'depositCollateral',
+        blockExplorerUrls: [],
+        marketId: MARKET_ID,
+        receipt: [],
+      })
+
+      const res = await createApp().request(
+        '/borrow/position/deposit-collateral',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', ...authHeaders() },
+          body: JSON.stringify({
+            marketId: MARKET_ID,
+            amount: { max: true },
+          }),
+        },
+      )
+
+      expect(res.status).toBe(200)
+      expect(borrowService.depositCollateral).toHaveBeenCalledWith({
+        idToken: 'fake-id-token',
+        marketId: MARKET_ID,
+        amount: { max: true },
+      })
     })
   })
 

--- a/packages/demo/backend/src/controllers/borrow.ts
+++ b/packages/demo/backend/src/controllers/borrow.ts
@@ -128,7 +128,7 @@ export async function closePosition(c: Context) {
 
 const DepositCollateralParamsBody = z.strictObject({
   marketId: BorrowMarketIdSchema,
-  amount: AmountExactSchema,
+  amount: AmountWithMaxSchema,
 })
 
 const DepositCollateralRequestSchema = z.object({

--- a/packages/demo/backend/src/helpers/schemas.ts
+++ b/packages/demo/backend/src/helpers/schemas.ts
@@ -73,7 +73,7 @@ export const AmountExactSchema = z
 
 /**
  * AmountWithMax: AmountExact plus the `{ max: true }` sentinel for
- * operations targeting an existing balance (close / withdraw / repay).
+ * operations that accept the full available amount.
  */
 export const AmountWithMaxSchema = z
   .union([AmountByHuman, AmountByRaw, AmountByMax])

--- a/packages/demo/frontend/src/api/actionsApi.spec.ts
+++ b/packages/demo/frontend/src/api/actionsApi.spec.ts
@@ -89,4 +89,27 @@ describe('ActionsApiClient', () => {
       }),
     )
   })
+
+  it('omits the JSON content type from authenticated GET requests', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ result: [] }),
+    })
+
+    await actionsApi.getPositions(undefined, {
+      Authorization: 'Bearer access-token',
+      'privy-id-token': 'identity-token',
+    })
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://api.test.com/wallet/lend/positions',
+      expect.objectContaining({
+        headers: {
+          Authorization: 'Bearer access-token',
+          'privy-id-token': 'identity-token',
+        },
+        method: 'GET',
+      }),
+    )
+  })
 })

--- a/packages/demo/frontend/src/api/apiClient.ts
+++ b/packages/demo/frontend/src/api/apiClient.ts
@@ -1,6 +1,6 @@
 /**
  * Shared HTTP foundation for the demo's API clients. `BaseApiClient.request`
- * is a `fetch` wrapper that adds the JSON content-type, applies a per-call
+ * is a `fetch` wrapper that marks request bodies as JSON, applies a per-call
  * timeout, and raises `ActionsApiError` on non-2xx.
  */
 
@@ -34,10 +34,11 @@ export class BaseApiClient {
     const combinedSignal = signal
       ? AbortSignal.any([signal, timeoutSignal])
       : timeoutSignal
+    const hasBody = rest.body !== undefined && rest.body !== null
 
     const response = await fetch(url, {
       headers: {
-        'Content-Type': 'application/json',
+        ...(hasBody ? { 'Content-Type': 'application/json' } : {}),
         ...headers,
       },
       ...rest,

--- a/packages/demo/frontend/src/components/earn/Action.spec.tsx
+++ b/packages/demo/frontend/src/components/earn/Action.spec.tsx
@@ -91,6 +91,17 @@ describe('Action', () => {
     expect(screen.getByRole('button', { name: 'Get USDC' })).toBeInTheDocument()
   })
 
+  it('disables the amount input while the Get button shows for a zero balance', () => {
+    render(<Action {...defaultProps} />)
+    expect(screen.getByRole('button', { name: 'Get USDC' })).toBeInTheDocument()
+    expect(screen.getByRole('textbox')).toBeDisabled()
+  })
+
+  it('enables the amount input once a balance is available to lend', () => {
+    render(<Action {...defaultProps} assetBalance="100.00" />)
+    expect(screen.getByRole('textbox')).toBeEnabled()
+  })
+
   it('shows a success toast after the mint resolves', async () => {
     const onMintAsset = vi.fn().mockResolvedValue(undefined)
     render(<Action {...defaultProps} onMintAsset={onMintAsset} />)

--- a/packages/demo/frontend/src/components/earn/Action.tsx
+++ b/packages/demo/frontend/src/components/earn/Action.tsx
@@ -315,7 +315,7 @@ export function Action({
           <AmountInput
             value={effectiveAmount}
             onChange={handleAmountChange}
-            disabled={isLockedWithdrawAmount}
+            disabled={isLockedWithdrawAmount || needsMint}
             displaySymbol={displaySymbol}
           />
 

--- a/packages/demo/frontend/src/components/earn/EarnWithPrivyServerWallet.spec.tsx
+++ b/packages/demo/frontend/src/components/earn/EarnWithPrivyServerWallet.spec.tsx
@@ -1,0 +1,74 @@
+import { render, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const privyMocks = vi.hoisted(() => ({
+  addSessionSigners: vi.fn(),
+  walletsReady: false,
+}))
+
+vi.mock('@privy-io/react-auth', () => ({
+  useIdentityToken: () => ({ identityToken: 'identity-token' }),
+  useLogout: () => ({ logout: vi.fn() }),
+  usePrivy: () => ({
+    authenticated: true,
+    getAccessToken: vi.fn(),
+    ready: true,
+  }),
+  useSessionSigners: () => ({
+    addSessionSigners: privyMocks.addSessionSigners,
+  }),
+  useUser: () => ({
+    user: {
+      id: 'privy-user',
+      linkedAccounts: [
+        {
+          address: '0x0000000000000000000000000000000000000001',
+          chainType: 'ethereum',
+          delegated: false,
+          type: 'wallet',
+          walletClientType: 'privy',
+        },
+      ],
+    },
+  }),
+  useWallets: () => ({ ready: privyMocks.walletsReady, wallets: [] }),
+}))
+
+vi.mock('@/envVars', () => ({
+  env: { VITE_SESSION_SIGNER_ID: 'session-signer' },
+}))
+
+vi.mock('@/utils/analytics', () => ({
+  identifyUser: vi.fn(),
+  trackEvent: vi.fn(),
+}))
+
+vi.mock('./EarnWithServerWallet', () => ({
+  EarnWithServerWallet: () => null,
+}))
+
+import { EarnWithPrivyServerWallet } from './EarnWithPrivyServerWallet'
+
+describe('EarnWithPrivyServerWallet', () => {
+  beforeEach(() => {
+    privyMocks.addSessionSigners.mockReset().mockResolvedValue({})
+    privyMocks.walletsReady = false
+  })
+
+  it('waits for Privy wallets before adding session signers', async () => {
+    const { rerender } = render(<EarnWithPrivyServerWallet />)
+
+    expect(privyMocks.addSessionSigners).not.toHaveBeenCalled()
+
+    privyMocks.walletsReady = true
+    rerender(<EarnWithPrivyServerWallet />)
+
+    await waitFor(() =>
+      expect(privyMocks.addSessionSigners).toHaveBeenCalledWith({
+        address: '0x0000000000000000000000000000000000000001',
+        signers: [{ signerId: 'session-signer' }],
+      }),
+    )
+    expect(privyMocks.addSessionSigners).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/demo/frontend/src/components/earn/EarnWithPrivyServerWallet.tsx
+++ b/packages/demo/frontend/src/components/earn/EarnWithPrivyServerWallet.tsx
@@ -3,6 +3,7 @@ import {
   usePrivy,
   useSessionSigners,
   useUser,
+  useWallets,
   type WalletWithMetadata,
   useIdentityToken,
 } from '@privy-io/react-auth'
@@ -19,6 +20,7 @@ export function EarnWithPrivyServerWallet() {
   const { logout } = useLogout()
   const { user } = useUser()
   const { addSessionSigners } = useSessionSigners()
+  const { ready: walletsReady } = useWallets()
 
   // Track wallets that have signers added or are in progress
   const processedWallets = useRef(new Set<string>())
@@ -82,13 +84,15 @@ export function EarnWithPrivyServerWallet() {
 
   // Add session signers for undelegated wallets
   useEffect(() => {
+    if (!walletsReady) return
+
     const undelegatedEthereumEmbeddedWallets = ethereumEmbeddedWallets.filter(
       (wallet) => wallet.delegated !== true,
     )
     undelegatedEthereumEmbeddedWallets.forEach((wallet) => {
       addSessionSigner(wallet.address)
     })
-  }, [ethereumEmbeddedWallets, addSessionSigner])
+  }, [walletsReady, ethereumEmbeddedWallets, addSessionSigner])
 
   // Track successful login
   useEffect(() => {

--- a/packages/demo/frontend/src/components/earn/EarnWithTurnkeyWallet.spec.tsx
+++ b/packages/demo/frontend/src/components/earn/EarnWithTurnkeyWallet.spec.tsx
@@ -1,0 +1,104 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  identifyUser: vi.fn(),
+  trackEvent: vi.fn(),
+  useTurnkey: vi.fn(),
+  useTurnkeyWallet: vi.fn(),
+}))
+
+vi.mock('@turnkey/react-wallet-kit', () => ({
+  AuthState: {
+    Authenticated: 'authenticated',
+    Unauthenticated: 'unauthenticated',
+  },
+  ClientState: { Loading: 'loading', Ready: 'ready' },
+  useTurnkey: mocks.useTurnkey,
+}))
+
+vi.mock('@/hooks/useTurnkeyWallet', () => ({
+  useTurnkeyWallet: mocks.useTurnkeyWallet,
+}))
+
+vi.mock('@/utils/analytics', () => ({
+  identifyUser: mocks.identifyUser,
+  trackEvent: mocks.trackEvent,
+}))
+
+vi.mock('./LoginWithTurnkey', () => ({
+  LoginWithTurnkey: () => <div>Sign in with Turnkey</div>,
+}))
+
+vi.mock('./EarnWithFrontendWallet', () => ({
+  EarnWithFrontendWallet: ({ wallet }: { wallet: unknown }) =>
+    wallet ? <div>Earn page</div> : <div>Loading...</div>,
+}))
+
+import { EarnWithTurnkeyWallet } from './EarnWithTurnkeyWallet'
+
+const logout = vi.fn()
+const user = { userId: 'turnkey-user', userName: 'Turnkey User' }
+const session = { organizationId: 'organization-id' }
+
+describe('EarnWithTurnkeyWallet', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.useTurnkeyWallet.mockReturnValue({ smartWallet: null })
+  })
+
+  it('keeps session restoration and wallet creation visually stable', () => {
+    mocks.useTurnkey.mockReturnValue({
+      authState: 'unauthenticated',
+      clientState: 'loading',
+      logout,
+      session: undefined,
+      user: undefined,
+    })
+    const { rerender } = render(<EarnWithTurnkeyWallet />)
+
+    expect(screen.queryByText('Loading...')).not.toBeInTheDocument()
+    expect(screen.queryByText('Sign in with Turnkey')).not.toBeInTheDocument()
+
+    mocks.useTurnkey.mockReturnValue({
+      authState: 'unauthenticated',
+      clientState: 'ready',
+      logout,
+      session,
+      user,
+    })
+    rerender(<EarnWithTurnkeyWallet />)
+
+    expect(screen.queryByText('Sign in with Turnkey')).not.toBeInTheDocument()
+
+    mocks.useTurnkey.mockReturnValue({
+      authState: 'authenticated',
+      clientState: 'ready',
+      logout,
+      session,
+      user,
+    })
+    rerender(<EarnWithTurnkeyWallet />)
+
+    expect(screen.queryByText('Loading...')).not.toBeInTheDocument()
+
+    mocks.useTurnkeyWallet.mockReturnValue({ smartWallet: {} })
+    rerender(<EarnWithTurnkeyWallet />)
+
+    expect(screen.getByText('Earn page')).toBeInTheDocument()
+  })
+
+  it('shows sign-in after an unauthenticated client is ready', () => {
+    mocks.useTurnkey.mockReturnValue({
+      authState: 'unauthenticated',
+      clientState: 'ready',
+      logout,
+      session: undefined,
+      user: undefined,
+    })
+
+    render(<EarnWithTurnkeyWallet />)
+
+    expect(screen.getByText('Sign in with Turnkey')).toBeInTheDocument()
+  })
+})

--- a/packages/demo/frontend/src/components/earn/EarnWithTurnkeyWallet.tsx
+++ b/packages/demo/frontend/src/components/earn/EarnWithTurnkeyWallet.tsx
@@ -3,17 +3,19 @@ import { AuthState, ClientState, useTurnkey } from '@turnkey/react-wallet-kit'
 import { EarnWithFrontendWallet } from './EarnWithFrontendWallet'
 import { WALLET_PROVIDERS } from '@/constants/walletProviders'
 import { LoginWithTurnkey } from './LoginWithTurnkey'
+import { WalletLoadingScreen } from './WalletLoadingScreen'
 import { useTurnkeyWallet } from '@/hooks/useTurnkeyWallet'
 import { trackEvent, identifyUser } from '@/utils/analytics'
 
 export function EarnWithTurnkeyWallet() {
   const { smartWallet } = useTurnkeyWallet()
-  const { clientState, authState, user, logout } = useTurnkey()
+  const { clientState, authState, session, user, logout } = useTurnkey()
 
   const isLoggedIn =
     clientState === ClientState.Ready &&
     authState === AuthState.Authenticated &&
-    user
+    Boolean(session) &&
+    Boolean(user)
 
   // Track successful login
   useEffect(() => {
@@ -27,6 +29,14 @@ export function EarnWithTurnkeyWallet() {
       })
     }
   }, [isLoggedIn, user])
+
+  const isRestoringSession =
+    clientState !== ClientState.Ready ||
+    Boolean(session) !== (authState === AuthState.Authenticated)
+
+  if (isRestoringSession || (isLoggedIn && !smartWallet)) {
+    return <WalletLoadingScreen />
+  }
 
   if (!isLoggedIn) {
     return <LoginWithTurnkey />

--- a/packages/demo/frontend/src/components/earn/LoginWithPrivy.spec.tsx
+++ b/packages/demo/frontend/src/components/earn/LoginWithPrivy.spec.tsx
@@ -1,6 +1,10 @@
 import { render, screen, act } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+const { navigate } = vi.hoisted(() => ({ navigate: vi.fn() }))
+
+vi.mock('react-router-dom', () => ({ useNavigate: () => navigate }))
+
 // Capture the onError callback Privy would invoke on a failed login.
 let capturedOnError: ((code: string) => void) | undefined
 
@@ -17,6 +21,7 @@ import { LoginWithPrivy } from './LoginWithPrivy'
 describe('LoginWithPrivy', () => {
   beforeEach(() => {
     capturedOnError = undefined
+    navigate.mockReset()
   })
 
   it('logs the error code and surfaces the fallback message instead of swallowing it', () => {
@@ -32,17 +37,19 @@ describe('LoginWithPrivy', () => {
       '[LoginWithPrivy] Privy login failed:',
       'max_accounts_reached',
     )
+    expect(navigate).not.toHaveBeenCalled()
     errorSpy.mockRestore()
   })
 
-  it('surfaces the fallback message for any error code', () => {
+  it('does not surface an error when the user exits the auth flow', () => {
     vi.spyOn(console, 'error').mockImplementation(() => {})
     render(<LoginWithPrivy />)
 
     act(() => capturedOnError?.('exited_auth_flow'))
 
     expect(
-      screen.getByText(/Something went wrong signing in with Privy/i),
-    ).toBeInTheDocument()
+      screen.queryByText(/Something went wrong signing in with Privy/i),
+    ).not.toBeInTheDocument()
+    expect(navigate).toHaveBeenCalledWith('/earn', { replace: true })
   })
 })

--- a/packages/demo/frontend/src/components/earn/LoginWithPrivy.tsx
+++ b/packages/demo/frontend/src/components/earn/LoginWithPrivy.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useCallback, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { useLogin, usePrivy, type PrivyErrorCode } from '@privy-io/react-auth'
 import { ROUTES } from '@/constants/routes'
 import { CtaButton } from './CtaButton'
@@ -12,12 +13,21 @@ const FALLBACK_ERROR_MESSAGE =
  */
 export function LoginWithPrivy() {
   const [hasError, setHasError] = useState(false)
+  const navigate = useNavigate()
 
-  // Log and surface login failures instead of silently redirecting away.
-  const handleError = useCallback((error: PrivyErrorCode) => {
-    console.error('[LoginWithPrivy] Privy login failed:', error)
-    setHasError(true)
-  }, [])
+  // Surface login failures instead of silently redirecting away.
+  const handleError = useCallback(
+    (error: PrivyErrorCode) => {
+      if (error === 'exited_auth_flow') {
+        navigate(ROUTES.EARN, { replace: true })
+        return
+      }
+
+      console.error('[LoginWithPrivy] Privy login failed:', error)
+      setHasError(true)
+    },
+    [navigate],
+  )
 
   const { login } = useLogin({ onError: handleError })
   const { ready } = usePrivy()

--- a/packages/demo/frontend/src/components/earn/LoginWithTurnkey.spec.tsx
+++ b/packages/demo/frontend/src/components/earn/LoginWithTurnkey.spec.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const turnkey = vi.hoisted(() => ({
+  handleLogin: vi.fn(),
+  loginWithPasskey: vi.fn(),
+  signUpWithPasskey: vi.fn(),
+}))
+
+vi.mock('@turnkey/react-wallet-kit', () => ({
+  ClientState: { Ready: 'ready' },
+  useTurnkey: () => ({
+    clientState: 'ready',
+    handleLogin: turnkey.handleLogin,
+    loginWithPasskey: turnkey.loginWithPasskey,
+    signUpWithPasskey: turnkey.signUpWithPasskey,
+  }),
+  useModal: () => ({ modalStack: [] }),
+}))
+
+import { LoginWithTurnkey } from './LoginWithTurnkey'
+
+describe('LoginWithTurnkey', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    turnkey.handleLogin.mockResolvedValue(undefined)
+    turnkey.loginWithPasskey.mockResolvedValue(undefined)
+    turnkey.signUpWithPasskey.mockResolvedValue(undefined)
+  })
+
+  it('waits for an explicit user action before opening authentication', () => {
+    render(<LoginWithTurnkey />)
+
+    expect(turnkey.handleLogin).not.toHaveBeenCalled()
+    expect(turnkey.loginWithPasskey).not.toHaveBeenCalled()
+    expect(turnkey.signUpWithPasskey).not.toHaveBeenCalled()
+  })
+
+  it('logs in with a passkey from the sign-in button', async () => {
+    const user = userEvent.setup()
+    render(<LoginWithTurnkey />)
+
+    await user.click(
+      screen.getByRole('button', { name: 'Log in with passkey' }),
+    )
+
+    expect(turnkey.loginWithPasskey).toHaveBeenCalledOnce()
+  })
+
+  it('handles a rejected passkey request and offers recovery', async () => {
+    const user = userEvent.setup()
+    turnkey.loginWithPasskey.mockRejectedValueOnce(
+      new DOMException('The request is not allowed', 'NotAllowedError'),
+    )
+    render(<LoginWithTurnkey />)
+
+    await user.click(
+      screen.getByRole('button', { name: 'Log in with passkey' }),
+    )
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Passkey authentication was canceled or is unavailable',
+    )
+    expect(
+      screen.getByRole('button', { name: 'Choose another wallet' }),
+    ).toBeInTheDocument()
+  })
+})

--- a/packages/demo/frontend/src/components/earn/LoginWithTurnkey.tsx
+++ b/packages/demo/frontend/src/components/earn/LoginWithTurnkey.tsx
@@ -1,41 +1,77 @@
-import { useTurnkey, useModal, ClientState } from '@turnkey/react-wallet-kit'
-import { useEffect, useRef } from 'react'
+import { ClientState, useTurnkey } from '@turnkey/react-wallet-kit'
+import { useState } from 'react'
 import { ROUTES } from '@/constants/routes'
+import { CtaButton } from './CtaButton'
+
+const PASSKEY_ERROR_MESSAGE =
+  'Passkey authentication was canceled or is unavailable in this browser. Try again or choose another wallet.'
 
 /**
- * Login component for Turnkey authentication
- * Displays a simple sign-in screen with the Turnkey login flow
+ * @description Displays explicit Turnkey passkey actions and handles browser rejections.
+ * @returns The Turnkey authentication screen.
  */
 export function LoginWithTurnkey() {
-  const { clientState, handleLogin } = useTurnkey()
-  const { modalStack } = useModal()
-  const hasTriggeredLogin = useRef(false)
-  const hasModalBeenOpened = useRef(false)
+  const { clientState, loginWithPasskey, signUpWithPasskey } = useTurnkey()
+  const [isAuthenticating, setIsAuthenticating] = useState(false)
+  const [hasError, setHasError] = useState(false)
+  const isReady = clientState === ClientState.Ready
 
-  useEffect(() => {
-    if (clientState === ClientState.Ready && !hasTriggeredLogin.current) {
-      hasTriggeredLogin.current = true
-      handleLogin()
+  const authenticate = async (action: () => Promise<unknown>) => {
+    setHasError(false)
+    setIsAuthenticating(true)
+    try {
+      await action()
+    } catch {
+      setHasError(true)
+    } finally {
+      setIsAuthenticating(false)
     }
-  }, [clientState, handleLogin])
-
-  useEffect(() => {
-    if (modalStack.length > 0) {
-      hasModalBeenOpened.current = true
-    }
-
-    if (modalStack.length === 0 && hasModalBeenOpened.current) {
-      window.location.href = ROUTES.EARN
-    }
-  }, [modalStack])
+  }
 
   return (
     <div
-      className="min-h-screen"
+      className="min-h-screen flex items-center justify-center"
       style={{
         backgroundColor: '#FFFFFF',
         fontFamily: 'Inter, system-ui, -apple-system, sans-serif',
       }}
-    ></div>
+    >
+      <div className="shadow-none rounded-3xl inline-flex flex-col items-center py-8 px-6 gap-5 border border-[#E0E2EB] w-[361px] text-center">
+        <div className="text-2xl font-semibold leading-8 text-black">
+          Sign in with Turnkey
+        </div>
+        <div className="text-base font-normal leading-6 text-[#404454]">
+          Use an existing passkey or create one for this device.
+        </div>
+        {hasError && (
+          <div role="alert" className="text-sm leading-5 text-[#B42318]">
+            {PASSKEY_ERROR_MESSAGE}
+          </div>
+        )}
+        <div className="flex flex-col gap-3 w-full">
+          <CtaButton
+            disabled={!isReady || isAuthenticating}
+            onClick={() => void authenticate(loginWithPasskey)}
+          >
+            {isAuthenticating
+              ? 'Waiting for passkey...'
+              : 'Log in with passkey'}
+          </CtaButton>
+          <button
+            disabled={!isReady || isAuthenticating}
+            onClick={() => void authenticate(signUpWithPasskey)}
+            className="w-full py-3 px-4 font-medium rounded-xl border border-[#E0E2EB] text-[#404454] cursor-pointer bg-transparent disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            Sign up with passkey
+          </button>
+          <button
+            onClick={() => (window.location.href = ROUTES.EARN)}
+            className="w-full py-2 px-4 font-medium text-[#404454] cursor-pointer bg-transparent border-0"
+          >
+            Choose another wallet
+          </button>
+        </div>
+      </div>
+    </div>
   )
 }

--- a/packages/demo/frontend/src/components/earn/WalletLoadingScreen.tsx
+++ b/packages/demo/frontend/src/components/earn/WalletLoadingScreen.tsx
@@ -1,0 +1,7 @@
+/**
+ * @description Keeps the wallet surface visually stable while provider state is restored.
+ * @returns A blank wallet loading surface.
+ */
+export function WalletLoadingScreen() {
+  return <div className="min-h-screen bg-white" aria-busy="true" />
+}

--- a/packages/demo/frontend/src/components/earn/borrow/BorrowAction.spec.tsx
+++ b/packages/demo/frontend/src/components/earn/borrow/BorrowAction.spec.tsx
@@ -51,6 +51,7 @@ beforeEach(() => {
 })
 
 const OPS = 11155420 as SupportedChainId
+const BASE = 84532 as SupportedChainId
 const ETH: Asset = {
   type: 'native',
   address: { [OPS]: '0x4200000000000000000000000000000000000006' },
@@ -151,7 +152,7 @@ function usdcDemoBalance(amount: number): TokenBalance {
     asset: USDC_DEMO,
     totalBalance: amount,
     totalBalanceRaw: raw,
-    chains: { [OPS]: { balance: amount, balanceRaw: raw } },
+    chains: { [BASE]: { balance: amount, balanceRaw: raw } },
   } as unknown as TokenBalance
 }
 
@@ -180,22 +181,16 @@ describe('BorrowAction repay gating on debt-asset balance', () => {
     return buttons[buttons.length - 1]
   }
 
-  it('blocks repay when the USDC balance lives only on the non-borrow chain', () => {
-    const raw = 50_000000n
-    const crossChainOnly = {
-      asset: USDC_DEMO,
-      totalBalance: 50,
-      totalBalanceRaw: raw,
-      chains: { 84532: { balance: 50, balanceRaw: raw } },
-    } as unknown as TokenBalance
+  it('allows Aave repayment from the Base mirror balance', () => {
     renderRepay({
       borrowPositions: [aaveDebtPosition],
-      tokenBalances: [crossChainOnly],
+      tokenBalances: [usdcDemoBalance(50)],
     })
-    expect(
-      screen.getByText(/need USDC to repay this loan/i),
-    ).toBeInTheDocument()
-    expect(repayCta()).toBeDisabled()
+    fireEvent.change(screen.getByPlaceholderText('0'), {
+      target: { value: '2' },
+    })
+    expect(screen.queryByText(/need USDC to repay this loan/i)).toBeNull()
+    expect(repayCta()).not.toBeDisabled()
   })
 
   it('blocks repay with a re-acquire notice when the USDC balance is zero', () => {

--- a/packages/demo/frontend/src/components/earn/borrow/BorrowAction.tsx
+++ b/packages/demo/frontend/src/components/earn/borrow/BorrowAction.tsx
@@ -18,7 +18,7 @@ import {
 } from '@/utils/borrowMath'
 import { lendPositionUsd, positionUsd } from '@/utils/borrowValuation'
 import { assetBalanceAmount } from '@/utils/balanceMatching'
-import { repayGateAsset, ReacquireDebtNotice } from '@/demoMagic'
+import { resolveRepayBalanceSource, ReacquireDebtNotice } from '@/demoMagic'
 import { DEBT_DUST_THRESHOLD } from '@/constants/borrow'
 import { sameMarketId } from '@/utils/marketId'
 import { displaySymbol } from '@/utils/tokenDisplay'
@@ -105,8 +105,10 @@ export function BorrowAction({ selectedLendPosition }: BorrowActionProps) {
 
   const activeAsset = repayAsset ?? activeMarket?.borrowAsset ?? null
 
-  // Gate the repay on the asset the user holds (USDC_DEMO for the mirror market).
-  const repayBalanceAsset = repayGateAsset(activeMarket, activeAsset)
+  // The Aave mirror gates on USDC_DEMO on Base; ordinary markets gate on
+  // their debt asset on the market chain.
+  const { asset: repayBalanceAsset, chainId: repayBalanceChainId } =
+    resolveRepayBalanceSource(activeMarket, activeAsset)
 
   // Cap the repay at min(held balance, outstanding debt); the balance gates the CTA.
   const rawOutstandingDebt = activePosition
@@ -114,11 +116,11 @@ export function BorrowAction({ selectedLendPosition }: BorrowActionProps) {
     : 0
   const outstandingDebt =
     rawOutstandingDebt >= DEBT_DUST_THRESHOLD ? rawOutstandingDebt : 0
-  // Repay uses market-chain spendable balance.
+  // Repay uses the balance on the chain where its gate asset is spendable.
   const debtBalance = assetBalanceAmount(
     tokenBalances,
     repayBalanceAsset,
-    activeMarket?.marketId.chainId,
+    repayBalanceChainId,
   )
   const maxRepayable = Math.min(debtBalance, outstandingDebt)
   const isRepay = mode === 'repay'

--- a/packages/demo/frontend/src/demoMagic/aaveDemoMagic.ts
+++ b/packages/demo/frontend/src/demoMagic/aaveDemoMagic.ts
@@ -23,12 +23,22 @@ export function isMirrorMarket(marketId: BorrowMarketId): boolean {
   return sameMarketId(marketId, AaveETHBorrowUSDCDemo)
 }
 
-/** Returns USDC_DEMO for the mirror market (user holds USDC_DEMO, not the real borrowed USDC); otherwise returns the real borrow asset. */
-export function repayGateAsset(
+/**
+ * Resolve the balance used to gate a repayment.
+ * @description Uses the Base USDC_DEMO mirror for the Aave demo and the
+ * market-chain debt asset for ordinary markets.
+ * @param market - Active borrow market
+ * @param borrowAsset - Debt asset shown by the active position
+ * @returns Asset and chain containing the spendable gate balance
+ */
+export function resolveRepayBalanceSource(
   market: BorrowMarket | null,
   borrowAsset: Asset | null,
-): Asset | null {
-  return market && isMirrorMarket(market.marketId) ? USDC_DEMO : borrowAsset
+) {
+  if (market && isMirrorMarket(market.marketId)) {
+    return { asset: USDC_DEMO, chainId: baseSepolia.id }
+  }
+  return { asset: borrowAsset, chainId: market?.marketId.chainId }
 }
 
 /** Fires the USDC_DEMO mint (borrow) or remove (repay) for in-browser wallets. No-op for non-mirror markets or zero amounts. */

--- a/packages/demo/frontend/src/demoMagic/morphoDemoMagic.spec.ts
+++ b/packages/demo/frontend/src/demoMagic/morphoDemoMagic.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react'
+import { renderHook, waitFor } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import type { MarketInfo } from '@/components/earn/MarketSelector'
 import type { MarketPosition } from '@/types/market'
@@ -114,5 +114,24 @@ describe('useReconcileMorphoCollateral', () => {
     )
     expect(handleTransaction).not.toHaveBeenCalled()
     expect(setMarketPositions).not.toHaveBeenCalled()
+  })
+
+  it('does not retry failed reconciliation after a rerender', async () => {
+    const setMarketPositions = vi.fn()
+    const handleTransaction = vi.fn().mockRejectedValue(new Error('failed'))
+    const { rerender } = renderHook(
+      ({ marketPositions }) =>
+        useReconcileMorphoCollateral(
+          marketPositions,
+          handleTransaction,
+          setMarketPositions,
+        ),
+      { initialProps: { marketPositions: [lentPosition] } },
+    )
+
+    await waitFor(() => expect(setMarketPositions).toHaveBeenCalledTimes(2))
+    rerender({ marketPositions: [{ ...lentPosition }] })
+
+    expect(handleTransaction).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/demo/frontend/src/demoMagic/morphoDemoMagic.ts
+++ b/packages/demo/frontend/src/demoMagic/morphoDemoMagic.ts
@@ -58,7 +58,6 @@ export function useReconcileMorphoCollateral(
         },
         amount: { max: true },
       }).catch((error) => {
-        reconciledRef.current.delete(key)
         setMarketPositions((prev) =>
           prev.map((p) =>
             sameVault(p, position)

--- a/packages/demo/frontend/src/hooks/__tests__/useBorrowProjection.spec.ts
+++ b/packages/demo/frontend/src/hooks/__tests__/useBorrowProjection.spec.ts
@@ -46,10 +46,13 @@ describe('useBorrowProjection (stub-priced)', () => {
     expect(result.current.projectedLtv).toBeLessThan(result.current.currentLtv)
   })
 
-  it('falls back to the current LTV when no amount is entered', () => {
+  it('falls back to the current health readings when no amount is entered', () => {
     const { result } = renderHook(() =>
       useBorrowProjection({ ...base, amountNum: 0, amountUsd: 0 }),
     )
     expect(result.current.projectedLtv).toBe(result.current.currentLtv)
+    expect(result.current.projectedHealthFactor).toBeCloseTo(
+      (base.currentCollUsd * base.maxLtv) / base.currentBorrUsd,
+    )
   })
 })

--- a/packages/demo/frontend/src/hooks/__tests__/useSwap.spec.tsx
+++ b/packages/demo/frontend/src/hooks/__tests__/useSwap.spec.tsx
@@ -1,0 +1,101 @@
+import { createElement, type ReactNode } from 'react'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { TokenBalance } from '@eth-optimism/actions-sdk/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { OP_DEMO, USDC_DEMO } from '@/constants/markets'
+import { useSwap } from '@/hooks/useSwap'
+import { useTokenBalances } from '@/queries/useTokenBalances'
+import { ActivityLogProvider } from '@/providers/ActivityLogProvider'
+import type { EarnOperations } from '@/hooks/useLendProvider'
+
+const CHAIN_ID = 84532
+const tokenBalances: TokenBalance[] = [
+  {
+    asset: USDC_DEMO,
+    totalBalance: 10,
+    totalBalanceRaw: 10_000_000n,
+    chains: {
+      [CHAIN_ID]: { balance: 10, balanceRaw: 10_000_000n },
+    },
+  },
+  {
+    asset: OP_DEMO,
+    totalBalance: 20,
+    totalBalanceRaw: 20_000_000_000_000_000_000n,
+    chains: {
+      [CHAIN_ID]: {
+        balance: 20,
+        balanceRaw: 20_000_000_000_000_000_000n,
+      },
+    },
+  },
+]
+
+function createOperations(
+  getTokenBalances: EarnOperations['getTokenBalances'],
+): EarnOperations {
+  return {
+    getTokenBalances,
+    getMarkets: async () => [],
+    getPosition: async () => {
+      throw new Error('Not used by this test')
+    },
+    getPositions: async () => [],
+    mintAsset: async () => undefined,
+    openPosition: async () => {
+      throw new Error('Not used by this test')
+    },
+    closePosition: async () => {
+      throw new Error('Not used by this test')
+    },
+    executeSwap: async () => ({}),
+    getConfiguredAssets: async () => [USDC_DEMO, OP_DEMO],
+    getSwapMarkets: async () => [],
+    getSwapQuote: async () => null,
+  }
+}
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      createElement(ActivityLogProvider, null, children),
+    )
+  }
+}
+
+describe('useSwap', () => {
+  it('preserves shared balances when they are invalidated', async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    const getTokenBalances = vi.fn(async () => tokenBalances)
+    const operations = createOperations(getTokenBalances)
+
+    const { result } = renderHook(
+      () => {
+        const balanceQuery = useTokenBalances({
+          getTokenBalances,
+          isReady: () => true,
+        })
+        const swap = useSwap({ operations, activeTab: 'swap' })
+        return { balanceQuery, swap }
+      },
+      { wrapper: createWrapper(queryClient) },
+    )
+
+    await waitFor(() => expect(result.current.swap.swapAssets).toHaveLength(2))
+    getTokenBalances.mockClear()
+
+    await act(async () => {
+      await queryClient.invalidateQueries({ queryKey: ['tokenBalances'] })
+    })
+
+    expect(getTokenBalances).toHaveBeenCalledOnce()
+    expect(queryClient.getQueryData(['tokenBalances'])).toEqual(tokenBalances)
+    expect(result.current.swap.swapAssets).toHaveLength(2)
+  })
+})

--- a/packages/demo/frontend/src/hooks/useBorrowProjection.ts
+++ b/packages/demo/frontend/src/hooks/useBorrowProjection.ts
@@ -6,7 +6,7 @@
 
 import { useMemo } from 'react'
 import type { Asset, BorrowMarket } from '@eth-optimism/actions-sdk'
-import { computeProjection } from '@/utils/borrowMath'
+import { computeHealthFactor, computeProjection } from '@/utils/borrowMath'
 
 export function useBorrowProjection({
   activeMarket,
@@ -69,7 +69,7 @@ export function useBorrowProjection({
   const projectedHealthFactor =
     localProjection && localProjection.kind === 'projected'
       ? localProjection.healthFactor
-      : Number.POSITIVE_INFINITY
+      : computeHealthFactor(currentCollUsd, maxLtv, currentBorrUsd)
 
   return { currentLtv, projectedLtv, wouldLiquidate, projectedHealthFactor }
 }

--- a/packages/demo/frontend/src/hooks/useSwap.ts
+++ b/packages/demo/frontend/src/hooks/useSwap.ts
@@ -25,12 +25,11 @@ export function useSwap({ operations, activeTab }: UseSwapParams) {
   const queryClient = useQueryClient()
   const { logActivity } = useActivityLogger()
 
-  // Read-only subscriber to tokenBalances cache (managed by lend path's useTokenBalances).
-  // enabled:false means this never triggers fetches — it only receives cache updates.
-  // queryFn provided to suppress React Query warning (never called when disabled).
+  // This disabled observer only reads the shared cache during normal rendering.
+  // Invalidations can still select its queryFn, so it must use the real fetcher.
   const { data: walletTokenBalances } = useQuery<TokenBalance[]>({
     queryKey: ['tokenBalances'],
-    queryFn: () => Promise.resolve([]),
+    queryFn: operations.getTokenBalances,
     enabled: false,
   })
   const isLoadingBalances = !walletTokenBalances

--- a/packages/demo/frontend/src/main.tsx
+++ b/packages/demo/frontend/src/main.tsx
@@ -1,3 +1,4 @@
+import './polyfills'
 import 'reflect-metadata'
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'

--- a/packages/demo/frontend/src/pages/EarnPage.tsx
+++ b/packages/demo/frontend/src/pages/EarnPage.tsx
@@ -2,6 +2,7 @@ import { lazy, Suspense } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { WALLET_PROVIDERS } from '@/constants/walletProviders'
 import { WelcomeWalletPicker } from '@/components/earn/WelcomeWalletPicker'
+import { WalletLoadingScreen } from '@/components/earn/WalletLoadingScreen'
 
 // Lazy load wallet providers to reduce bundle size and build memory
 const PrivyProvider = lazy(() =>
@@ -75,7 +76,7 @@ export function EarnPage() {
 
   if (walletProvider === WALLET_PROVIDERS.TURNKEY) {
     return (
-      <Suspense fallback={<LoadingFallback />}>
+      <Suspense fallback={<WalletLoadingScreen />}>
         <TurnkeyProvider>
           <EarnWithTurnkeyWallet />
         </TurnkeyProvider>

--- a/packages/demo/frontend/src/polyfills.spec.ts
+++ b/packages/demo/frontend/src/polyfills.spec.ts
@@ -1,0 +1,14 @@
+import { Buffer } from 'buffer'
+import { describe, expect, it } from 'vitest'
+
+import { installBuffer } from './polyfills'
+
+describe('browser polyfills', () => {
+  it('defines Buffer when the browser does not provide it', () => {
+    const browserGlobal: { Buffer?: typeof Buffer } = {}
+
+    installBuffer(browserGlobal)
+
+    expect(browserGlobal.Buffer).toBe(Buffer)
+  })
+})

--- a/packages/demo/frontend/src/polyfills.ts
+++ b/packages/demo/frontend/src/polyfills.ts
@@ -1,0 +1,8 @@
+import { Buffer } from 'buffer'
+
+// Privy's authorization-signature path expects Node's global Buffer.
+export function installBuffer(target: { Buffer?: typeof Buffer }): void {
+  if (typeof target.Buffer === 'undefined') target.Buffer = Buffer
+}
+
+installBuffer(globalThis)

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -56,13 +56,10 @@
   "author": "Optimism PBC",
   "license": "MIT",
   "dependencies": {
-    "@aave/contract-helpers": "^1.30.0",
-    "@aave/math-utils": "^1.30.0",
     "@eth-optimism/viem": "^0.4.13",
     "@morpho-org/blue-sdk": ">=4.13.1 <4.14.0",
     "@morpho-org/blue-sdk-viem": ">=3.2.0 <3.3.0",
     "@morpho-org/morpho-ts": ">=2.4.6 <2.5.0",
-    "ethers": "^5.7.2",
     "permissionless": ">=0.2.57 <0.3.0"
   },
   "peerDependencies": {

--- a/packages/sdk/src/actions/borrow/providers/aave/prices.ts
+++ b/packages/sdk/src/actions/borrow/providers/aave/prices.ts
@@ -1,0 +1,71 @@
+import type { Address, PublicClient } from 'viem'
+
+import {
+  ADDRESSES_PROVIDER_ABI,
+  ORACLE_ABI,
+} from '@/actions/shared/aave/abis/pool.js'
+import { getAaveAddresses } from '@/actions/shared/aave/addresses.js'
+import { ChainNotSupportedError } from '@/core/error/errors.js'
+import type { AaveBorrowMarketConfig } from '@/types/borrow/index.js'
+
+import type { AavePositionState, AaveReservePrices } from './presentation.js'
+import { fetchAavePositionState } from './state.js'
+
+/**
+ * @description Reads base-currency oracle prices for both configured reserves.
+ * @param client - Public client for the market chain.
+ * @param config - Aave borrow market configuration.
+ * @returns Collateral and debt prices in the pool's base currency.
+ * @throws ChainNotSupportedError when Aave is not configured for the chain.
+ */
+async function fetchAavePrices(
+  client: PublicClient,
+  config: AaveBorrowMarketConfig,
+): Promise<AaveReservePrices> {
+  const addresses = getAaveAddresses(config.chainId)
+  if (!addresses) throw new ChainNotSupportedError({ chainId: config.chainId })
+
+  const oracle = await client.readContract({
+    address: addresses.poolAddressesProvider,
+    abi: ADDRESSES_PROVIDER_ABI,
+    functionName: 'getPriceOracle',
+  })
+  const [collateralPrice, debtPrice] = await client.multicall({
+    allowFailure: false,
+    contracts: [
+      {
+        address: oracle,
+        abi: ORACLE_ABI,
+        functionName: 'getAssetPrice',
+        args: [config.aave.collateralReserve],
+      },
+      {
+        address: oracle,
+        abi: ORACLE_ABI,
+        functionName: 'getAssetPrice',
+        args: [config.aave.debtReserve],
+      },
+    ],
+  })
+  return { collateralPrice, debtPrice }
+}
+
+/**
+ * @description Reads a wallet position and both reserve prices concurrently.
+ * @param client - Public client for the market chain.
+ * @param config - Aave borrow market configuration.
+ * @param user - Wallet whose position should be read.
+ * @returns Current position state and reserve prices.
+ * @throws A viem contract error when a position or oracle read fails.
+ */
+export async function fetchAaveStateAndPrices(
+  client: PublicClient,
+  config: AaveBorrowMarketConfig,
+  user: Address,
+): Promise<{ current: AavePositionState; prices: AaveReservePrices }> {
+  const [current, prices] = await Promise.all([
+    fetchAavePositionState(client, config, user),
+    fetchAavePrices(client, config),
+  ])
+  return { current, prices }
+}

--- a/packages/sdk/src/actions/borrow/providers/aave/quote.ts
+++ b/packages/sdk/src/actions/borrow/providers/aave/quote.ts
@@ -8,7 +8,7 @@ import {
   type AssembleAaveQuoteArgs,
   projectAavePositionState,
 } from '@/actions/borrow/providers/aave/presentation.js'
-import { fetchAaveStateAndPrices } from '@/actions/borrow/providers/aave/state.js'
+import { fetchAaveStateAndPrices } from '@/actions/borrow/providers/aave/prices.js'
 import {
   buildAaveCollateralDeposit,
   buildAaveCollateralWithdraw,

--- a/packages/sdk/src/actions/borrow/providers/aave/state.ts
+++ b/packages/sdk/src/actions/borrow/providers/aave/state.ts
@@ -1,28 +1,15 @@
-import {
-  type Address,
-  type ContractFunctionReturnType,
-  erc20Abi,
-  type PublicClient,
-} from 'viem'
+import { type Address, erc20Abi, type PublicClient } from 'viem'
 
+import { POOL_ACCOUNT_ABI } from '@/actions/shared/aave/abis/pool.js'
+import { requireAavePoolAddress } from '@/actions/shared/aave/addresses.js'
 import {
-  ADDRESSES_PROVIDER_ABI,
-  ORACLE_ABI,
-  POOL_ACCOUNT_ABI,
-  POOL_GET_RESERVE_DATA_ABI,
-} from '@/actions/shared/aave/abis/pool.js'
-import {
-  getAaveAddresses,
-  requireAavePoolAddress,
-} from '@/actions/shared/aave/addresses.js'
-import { ChainNotSupportedError } from '@/core/error/errors.js'
+  aaveReserveDataCall,
+  decodeAaveReserveData,
+  type DecodedAaveReserveData,
+} from '@/actions/shared/aave/reserve.js'
 import type { AaveBorrowMarketConfig } from '@/types/borrow/index.js'
 
-import type {
-  AaveMarketState,
-  AavePositionState,
-  AaveReservePrices,
-} from './presentation.js'
+import type { AaveMarketState, AavePositionState } from './presentation.js'
 
 /**
  * Decode the packed Aave reserve `configuration.data` bitmap.
@@ -44,45 +31,6 @@ export function decodeReserveConfig(data: bigint): {
   }
 }
 
-type RawReserveData = ContractFunctionReturnType<
-  typeof POOL_GET_RESERVE_DATA_ABI,
-  'view',
-  'getReserveData'
->
-
-interface DecodedReserveData {
-  configData: bigint
-  variableBorrowRateRay: bigint
-  aToken: Address
-  variableDebtToken: Address
-}
-
-/**
- * `getReserveData` returns a flat tuple. Pull out the fields the borrow
- * provider needs by their documented positions: configuration bitmap (0),
- * variable borrow rate (4), aToken address (8), variable debt token (10).
- * Positions follow the `ReserveData` struct field order:
- * https://github.com/aave/aave-v3-core/blob/master/contracts/protocol/libraries/types/DataTypes.sol
- */
-function decodeReserveData(reserve: RawReserveData): DecodedReserveData {
-  return {
-    configData: reserve[0].data,
-    variableBorrowRateRay: reserve[4],
-    aToken: reserve[8],
-    variableDebtToken: reserve[10],
-  }
-}
-
-/** A `getReserveData(asset)` multicall contract spec against the pool. */
-function reserveDataCall(pool: Address, asset: Address) {
-  return {
-    address: pool,
-    abi: POOL_GET_RESERVE_DATA_ABI,
-    functionName: 'getReserveData',
-    args: [asset],
-  } as const
-}
-
 /**
  * Read and decode both the debt and collateral reserves' `getReserveData`
  * in one multicall. Shared by the reserve-only read paths; the position
@@ -92,17 +40,20 @@ async function readBothReserveData(
   client: PublicClient,
   pool: Address,
   config: AaveBorrowMarketConfig,
-): Promise<{ debt: DecodedReserveData; collateral: DecodedReserveData }> {
+): Promise<{
+  debt: DecodedAaveReserveData
+  collateral: DecodedAaveReserveData
+}> {
   const [debtRaw, collateralRaw] = await client.multicall({
     allowFailure: false,
     contracts: [
-      reserveDataCall(pool, config.aave.debtReserve),
-      reserveDataCall(pool, config.aave.collateralReserve),
+      aaveReserveDataCall(pool, config.aave.debtReserve),
+      aaveReserveDataCall(pool, config.aave.collateralReserve),
     ],
   })
   return {
-    debt: decodeReserveData(debtRaw),
-    collateral: decodeReserveData(collateralRaw),
+    debt: decodeAaveReserveData(debtRaw),
+    collateral: decodeAaveReserveData(collateralRaw),
   }
 }
 
@@ -163,8 +114,8 @@ export async function fetchAavePositionState(
     await client.multicall({
       allowFailure: false,
       contracts: [
-        reserveDataCall(pool, config.aave.debtReserve),
-        reserveDataCall(pool, config.aave.collateralReserve),
+        aaveReserveDataCall(pool, config.aave.debtReserve),
+        aaveReserveDataCall(pool, config.aave.collateralReserve),
         {
           address: pool,
           abi: POOL_ACCOUNT_ABI,
@@ -174,8 +125,8 @@ export async function fetchAavePositionState(
       ],
     })
 
-  const debtReserve = decodeReserveData(debtReserveRaw)
-  const collateralReserve = decodeReserveData(collateralReserveRaw)
+  const debtReserve = decodeAaveReserveData(debtReserveRaw)
+  const collateralReserve = decodeAaveReserveData(collateralReserveRaw)
   const collateralConfig = decodeReserveConfig(collateralReserve.configData)
 
   const [collateralAmount, debtAmount] = await client.multicall({
@@ -227,59 +178,4 @@ export async function fetchAaveReserveTokens(
     aToken: collateral.aToken,
     variableDebtToken: debt.variableDebtToken,
   }
-}
-
-/**
- * Read base-currency (USD) oracle prices for the collateral and debt reserves.
- * Resolves the oracle via the pool addresses provider, then reads both prices.
- * Used by the write path to project the resulting position's health factor.
- */
-async function fetchAavePrices(
-  client: PublicClient,
-  config: AaveBorrowMarketConfig,
-): Promise<AaveReservePrices> {
-  const addresses = getAaveAddresses(config.chainId)
-  if (!addresses) throw new ChainNotSupportedError({ chainId: config.chainId })
-
-  const oracle = await client.readContract({
-    address: addresses.poolAddressesProvider,
-    abi: ADDRESSES_PROVIDER_ABI,
-    functionName: 'getPriceOracle',
-  })
-
-  const [collateralPrice, debtPrice] = await client.multicall({
-    allowFailure: false,
-    contracts: [
-      {
-        address: oracle,
-        abi: ORACLE_ABI,
-        functionName: 'getAssetPrice',
-        args: [config.aave.collateralReserve],
-      },
-      {
-        address: oracle,
-        abi: ORACLE_ABI,
-        functionName: 'getAssetPrice',
-        args: [config.aave.debtReserve],
-      },
-    ],
-  })
-
-  return { collateralPrice, debtPrice }
-}
-
-/**
- * Read the caller's position and the reserve prices in parallel. Both feed
- * `projectAavePositionState`, so every write path fetches them together.
- */
-export async function fetchAaveStateAndPrices(
-  client: PublicClient,
-  config: AaveBorrowMarketConfig,
-  user: Address,
-): Promise<{ current: AavePositionState; prices: AaveReservePrices }> {
-  const [current, prices] = await Promise.all([
-    fetchAavePositionState(client, config, user),
-    fetchAavePrices(client, config),
-  ])
-  return { current, prices }
 }

--- a/packages/sdk/src/actions/lend/providers/aave/__tests__/sdk.test.ts
+++ b/packages/sdk/src/actions/lend/providers/aave/__tests__/sdk.test.ts
@@ -1,0 +1,136 @@
+import {
+  createPublicClient,
+  custom,
+  encodeFunctionResult,
+  erc20Abi,
+  type Hex,
+  multicall3Abi,
+  type PublicClient,
+  zeroAddress,
+} from 'viem'
+import { mainnet, optimismSepolia } from 'viem/chains'
+import { describe, expect, it } from 'vitest'
+
+import {
+  calculateApyBreakdown,
+  getReserve,
+} from '@/actions/lend/providers/aave/sdk.js'
+import { POOL_GET_RESERVE_DATA_ABI } from '@/actions/shared/aave/abis/pool.js'
+import { WETH } from '@/constants/assets.js'
+import { ChainManager } from '@/services/ChainManager.js'
+import type { LendProviderConfig } from '@/types/actions.js'
+import type { LendMarketConfig } from '@/types/lend/index.js'
+import { getAssetAddress } from '@/utils/assets.js'
+
+const LIQUIDITY_RATE_RAY = 70_000_000_000_000_000_000_000_000n
+const AVAILABLE_LIQUIDITY = 6_026_826_049_431_131_650n
+const A_TOKEN_SUPPLY = 292_100_687_278_031_065_961n
+const A_TOKEN = '0x23e4ed24c1b47491edbc64d4f905225c6ae4d0a1'
+
+const reserveData = [
+  { data: 0n },
+  0n,
+  LIQUIDITY_RATE_RAY,
+  0n,
+  0n,
+  0n,
+  0,
+  0,
+  A_TOKEN,
+  zeroAddress,
+  zeroAddress,
+  zeroAddress,
+  0n,
+  0n,
+  0n,
+] as const
+
+class TestChainManager extends ChainManager {
+  constructor(private readonly client: PublicClient) {
+    super([])
+  }
+
+  override getPublicClient(): PublicClient {
+    return this.client
+  }
+}
+
+function createAaveClient(results: Hex[]): PublicClient {
+  return createPublicClient({
+    chain: mainnet,
+    transport: custom({
+      request: async () => {
+        const result = results.shift()
+        if (!result) throw new Error('Unexpected RPC request')
+        return result
+      },
+    }),
+  })
+}
+
+function encodedReserveReads(): Hex[] {
+  const availableLiquidity = encodeFunctionResult({
+    abi: erc20Abi,
+    functionName: 'balanceOf',
+    result: AVAILABLE_LIQUIDITY,
+  })
+  const totalSupply = encodeFunctionResult({
+    abi: erc20Abi,
+    functionName: 'totalSupply',
+    result: A_TOKEN_SUPPLY,
+  })
+  return [
+    encodeFunctionResult({
+      abi: POOL_GET_RESERVE_DATA_ABI,
+      functionName: 'getReserveData',
+      result: reserveData,
+    }),
+    encodeFunctionResult({
+      abi: multicall3Abi,
+      functionName: 'aggregate3',
+      result: [
+        { success: true, returnData: availableLiquidity },
+        { success: true, returnData: totalSupply },
+      ],
+    }),
+  ]
+}
+
+const wethAddress = getAssetAddress(WETH, optimismSepolia.id)
+const market: LendMarketConfig = {
+  address: wethAddress,
+  chainId: optimismSepolia.id,
+  name: 'Aave WETH Optimism Sepolia',
+  asset: WETH,
+  lendProvider: 'aave',
+}
+const lendConfig: LendProviderConfig = { marketAllowlist: [market] }
+
+describe('calculateApyBreakdown', () => {
+  it('converts a ray-sized liquidity rate without integer overflow', () => {
+    const apy = calculateApyBreakdown(LIQUIDITY_RATE_RAY)
+
+    expect(apy.native).toBeCloseTo(Math.exp(0.07) - 1, 8)
+    expect(apy.total).toBe(apy.native)
+  })
+})
+
+describe('getReserve', () => {
+  it('reads reserve state directly without the UI provider tuple', async () => {
+    const chainManager = new TestChainManager(
+      createAaveClient(encodedReserveReads()),
+    )
+
+    const reserve = await getReserve({
+      marketId: { address: wethAddress, chainId: optimismSepolia.id },
+      chainManager,
+      lendConfig,
+    })
+
+    expect(reserve.supply).toEqual({
+      totalAssets: AVAILABLE_LIQUIDITY,
+      totalShares: A_TOKEN_SUPPLY,
+    })
+    expect(reserve.apy.native).toBeGreaterThan(0)
+  })
+})

--- a/packages/sdk/src/actions/lend/providers/aave/sdk.ts
+++ b/packages/sdk/src/actions/lend/providers/aave/sdk.ts
@@ -1,20 +1,11 @@
-import { UiPoolDataProvider } from '@aave/contract-helpers'
-import { formatReserves } from '@aave/math-utils'
-import { providers } from 'ethers'
-import type { Address } from 'viem'
+import { type Address, formatUnits } from 'viem'
 
 import { findMarketInAllowlist } from '@/actions/lend/utils/markets.js'
-import { POOL_GET_RESERVE_DATA_ABI } from '@/actions/shared/aave/abis/pool.js'
-import {
-  getAaveAddresses,
-  getPoolAddress,
-} from '@/actions/shared/aave/addresses.js'
+import { requireAavePoolAddress } from '@/actions/shared/aave/addresses.js'
+import { readAaveReserveData } from '@/actions/shared/aave/reserve.js'
 import { WETH } from '@/constants/assets.js'
 import type { SupportedChainId } from '@/constants/supportedChains.js'
-import {
-  ChainNotSupportedError,
-  MarketNotAllowedError,
-} from '@/core/error/errors.js'
+import { MarketNotAllowedError } from '@/core/error/errors.js'
 import type { ChainManager } from '@/services/ChainManager.js'
 import type { LendProviderConfig } from '@/types/actions.js'
 import type {
@@ -23,250 +14,151 @@ import type {
   LendMarketConfig,
   LendMarketId,
 } from '@/types/lend/index.js'
-import { getAssetAddress } from '@/utils/assets.js'
+import { getAssetAddress, isNativeAsset } from '@/utils/assets.js'
+import { SECONDS_PER_YEAR } from '@/utils/constants.js'
+import { validateNotZeroAddress } from '@/utils/validation.js'
 
-/**
- * Parameters for getReserve function
- */
+import {
+  type AaveLendReserveState,
+  fetchAaveLendReserveState,
+} from './state.js'
+
+const SECONDS_PER_YEAR_NUMBER = Number(SECONDS_PER_YEAR)
+
 interface GetReserveParams {
-  /** Market identifier (asset address and chainId) */
   marketId: LendMarketId
-  /** Chain manager instance */
   chainManager: ChainManager
-  /** Lend configuration containing market allowlist */
   lendConfig?: LendProviderConfig
 }
 
-/**
- * Parameters for getReserves function
- */
 interface GetReservesParams {
   chainManager: ChainManager
   lendConfig: LendProviderConfig
   markets: LendMarketConfig[]
 }
 
-/**
- * Calculate APY breakdown from reserve data
- * @param reserve - Formatted reserve data from Aave
- * @returns APY breakdown with native APY and rewards
- */
-export function calculateApyBreakdown(reserve: {
-  formattedReserve?: any
-}): ApyBreakdown {
-  // Get supply APY from formatted reserve data
-  const supplyApy = reserve.formattedReserve?.supplyAPY
-    ? parseFloat(reserve.formattedReserve.supplyAPY)
-    : 0
+interface BuildMarketParams {
+  marketId: LendMarketId
+  config: LendMarketConfig
+  pool: Address
+  state: AaveLendReserveState
+}
 
-  // Aave doesn't have vault-style performance fees
-  // Total APY = Supply APY + any rewards (to be added later)
+function requireMarketConfig(params: GetReserveParams): LendMarketConfig {
+  const config = findMarketInAllowlist(
+    params.lendConfig?.marketAllowlist,
+    params.marketId,
+  )
+  if (config) return config
+  throw new MarketNotAllowedError({
+    address: params.marketId.address,
+    chainId: params.marketId.chainId,
+    reason: 'Market not found in allowlist',
+  })
+}
+
+function resolveReserveAsset(config: LendMarketConfig): Address {
+  return isNativeAsset(config.asset)
+    ? getAssetAddress(WETH, config.chainId)
+    : getAssetAddress(config.asset, config.chainId)
+}
+
+/**
+ * @description Converts an Aave liquidity rate from ray units to compounded APY.
+ * @param liquidityRateRay - Annualized supply rate scaled by 1e27.
+ * @returns Native, reward, fee, and total APY components as decimal fractions.
+ */
+export function calculateApyBreakdown(liquidityRateRay: bigint): ApyBreakdown {
+  const annualRate = Number(formatUnits(liquidityRateRay, 27))
+  const supplyApy = Math.expm1(
+    SECONDS_PER_YEAR_NUMBER * Math.log1p(annualRate / SECONDS_PER_YEAR_NUMBER),
+  )
   return {
     total: supplyApy,
     native: supplyApy,
-    totalRewards: 0, // TODO: Fetch from incentives data provider if needed
-    performanceFee: 0, // Aave doesn't have performance fees
+    totalRewards: 0,
+    performanceFee: 0,
+  }
+}
+
+function buildMarket(params: BuildMarketParams): LendMarket {
+  const lastUpdate = Math.floor(Date.now() / 1000)
+  return {
+    marketId: params.marketId,
+    name: params.config.name,
+    asset: params.config.asset,
+    supply: {
+      totalAssets: params.state.availableLiquidity,
+      totalShares: params.state.totalSupply,
+    },
+    apy: calculateApyBreakdown(params.state.liquidityRateRay),
+    metadata: {
+      owner: params.pool,
+      curator: params.pool,
+      fee: 0,
+      lastUpdate,
+    },
   }
 }
 
 /**
- * Get detailed reserve (market) information from Aave
- * @param params - Named parameters object
- * @returns Promise resolving to detailed market information
+ * @description Gets one configured Aave lend market from onchain reserve state.
+ * @param params - Market identifier, chain manager, and lend configuration.
+ * @returns Detailed market liquidity, shares, APY, and metadata.
+ * @throws MarketNotAllowedError when the market is absent from the allowlist.
+ * @throws ChainNotSupportedError when Aave is not configured for the chain.
  */
 export async function getReserve(
   params: GetReserveParams,
 ): Promise<LendMarket> {
-  // Find market configuration in allowlist for metadata
-  const marketConfig = params.lendConfig?.marketAllowlist
-    ? findMarketInAllowlist(params.lendConfig.marketAllowlist, params.marketId)
-    : undefined
-
-  if (!marketConfig) {
-    throw new MarketNotAllowedError({
-      address: params.marketId.address,
-      chainId: params.marketId.chainId,
-      reason: 'Market not found in allowlist',
-    })
-  }
-
-  const addresses = getAaveAddresses(params.marketId.chainId)
-  if (!addresses) {
-    throw new ChainNotSupportedError({ chainId: params.marketId.chainId })
-  }
-
-  const poolAddress = addresses.pool
-  const uiPoolDataProviderAddress = addresses.uiPoolDataProvider
-  const poolAddressesProvider = addresses.poolAddressesProvider
-
-  try {
-    // Get viem public client for this chain
-    const publicClient = params.chainManager.getPublicClient(
-      params.marketId.chainId,
-    )
-
-    // Create ethers provider from viem's RPC URL
-    // Aave SDK requires ethers provider, not viem
-    const rpcUrl =
-      publicClient.chain?.rpcUrls.default.http[0] ||
-      publicClient.chain?.rpcUrls.public?.http[0]
-    if (!rpcUrl) {
-      throw new Error(
-        `No RPC URL available for chain ${params.marketId.chainId}`,
-      )
-    }
-    const ethersProvider = new providers.JsonRpcProvider(rpcUrl)
-
-    // Create UiPoolDataProvider instance
-    const uiPoolDataProvider = new UiPoolDataProvider({
-      uiPoolDataProviderAddress,
-      provider: ethersProvider,
-      chainId: params.marketId.chainId,
-    })
-
-    // Fetch reserve data
-    const reservesData = await uiPoolDataProvider.getReservesHumanized({
-      lendingPoolAddressProvider: poolAddressesProvider,
-    })
-
-    // Find the specific reserve for this asset
-    // For native ETH assets, use WETH address since Aave uses WETH internally
-    const assetAddress =
-      marketConfig.asset.type === 'native'
-        ? getAssetAddress(WETH, params.marketId.chainId)
-        : getAssetAddress(marketConfig.asset, params.marketId.chainId)
-
-    const reserve = reservesData.reservesData.find(
-      (r) => r.underlyingAsset.toLowerCase() === assetAddress.toLowerCase(),
-    )
-
-    if (!reserve) {
-      throw new Error(
-        `Reserve not found for asset ${assetAddress} on chain ${params.marketId.chainId}`,
-      )
-    }
-
-    // Format reserves using Aave math-utils
-    const currentTimestamp = Math.floor(Date.now() / 1000)
-    const formattedReserves = formatReserves({
-      reserves: [reserve],
-      currentTimestamp,
-      marketReferenceCurrencyDecimals:
-        reservesData.baseCurrencyData.marketReferenceCurrencyDecimals,
-      marketReferencePriceInUsd:
-        reservesData.baseCurrencyData.marketReferenceCurrencyPriceInUsd,
-    })
-
-    const formattedReserve = formattedReserves[0]
-
-    // Calculate APY breakdown
-    const apy = calculateApyBreakdown({
-      ...reserve,
-      formattedReserve,
-    })
-
-    // Return market information in our standard format
-    return {
-      marketId: params.marketId,
-      name: marketConfig.name,
-      asset: marketConfig.asset,
-      supply: {
-        totalAssets: BigInt(reserve.availableLiquidity),
-        totalShares: BigInt(reserve.totalScaledVariableDebt || '0'),
-      },
-      apy,
-      metadata: {
-        owner: poolAddress, // Use Pool as owner
-        curator: poolAddress, // No curator in Aave
-        fee: 0, // No performance fee in Aave
-        lastUpdate: currentTimestamp,
-      },
-    }
-  } catch (error) {
-    throw new Error(
-      `Failed to get reserve info for ${params.marketId.address}: ${
-        error instanceof Error ? error.message : 'Unknown error'
-      }`,
-    )
-  }
+  const config = requireMarketConfig(params)
+  const pool = requireAavePoolAddress(params.marketId.chainId)
+  const asset = resolveReserveAsset(config)
+  const client = params.chainManager.getPublicClient(params.marketId.chainId)
+  const state = await fetchAaveLendReserveState(client, pool, asset)
+  return buildMarket({ marketId: params.marketId, config, pool, state })
 }
 
 /**
- * Get multiple reserves (markets)
- * @param params - Parameters including markets to fetch
- * @returns Promise resolving to array of market information
+ * @description Gets all configured Aave lend markets concurrently.
+ * @param params - Markets, chain manager, and lend configuration.
+ * @returns Detailed market information in input order.
+ * @throws MarketNotAllowedError when a market is absent from the allowlist.
+ * @throws ChainNotSupportedError when Aave is not configured for a chain.
  */
 export async function getReserves(
   params: GetReservesParams,
 ): Promise<LendMarket[]> {
-  try {
-    const reservePromises = params.markets.map((marketConfig) => {
-      return getReserve({
-        marketId: {
-          address: marketConfig.address,
-          chainId: marketConfig.chainId,
-        },
+  return Promise.all(
+    params.markets.map((market) =>
+      getReserve({
+        marketId: { address: market.address, chainId: market.chainId },
         chainManager: params.chainManager,
         lendConfig: params.lendConfig,
-      })
-    })
-
-    return await Promise.all(reservePromises)
-  } catch (error) {
-    throw new Error(
-      `Failed to get reserves: ${
-        error instanceof Error ? error.message : 'Unknown error'
-      }`,
-    )
-  }
+      }),
+    ),
+  )
 }
 
 /**
- * Get aToken address for a given underlying asset
- * @param params - Parameters including asset address, chain ID, and chain manager
- * @returns Promise resolving to aToken address
- * @description Queries the Aave Pool to get the aToken address for the underlying asset
+ * @description Resolves an Aave reserve's aToken directly from the Pool.
+ * @param params - Underlying asset, chain ID, and chain manager.
+ * @returns The interest-bearing aToken address.
+ * @throws ChainNotSupportedError when Aave is not configured for the chain.
+ * @throws ZeroAddressError when the Pool has no reserve for the asset.
  */
 export async function getATokenAddress(params: {
   underlyingAsset: Address
   chainId: SupportedChainId
   chainManager: ChainManager
 }): Promise<Address> {
-  const poolAddress = getPoolAddress(params.chainId)
-  if (!poolAddress) {
-    throw new ChainNotSupportedError({ chainId: params.chainId })
-  }
-
-  try {
-    // Get viem public client for this chain
-    const publicClient = params.chainManager.getPublicClient(params.chainId)
-
-    // Query the Pool contract directly for reserve data
-    const reserveData = await publicClient.readContract({
-      address: poolAddress,
-      abi: POOL_GET_RESERVE_DATA_ABI,
-      functionName: 'getReserveData',
-      args: [params.underlyingAsset],
-    })
-
-    // The return is a tuple where index 8 is aTokenAddress
-    const aTokenAddress = reserveData[8]
-
-    if (
-      !aTokenAddress ||
-      aTokenAddress === '0x0000000000000000000000000000000000000000'
-    ) {
-      throw new Error(
-        `No aToken found for asset ${params.underlyingAsset} on chain ${params.chainId}`,
-      )
-    }
-
-    return aTokenAddress
-  } catch (error) {
-    throw new Error(
-      `Failed to get aToken address for ${params.underlyingAsset}: ${
-        error instanceof Error ? error.message : 'Unknown error'
-      }`,
-    )
-  }
+  const pool = requireAavePoolAddress(params.chainId)
+  const client = params.chainManager.getPublicClient(params.chainId)
+  const reserve = await readAaveReserveData(
+    client,
+    pool,
+    params.underlyingAsset,
+  )
+  validateNotZeroAddress(reserve.aToken, 'Aave aToken')
+  return reserve.aToken
 }

--- a/packages/sdk/src/actions/lend/providers/aave/state.ts
+++ b/packages/sdk/src/actions/lend/providers/aave/state.ts
@@ -1,0 +1,50 @@
+import { type Address, erc20Abi, type PublicClient } from 'viem'
+
+import { readAaveReserveData } from '@/actions/shared/aave/reserve.js'
+
+/** Aave reserve state needed by the lend market presentation. */
+export interface AaveLendReserveState {
+  /** Underlying liquidity currently held by the aToken contract. */
+  availableLiquidity: bigint
+  /** Total issued aToken shares. */
+  totalSupply: bigint
+  /** Current supply rate in ray units. */
+  liquidityRateRay: bigint
+}
+
+/**
+ * @description Reads one Aave reserve through Pool and ERC-20 calls.
+ * @param client - Public client for the reserve chain.
+ * @param pool - Aave Pool address.
+ * @param asset - Underlying reserve asset address.
+ * @returns Liquidity, share supply, and supply rate.
+ * @throws A viem contract error when a reserve or token read fails.
+ */
+export async function fetchAaveLendReserveState(
+  client: PublicClient,
+  pool: Address,
+  asset: Address,
+): Promise<AaveLendReserveState> {
+  const reserve = await readAaveReserveData(client, pool, asset)
+  const [availableLiquidity, totalSupply] = await client.multicall({
+    allowFailure: false,
+    contracts: [
+      {
+        address: asset,
+        abi: erc20Abi,
+        functionName: 'balanceOf',
+        args: [reserve.aToken],
+      },
+      {
+        address: reserve.aToken,
+        abi: erc20Abi,
+        functionName: 'totalSupply',
+      },
+    ],
+  })
+  return {
+    availableLiquidity,
+    totalSupply,
+    liquidityRateRay: reserve.liquidityRateRay,
+  }
+}

--- a/packages/sdk/src/actions/shared/aave/reserve.ts
+++ b/packages/sdk/src/actions/shared/aave/reserve.ts
@@ -1,0 +1,72 @@
+import type { Address, ContractFunctionReturnType, PublicClient } from 'viem'
+
+import { POOL_GET_RESERVE_DATA_ABI } from './abis/pool.js'
+
+type RawAaveReserveData = ContractFunctionReturnType<
+  typeof POOL_GET_RESERVE_DATA_ABI,
+  'view',
+  'getReserveData'
+>
+
+/** Decoded Aave reserve fields shared by lend and borrow providers. */
+export interface DecodedAaveReserveData {
+  /** Packed reserve configuration bitmap. */
+  configData: bigint
+  /** Current supply rate in ray units. */
+  liquidityRateRay: bigint
+  /** Current variable borrow rate in ray units. */
+  variableBorrowRateRay: bigint
+  /** Interest-bearing token address. */
+  aToken: Address
+  /** Variable debt token address. */
+  variableDebtToken: Address
+}
+
+/**
+ * @description Decodes the shared fields from an Aave Pool reserve tuple.
+ * @param reserve - Raw `getReserveData` return value.
+ * @returns Reserve configuration, rates, and token addresses.
+ */
+export function decodeAaveReserveData(
+  reserve: RawAaveReserveData,
+): DecodedAaveReserveData {
+  return {
+    configData: reserve[0].data,
+    liquidityRateRay: reserve[2],
+    variableBorrowRateRay: reserve[4],
+    aToken: reserve[8],
+    variableDebtToken: reserve[10],
+  }
+}
+
+/**
+ * @description Builds a typed Aave Pool `getReserveData` contract call.
+ * @param pool - Aave Pool address.
+ * @param asset - Underlying reserve asset address.
+ * @returns A viem contract-call descriptor.
+ */
+export function aaveReserveDataCall(pool: Address, asset: Address) {
+  return {
+    address: pool,
+    abi: POOL_GET_RESERVE_DATA_ABI,
+    functionName: 'getReserveData',
+    args: [asset],
+  } as const
+}
+
+/**
+ * @description Reads and decodes one reserve directly from the Aave Pool.
+ * @param client - Public client for the reserve chain.
+ * @param pool - Aave Pool address.
+ * @param asset - Underlying reserve asset address.
+ * @returns Decoded reserve configuration, rates, and token addresses.
+ * @throws A viem contract error when the Pool read fails.
+ */
+export async function readAaveReserveData(
+  client: PublicClient,
+  pool: Address,
+  asset: Address,
+): Promise<DecodedAaveReserveData> {
+  const reserve = await client.readContract(aaveReserveDataCall(pool, asset))
+  return decodeAaveReserveData(reserve)
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -297,12 +297,6 @@ importers:
 
   packages/sdk:
     dependencies:
-      '@aave/contract-helpers':
-        specifier: ^1.30.0
-        version: 1.38.0(bignumber.js@9.3.1)(encoding@0.1.13)(ethers@5.8.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(reflect-metadata@0.2.2)(tslib@2.8.1)
-      '@aave/math-utils':
-        specifier: ^1.30.0
-        version: 1.38.0(bignumber.js@9.3.1)(tslib@2.8.1)
       '@dynamic-labs/ethereum':
         specifier: '>=4.31.4 <5.0.0'
         version: 4.92.2(@dynamic-labs-wallet/primitives@1.0.48)(@types/react@18.3.31)(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@18.3.1))(utf-8-validate@6.0.6)(viem@2.33.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))(zod@3.25.76)
@@ -330,9 +324,6 @@ importers:
       '@privy-io/react-auth':
         specifier: '>=2.24.0 <3.0.0'
         version: 2.25.0(@solana-program/system@0.10.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)))(@solana-program/token@0.9.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)))(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))(@solana/spl-token@0.4.14(@solana/web3.js@1.98.1(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))(@solana/web3.js@1.98.1(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6))(@types/react@18.3.31)(bs58@6.0.0)(bufferutil@4.1.0)(css-to-react-native@3.2.0)(fastestsmallesttextencoderdecoder@1.0.22)(permissionless@0.2.57(ox@0.9.3(typescript@5.9.3)(zod@3.25.76))(viem@2.33.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@18.3.1))(utf-8-validate@6.0.6)(zod@3.25.76)
-      ethers:
-        specifier: ^5.7.2
-        version: 5.8.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       permissionless:
         specifier: '>=0.2.57 <0.3.0'
         version: 0.2.57(ox@0.9.3(typescript@5.9.3)(zod@3.25.76))(viem@2.33.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))
@@ -392,20 +383,6 @@ packages:
     peerDependencies:
       graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
       typescript: ^5.0.0 || ^6.0.0
-
-  '@aave/contract-helpers@1.38.0':
-    resolution: {integrity: sha512-Z0lGFcU77OH+NaAUP3REJ9iGws+Fjndg2xtSHmGCu/ZJUL6MZsEjKhw4U6pxJXVOnCPZQsgflcrANnLX8z/JjA==}
-    peerDependencies:
-      bignumber.js: ^9.x
-      ethers: ^5.x
-      reflect-metadata: ^0.1.x
-      tslib: ^2.4.x
-
-  '@aave/math-utils@1.38.0':
-    resolution: {integrity: sha512-Zeq2Dpflb5zst3OZKHA7UMVI4wcfpxbxA8tXZyVTmw313Q7oF1oOctrEF3JnfyjcyusmU91qdJRrCAXQrQtyXA==}
-    peerDependencies:
-      bignumber.js: ^9.x
-      tslib: ^2.4.x
 
   '@ably/msgpack-js@0.4.1':
     resolution: {integrity: sha512-Sjxj6SOr17hExAVrsycN7u6oV4PhZcK7Z2S8dM71CH/butgO47cSo/TL6FJPCXUyDAzKkOWjMUpJGyZkEpyu4Q==}
@@ -1692,12 +1669,6 @@ packages:
   '@ethersproject/hash@5.8.0':
     resolution: {integrity: sha512-ac/lBcTbEWW/VGJij0CNSw/wPcw9bSRgCB0AIBz8CvED/jfvDoV9hsIIiWfvWmFEi8RcXtlNwp2jv6ozWOsooA==}
 
-  '@ethersproject/hdnode@5.8.0':
-    resolution: {integrity: sha512-4bK1VF6E83/3/Im0ERnnUeWOY3P1BZml4ZD3wcH8Ys0/d1h1xaFt6Zc+Dh9zXf9TapGro0T4wvO71UTCp3/uoA==}
-
-  '@ethersproject/json-wallets@5.8.0':
-    resolution: {integrity: sha512-HxblNck8FVUtNxS3VTEYJAcwiKYsBIF77W15HufqlBF9gGfhmYOJtYZp8fSDZtn9y5EaXTE87zDwzxRoTFk11w==}
-
   '@ethersproject/keccak256@5.8.0':
     resolution: {integrity: sha512-A1pkKLZSz8pDaQ1ftutZoaN46I6+jvuqugx5KYNeQOPqq+JZ0Txm7dlWesCHB5cndJSu5vP2VKptKf7cksERng==}
 
@@ -1706,9 +1677,6 @@ packages:
 
   '@ethersproject/networks@5.8.0':
     resolution: {integrity: sha512-egPJh3aPVAzbHwq8DD7Po53J4OUSsA1MjQp8Vf/OZPav5rlmWUaFLiq8cvQiGK0Z5K6LYzm29+VA/p4RL1FzNg==}
-
-  '@ethersproject/pbkdf2@5.8.0':
-    resolution: {integrity: sha512-wuHiv97BrzCmfEaPbUFpMjlVg/IDkZThp9Ri88BpjRleg4iePJaj2SW8AIyE8cXn5V1tuAaMj6lzvsGJkGWskg==}
 
   '@ethersproject/properties@5.8.0':
     resolution: {integrity: sha512-PYuiEoQ+FMaZZNGrStmN7+lWjlsoufGIHdww7454FIaGdbe/p5rnaCXTr5MtBYl3NkeoVhHZuyzChPeGeKIpQw==}
@@ -1728,9 +1696,6 @@ packages:
   '@ethersproject/signing-key@5.8.0':
     resolution: {integrity: sha512-LrPW2ZxoigFi6U6aVkFN/fa9Yx/+4AtIUe4/HACTvKJdhm0eeb107EVCIQcrLZkxaSIgc/eCrX8Q1GtbH+9n3w==}
 
-  '@ethersproject/solidity@5.8.0':
-    resolution: {integrity: sha512-4CxFeCgmIWamOHwYN9d+QWGxye9qQLilpgTU0XhYs1OahkclF+ewO+3V1U0mvpiuQxm5EHHmv8f7ClVII8EHsA==}
-
   '@ethersproject/strings@5.8.0':
     resolution: {integrity: sha512-qWEAk0MAvl0LszjdfnZ2uC8xbR2wdv4cDabyHiBh3Cldq/T8dPH3V4BbBsAYJUeonwD+8afVXld274Ls+Y1xXg==}
 
@@ -1740,14 +1705,8 @@ packages:
   '@ethersproject/units@5.8.0':
     resolution: {integrity: sha512-lxq0CAnc5kMGIiWW4Mr041VT8IhNM+Pn5T3haO74XZWFulk7wH1Gv64HqE96hT4a7iiNMdOCFEBgaxWuk8ETKQ==}
 
-  '@ethersproject/wallet@5.8.0':
-    resolution: {integrity: sha512-G+jnzmgg6UxurVKRKvw27h0kvG75YKXZKdlLYmAHeF32TGUzHkOFd7Zn6QHOTYRFWnfjtSSFjBowKo7vfrXzPA==}
-
   '@ethersproject/web@5.8.0':
     resolution: {integrity: sha512-j7+Ksi/9KfGviws6Qtf9Q7KCqRhpwrYKQPs+JBA/rKVFF/yaWLHJEH3zfVP2plVu+eys0d2DlFmhoQJayFewcw==}
-
-  '@ethersproject/wordlists@5.8.0':
-    resolution: {integrity: sha512-2df9bbXicZws2Sb5S6ET493uJ0Z84Fjr3pC4tu/qlnZERibZCeUVuqdtt+7Tv9xxhUxHoIekIA7avrKUWHrezg==}
 
   '@evervault/wasm-attestation-bindings@0.3.1':
     resolution: {integrity: sha512-pJsbax/pEPdRXSnFKahzGZeq2CNTZ0skAPWpnEZK/8vdcvlan7LE7wMSOVr+Z+MqTBnVEnS7O80TKpXKU5Rsbw==}
@@ -4094,9 +4053,6 @@ packages:
     resolution: {integrity: sha512-4B/qKCfeE/ODUaAUpSwfzazo5x29WD4r3vXiWsB7I2mSDAihwEqKO+g8GELZUQSSAo5e1XTYh3ZVfLyxBc12nA==}
     engines: {node: '>= 10.0.0'}
 
-  aes-js@3.0.0:
-    resolution: {integrity: sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==}
-
   aes-js@4.0.0-beta.5:
     resolution: {integrity: sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==}
 
@@ -5093,9 +5049,6 @@ packages:
   ethereum-cryptography@2.2.1:
     resolution: {integrity: sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg==}
 
-  ethers@5.8.0:
-    resolution: {integrity: sha512-DUq+7fHrCg1aPDFCHx6UIPb3nmt2XMpM7Y/g2gLhsl3lIBqeAfOJIl1qEvRf2uq3BiKxmh6Fh5pfp2ieyek7Kg==}
-
   ethers@6.17.0:
     resolution: {integrity: sha512-BpyrpIPJ3ydEVow8zGaz1DuPS7YU8DcWxuBnY9a0UA/lvAPwrMr+EPXsfrul628SRaekPNeIM4UFh/91GWZang==}
     engines: {node: '>=14.0.0'}
@@ -5718,9 +5671,6 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
-
-  isomorphic-unfetch@3.1.0:
-    resolution: {integrity: sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==}
 
   isomorphic-ws@4.0.1:
     resolution: {integrity: sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==}
@@ -6916,9 +6866,6 @@ packages:
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
-  scrypt-js@3.0.1:
-    resolution: {integrity: sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==}
-
   secure-json-parse@2.7.0:
     resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
 
@@ -7412,9 +7359,6 @@ packages:
     resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
     engines: {node: '>=18.17'}
 
-  unfetch@4.2.0:
-    resolution: {integrity: sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==}
-
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
     engines: {node: '>=4'}
@@ -7899,21 +7843,6 @@ snapshots:
       '@gql.tada/internal': 1.2.1(graphql@16.14.2)(typescript@5.9.3)
       graphql: 16.14.2
       typescript: 5.9.3
-
-  '@aave/contract-helpers@1.38.0(bignumber.js@9.3.1)(encoding@0.1.13)(ethers@5.8.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(reflect-metadata@0.2.2)(tslib@2.8.1)':
-    dependencies:
-      bignumber.js: 9.3.1
-      ethers: 5.8.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      isomorphic-unfetch: 3.1.0(encoding@0.1.13)
-      reflect-metadata: 0.2.2
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - encoding
-
-  '@aave/math-utils@1.38.0(bignumber.js@9.3.1)(tslib@2.8.1)':
-    dependencies:
-      bignumber.js: 9.3.1
-      tslib: 2.8.1
 
   '@ably/msgpack-js@0.4.1':
     dependencies:
@@ -10165,37 +10094,6 @@ snapshots:
       '@ethersproject/properties': 5.8.0
       '@ethersproject/strings': 5.8.0
 
-  '@ethersproject/hdnode@5.8.0':
-    dependencies:
-      '@ethersproject/abstract-signer': 5.8.0
-      '@ethersproject/basex': 5.8.0
-      '@ethersproject/bignumber': 5.8.0
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      '@ethersproject/pbkdf2': 5.8.0
-      '@ethersproject/properties': 5.8.0
-      '@ethersproject/sha2': 5.8.0
-      '@ethersproject/signing-key': 5.8.0
-      '@ethersproject/strings': 5.8.0
-      '@ethersproject/transactions': 5.8.0
-      '@ethersproject/wordlists': 5.8.0
-
-  '@ethersproject/json-wallets@5.8.0':
-    dependencies:
-      '@ethersproject/abstract-signer': 5.8.0
-      '@ethersproject/address': 5.8.0
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/hdnode': 5.8.0
-      '@ethersproject/keccak256': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      '@ethersproject/pbkdf2': 5.8.0
-      '@ethersproject/properties': 5.8.0
-      '@ethersproject/random': 5.8.0
-      '@ethersproject/strings': 5.8.0
-      '@ethersproject/transactions': 5.8.0
-      aes-js: 3.0.0
-      scrypt-js: 3.0.1
-
   '@ethersproject/keccak256@5.8.0':
     dependencies:
       '@ethersproject/bytes': 5.8.0
@@ -10206,11 +10104,6 @@ snapshots:
   '@ethersproject/networks@5.8.0':
     dependencies:
       '@ethersproject/logger': 5.8.0
-
-  '@ethersproject/pbkdf2@5.8.0':
-    dependencies:
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/sha2': 5.8.0
 
   '@ethersproject/properties@5.8.0':
     dependencies:
@@ -10267,15 +10160,6 @@ snapshots:
       elliptic: 6.6.1
       hash.js: 1.1.7
 
-  '@ethersproject/solidity@5.8.0':
-    dependencies:
-      '@ethersproject/bignumber': 5.8.0
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/keccak256': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      '@ethersproject/sha2': 5.8.0
-      '@ethersproject/strings': 5.8.0
-
   '@ethersproject/strings@5.8.0':
     dependencies:
       '@ethersproject/bytes': 5.8.0
@@ -10300,36 +10184,10 @@ snapshots:
       '@ethersproject/constants': 5.8.0
       '@ethersproject/logger': 5.8.0
 
-  '@ethersproject/wallet@5.8.0':
-    dependencies:
-      '@ethersproject/abstract-provider': 5.8.0
-      '@ethersproject/abstract-signer': 5.8.0
-      '@ethersproject/address': 5.8.0
-      '@ethersproject/bignumber': 5.8.0
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/hash': 5.8.0
-      '@ethersproject/hdnode': 5.8.0
-      '@ethersproject/json-wallets': 5.8.0
-      '@ethersproject/keccak256': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      '@ethersproject/properties': 5.8.0
-      '@ethersproject/random': 5.8.0
-      '@ethersproject/signing-key': 5.8.0
-      '@ethersproject/transactions': 5.8.0
-      '@ethersproject/wordlists': 5.8.0
-
   '@ethersproject/web@5.8.0':
     dependencies:
       '@ethersproject/base64': 5.8.0
       '@ethersproject/bytes': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      '@ethersproject/properties': 5.8.0
-      '@ethersproject/strings': 5.8.0
-
-  '@ethersproject/wordlists@5.8.0':
-    dependencies:
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/hash': 5.8.0
       '@ethersproject/logger': 5.8.0
       '@ethersproject/properties': 5.8.0
       '@ethersproject/strings': 5.8.0
@@ -17216,8 +17074,6 @@ snapshots:
 
   address@1.2.2: {}
 
-  aes-js@3.0.0: {}
-
   aes-js@4.0.0-beta.5: {}
 
   agent-base@6.0.2:
@@ -18440,42 +18296,6 @@ snapshots:
       '@scure/bip32': 1.4.0
       '@scure/bip39': 1.3.0
 
-  ethers@5.8.0(bufferutil@4.1.0)(utf-8-validate@6.0.6):
-    dependencies:
-      '@ethersproject/abi': 5.8.0
-      '@ethersproject/abstract-provider': 5.8.0
-      '@ethersproject/abstract-signer': 5.8.0
-      '@ethersproject/address': 5.8.0
-      '@ethersproject/base64': 5.8.0
-      '@ethersproject/basex': 5.8.0
-      '@ethersproject/bignumber': 5.8.0
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/constants': 5.8.0
-      '@ethersproject/contracts': 5.8.0
-      '@ethersproject/hash': 5.8.0
-      '@ethersproject/hdnode': 5.8.0
-      '@ethersproject/json-wallets': 5.8.0
-      '@ethersproject/keccak256': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      '@ethersproject/networks': 5.8.0
-      '@ethersproject/pbkdf2': 5.8.0
-      '@ethersproject/properties': 5.8.0
-      '@ethersproject/providers': 5.8.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      '@ethersproject/random': 5.8.0
-      '@ethersproject/rlp': 5.8.0
-      '@ethersproject/sha2': 5.8.0
-      '@ethersproject/signing-key': 5.8.0
-      '@ethersproject/solidity': 5.8.0
-      '@ethersproject/strings': 5.8.0
-      '@ethersproject/transactions': 5.8.0
-      '@ethersproject/units': 5.8.0
-      '@ethersproject/wallet': 5.8.0
-      '@ethersproject/web': 5.8.0
-      '@ethersproject/wordlists': 5.8.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
   ethers@6.17.0(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
@@ -19114,13 +18934,6 @@ snapshots:
   isarray@2.0.5: {}
 
   isexe@2.0.0: {}
-
-  isomorphic-unfetch@3.1.0(encoding@0.1.13):
-    dependencies:
-      node-fetch: 2.7.0(encoding@0.1.13)
-      unfetch: 4.2.0
-    transitivePeerDependencies:
-      - encoding
 
   isomorphic-ws@4.0.1(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
     dependencies:
@@ -20466,8 +20279,6 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
-  scrypt-js@3.0.1: {}
-
   secure-json-parse@2.7.0: {}
 
   secure-json-parse@4.1.0: {}
@@ -21013,8 +20824,6 @@ snapshots:
     optional: true
 
   undici@6.27.0: {}
-
-  unfetch@4.2.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 


### PR DESCRIPTION
| Problem | Solution |
| --- | --- |
| Users cannot load positions, borrow markets, or swap quotes because bodyless GET requests advertise JSON and the backend rejects their empty bodies ([#465](https://github.com/ethereum-optimism/actions/pull/465), [#508](https://github.com/ethereum-optimism/actions/pull/508)). | Include the JSON content type only when a request has a body, with regression coverage from [#554](https://github.com/ethereum-optimism/actions/pull/554). |
| Users can trigger an endless stream of collateral-deposit requests when automatic Morpho reconciliation fails because [#490](https://github.com/ethereum-optimism/actions/pull/490) clears its attempt marker and [#512](https://github.com/ethereum-optimism/actions/pull/512) restores the same eligible position. | Retain the once-per-mount marker after failure and cover rejection-driven rerenders. |
| Users cannot auto-pledge Morpho collateral because the backend rejects the SDK-supported `{ max: true }` deposit payload before it reaches the provider. | Accept max amounts at the deposit-mutation boundary and cover the authenticated HTTP route. |
| Privy users see “Unable to sign in” after intentionally closing the auth dialog because [#541](https://github.com/ethereum-optimism/actions/pull/541) treats `exited_auth_flow` as a failure. | Return cancellations to the wallet picker while preserving the error UI for genuine failures. |
| Users cannot repay Aave debt despite holding USDC because [#512](https://github.com/ethereum-optimism/actions/pull/512) checks Base-only `USDC_DEMO` on the Aave market's OP Sepolia chain and always reads zero. | Gate mirrored Aave repayment on the Base balance while keeping ordinary repayment scoped to its market chain. |
| Users briefly lose every displayed balance and cannot swap after borrow or repay because [#311](https://github.com/ethereum-optimism/actions/pull/311) registered an empty fetcher for the shared balance query, which transaction refreshes can execute. | Keep Swap passive while sharing the real balance fetcher, with invalidation regression coverage. |
| Users see an infinite health factor for an active loan when the borrow or repay amount is zero because [#466](https://github.com/ethereum-optimism/actions/pull/466) treats the absence of a projection as a debt-free position. | Derive the fallback from current collateral and debt; reserve infinity for no debt. |
| Isolated provider fixes do not prove the full demo works when combined. | Temporarily stack [#551](https://github.com/ethereum-optimism/actions/pull/551), [#552](https://github.com/ethereum-optimism/actions/pull/552), and [#553](https://github.com/ethereum-optimism/actions/pull/553) for final UX QA; issues remain owned by those PRs and these commits will be removed here before merge. |
