### PR TITLE
fix: stop Morpho collateral retry loop and accept max deposits

### DIFF
--- a/packages/demo/backend/src/controllers/borrow.routes.spec.ts
+++ b/packages/demo/backend/src/controllers/borrow.routes.spec.ts
@@ -62,8 +62,9 @@ vi.mock('@/middleware/actions.js', () => ({
 const MARKET_ID = {
   kind: 'morpho-blue' as const,
   chainId: 84532,
-  marketId: '0x' + 'a'.repeat(64),
-}
+  marketId:
+    '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+} as const
 const WALLET = '0xaabbccddeeff00112233445566778899aabbccdd'
 
 beforeEach(async () => {
@@ -164,6 +165,36 @@ describe('borrow routes', () => {
         body: JSON.stringify({ nothing: 'here' }),
       })
       expect(res.status).toBe(400)
+    })
+  })
+
+  describe('POST /borrow/position/deposit-collateral', () => {
+    it('forwards max deposits to the borrow service', async () => {
+      vi.mocked(borrowService.depositCollateral).mockResolvedValue({
+        action: 'depositCollateral',
+        blockExplorerUrls: [],
+        marketId: MARKET_ID,
+        receipt: [],
+      })
+
+      const res = await createApp().request(
+        '/borrow/position/deposit-collateral',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', ...authHeaders() },
+          body: JSON.stringify({
+            marketId: MARKET_ID,
+            amount: { max: true },
+          }),
+        },
+      )
+
+      expect(res.status).toBe(200)
+      expect(borrowService.depositCollateral).toHaveBeenCalledWith({
+        idToken: 'fake-id-token',
+        marketId: MARKET_ID,
+        amount: { max: true },
+      })
     })
   })
 

--- a/packages/demo/backend/src/controllers/borrow.ts
+++ b/packages/demo/backend/src/controllers/borrow.ts
@@ -128,7 +128,7 @@ export async function closePosition(c: Context) {
 
 const DepositCollateralParamsBody = z.strictObject({
   marketId: BorrowMarketIdSchema,
-  amount: AmountExactSchema,
+  amount: AmountWithMaxSchema,
 })
 
 const DepositCollateralRequestSchema = z.object({

--- a/packages/demo/backend/src/helpers/schemas.ts
+++ b/packages/demo/backend/src/helpers/schemas.ts
@@ -73,7 +73,7 @@ export const AmountExactSchema = z
 
 /**
  * AmountWithMax: AmountExact plus the `{ max: true }` sentinel for
- * operations targeting an existing balance (close / withdraw / repay).
+ * operations that accept the full available amount.
  */
 export const AmountWithMaxSchema = z
   .union([AmountByHuman, AmountByRaw, AmountByMax])

--- a/packages/demo/frontend/src/demoMagic/morphoDemoMagic.spec.ts
+++ b/packages/demo/frontend/src/demoMagic/morphoDemoMagic.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react'
+import { renderHook, waitFor } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import type { MarketInfo } from '@/components/earn/MarketSelector'
 import type { MarketPosition } from '@/types/market'
@@ -114,5 +114,24 @@ describe('useReconcileMorphoCollateral', () => {
     )
     expect(handleTransaction).not.toHaveBeenCalled()
     expect(setMarketPositions).not.toHaveBeenCalled()
+  })
+
+  it('does not retry failed reconciliation after a rerender', async () => {
+    const setMarketPositions = vi.fn()
+    const handleTransaction = vi.fn().mockRejectedValue(new Error('failed'))
+    const { rerender } = renderHook(
+      ({ marketPositions }) =>
+        useReconcileMorphoCollateral(
+          marketPositions,
+          handleTransaction,
+          setMarketPositions,
+        ),
+      { initialProps: { marketPositions: [lentPosition] } },
+    )
+
+    await waitFor(() => expect(setMarketPositions).toHaveBeenCalledTimes(2))
+    rerender({ marketPositions: [{ ...lentPosition }] })
+
+    expect(handleTransaction).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/demo/frontend/src/demoMagic/morphoDemoMagic.ts
+++ b/packages/demo/frontend/src/demoMagic/morphoDemoMagic.ts
@@ -58,7 +58,6 @@ export function useReconcileMorphoCollateral(
         },
         amount: { max: true },
       }).catch((error) => {
-        reconciledRef.current.delete(key)
         setMarketPositions((prev) =>
           prev.map((p) =>
             sameVault(p, position)


### PR DESCRIPTION
| Problem | Solution |
| --- | --- |
| When a user opens the Borrow tab, the demo automatically pledges their existing collateral. If that automatic deposit fails even once, the app retries it on every re-render, firing an endless stream of failed `deposit-collateral` requests and leaving the user stuck. | Keep the once-per-mount "already attempted" marker set after a failure so a failed reconciliation is not retried on every render. Adds a regression test covering a rejected deposit followed by re-renders. |
| A user cannot auto-pledge their full collateral balance because the backend rejects the "deposit the maximum" payload (`{ max: true }`) before it reaches the lending provider. | Accept the max-amount payload at the deposit route and pass it through to the provider. Adds a test for the authenticated deposit route with a max amount. |
