### PR TITLE
fix: restore Aave repayment balance and health factor

### DIFF
--- a/packages/demo/frontend/src/components/earn/borrow/BorrowAction.spec.tsx
+++ b/packages/demo/frontend/src/components/earn/borrow/BorrowAction.spec.tsx
@@ -51,6 +51,7 @@ beforeEach(() => {
 })
 
 const OPS = 11155420 as SupportedChainId
+const BASE = 84532 as SupportedChainId
 const ETH: Asset = {
   type: 'native',
   address: { [OPS]: '0x4200000000000000000000000000000000000006' },
@@ -151,7 +152,7 @@ function usdcDemoBalance(amount: number): TokenBalance {
     asset: USDC_DEMO,
     totalBalance: amount,
     totalBalanceRaw: raw,
-    chains: { [OPS]: { balance: amount, balanceRaw: raw } },
+    chains: { [BASE]: { balance: amount, balanceRaw: raw } },
   } as unknown as TokenBalance
 }
 
@@ -180,22 +181,16 @@ describe('BorrowAction repay gating on debt-asset balance', () => {
     return buttons[buttons.length - 1]
   }
 
-  it('blocks repay when the USDC balance lives only on the non-borrow chain', () => {
-    const raw = 50_000000n
-    const crossChainOnly = {
-      asset: USDC_DEMO,
-      totalBalance: 50,
-      totalBalanceRaw: raw,
-      chains: { 84532: { balance: 50, balanceRaw: raw } },
-    } as unknown as TokenBalance
+  it('allows Aave repayment from the Base mirror balance', () => {
     renderRepay({
       borrowPositions: [aaveDebtPosition],
-      tokenBalances: [crossChainOnly],
+      tokenBalances: [usdcDemoBalance(50)],
     })
-    expect(
-      screen.getByText(/need USDC to repay this loan/i),
-    ).toBeInTheDocument()
-    expect(repayCta()).toBeDisabled()
+    fireEvent.change(screen.getByPlaceholderText('0'), {
+      target: { value: '2' },
+    })
+    expect(screen.queryByText(/need USDC to repay this loan/i)).toBeNull()
+    expect(repayCta()).not.toBeDisabled()
   })
 
   it('blocks repay with a re-acquire notice when the USDC balance is zero', () => {

--- a/packages/demo/frontend/src/components/earn/borrow/BorrowAction.tsx
+++ b/packages/demo/frontend/src/components/earn/borrow/BorrowAction.tsx
@@ -18,7 +18,7 @@ import {
 } from '@/utils/borrowMath'
 import { lendPositionUsd, positionUsd } from '@/utils/borrowValuation'
 import { assetBalanceAmount } from '@/utils/balanceMatching'
-import { repayGateAsset, ReacquireDebtNotice } from '@/demoMagic'
+import { resolveRepayBalanceSource, ReacquireDebtNotice } from '@/demoMagic'
 import { DEBT_DUST_THRESHOLD } from '@/constants/borrow'
 import { sameMarketId } from '@/utils/marketId'
 import { displaySymbol } from '@/utils/tokenDisplay'
@@ -105,8 +105,10 @@ export function BorrowAction({ selectedLendPosition }: BorrowActionProps) {
 
   const activeAsset = repayAsset ?? activeMarket?.borrowAsset ?? null
 
-  // Gate the repay on the asset the user holds (USDC_DEMO for the mirror market).
-  const repayBalanceAsset = repayGateAsset(activeMarket, activeAsset)
+  // The Aave mirror gates on USDC_DEMO on Base; ordinary markets gate on
+  // their debt asset on the market chain.
+  const { asset: repayBalanceAsset, chainId: repayBalanceChainId } =
+    resolveRepayBalanceSource(activeMarket, activeAsset)
 
   // Cap the repay at min(held balance, outstanding debt); the balance gates the CTA.
   const rawOutstandingDebt = activePosition
@@ -114,11 +116,11 @@ export function BorrowAction({ selectedLendPosition }: BorrowActionProps) {
     : 0
   const outstandingDebt =
     rawOutstandingDebt >= DEBT_DUST_THRESHOLD ? rawOutstandingDebt : 0
-  // Repay uses market-chain spendable balance.
+  // Repay uses the balance on the chain where its gate asset is spendable.
   const debtBalance = assetBalanceAmount(
     tokenBalances,
     repayBalanceAsset,
-    activeMarket?.marketId.chainId,
+    repayBalanceChainId,
   )
   const maxRepayable = Math.min(debtBalance, outstandingDebt)
   const isRepay = mode === 'repay'

--- a/packages/demo/frontend/src/demoMagic/aaveDemoMagic.ts
+++ b/packages/demo/frontend/src/demoMagic/aaveDemoMagic.ts
@@ -23,12 +23,22 @@ export function isMirrorMarket(marketId: BorrowMarketId): boolean {
   return sameMarketId(marketId, AaveETHBorrowUSDCDemo)
 }
 
-/** Returns USDC_DEMO for the mirror market (user holds USDC_DEMO, not the real borrowed USDC); otherwise returns the real borrow asset. */
-export function repayGateAsset(
+/**
+ * Resolve the balance used to gate a repayment.
+ * @description Uses the Base USDC_DEMO mirror for the Aave demo and the
+ * market-chain debt asset for ordinary markets.
+ * @param market - Active borrow market
+ * @param borrowAsset - Debt asset shown by the active position
+ * @returns Asset and chain containing the spendable gate balance
+ */
+export function resolveRepayBalanceSource(
   market: BorrowMarket | null,
   borrowAsset: Asset | null,
-): Asset | null {
-  return market && isMirrorMarket(market.marketId) ? USDC_DEMO : borrowAsset
+) {
+  if (market && isMirrorMarket(market.marketId)) {
+    return { asset: USDC_DEMO, chainId: baseSepolia.id }
+  }
+  return { asset: borrowAsset, chainId: market?.marketId.chainId }
 }
 
 /** Fires the USDC_DEMO mint (borrow) or remove (repay) for in-browser wallets. No-op for non-mirror markets or zero amounts. */

--- a/packages/demo/frontend/src/demoMagic/aaveDemoMagic.ts
+++ b/packages/demo/frontend/src/demoMagic/aaveDemoMagic.ts
@@ -18,6 +18,9 @@ import { sameMarketId } from '@/utils/marketId'
 
 type MirrorWallet = Pick<Wallet, 'address'> & { sendBatch: Wallet['sendBatch'] }
 
+/** The mirrored Aave demo market's USDC_DEMO balance lives on Base Sepolia. */
+const mirrorMarketChainId = baseSepolia.id
+
 /** True only for the one mirrored market; matches full identity to avoid false-positives on future non-mirrored Aave markets. */
 export function isMirrorMarket(marketId: BorrowMarketId): boolean {
   return sameMarketId(marketId, AaveETHBorrowUSDCDemo)
@@ -36,7 +39,7 @@ export function resolveRepayBalanceSource(
   borrowAsset: Asset | null,
 ) {
   if (market && isMirrorMarket(market.marketId)) {
-    return { asset: USDC_DEMO, chainId: baseSepolia.id }
+    return { asset: USDC_DEMO, chainId: mirrorMarketChainId }
   }
   return { asset: borrowAsset, chainId: market?.marketId.chainId }
 }
@@ -66,7 +69,7 @@ async function sendMirrorTx(
   amountWei: bigint,
 ): Promise<void> {
   try {
-    const usdcDemo = getAssetAddress(USDC_DEMO, baseSepolia.id)
+    const usdcDemo = getAssetAddress(USDC_DEMO, mirrorMarketChainId)
     const data =
       action === 'mint'
         ? encodeFunctionData({
@@ -79,7 +82,10 @@ async function sendMirrorTx(
             functionName: 'transfer',
             args: [MIRROR_SINK_ADDRESS, amountWei],
           })
-    await wallet.sendBatch([{ to: usdcDemo, data, value: 0n }], baseSepolia.id)
+    await wallet.sendBatch(
+      [{ to: usdcDemo, data, value: 0n }],
+      mirrorMarketChainId,
+    )
     console.info('[mirror] settled', {
       scope: 'aave-borrow-mirror',
       action,

--- a/packages/demo/frontend/src/hooks/__tests__/useBorrowProjection.spec.ts
+++ b/packages/demo/frontend/src/hooks/__tests__/useBorrowProjection.spec.ts
@@ -46,10 +46,13 @@ describe('useBorrowProjection (stub-priced)', () => {
     expect(result.current.projectedLtv).toBeLessThan(result.current.currentLtv)
   })
 
-  it('falls back to the current LTV when no amount is entered', () => {
+  it('falls back to the current health readings when no amount is entered', () => {
     const { result } = renderHook(() =>
       useBorrowProjection({ ...base, amountNum: 0, amountUsd: 0 }),
     )
     expect(result.current.projectedLtv).toBe(result.current.currentLtv)
+    expect(result.current.projectedHealthFactor).toBeCloseTo(
+      (base.currentCollUsd * base.maxLtv) / base.currentBorrUsd,
+    )
   })
 })

--- a/packages/demo/frontend/src/hooks/useBorrowProjection.ts
+++ b/packages/demo/frontend/src/hooks/useBorrowProjection.ts
@@ -6,7 +6,7 @@
 
 import { useMemo } from 'react'
 import type { Asset, BorrowMarket } from '@eth-optimism/actions-sdk'
-import { computeProjection } from '@/utils/borrowMath'
+import { computeHealthFactor, computeProjection } from '@/utils/borrowMath'
 
 export function useBorrowProjection({
   activeMarket,
@@ -69,7 +69,7 @@ export function useBorrowProjection({
   const projectedHealthFactor =
     localProjection && localProjection.kind === 'projected'
       ? localProjection.healthFactor
-      : Number.POSITIVE_INFINITY
+      : computeHealthFactor(currentCollUsd, maxLtv, currentBorrUsd)
 
   return { currentLtv, projectedLtv, wouldLiquidate, projectedHealthFactor }
 }


### PR DESCRIPTION
| Problem | Solution |
| --- | --- |
| A user who holds USDC still cannot repay their Aave loan. The repay screen reads the balance on the wrong chain (it checks a Base-only demo token while the Aave market lives on OP Sepolia), always sees zero, and tells the user to "Get USDC" by swapping for demo tokens that can never repay the loan, leaving them stuck. | Read the repayment balance from the correct chain for the mirrored Aave demo market, while ordinary repayments keep reading the balance on their own market's chain. |
| A user with an active loan sees an "infinite" health factor whenever the borrow or repay input is zero, because an empty input is mistaken for a debt-free position. | When the input is zero, derive the health factor from the position's current collateral and debt; only show infinity when there is genuinely no debt. |
