### PR TITLE
fix: preserve balances and disable unfunded lend input

### DIFF
--- a/packages/demo/frontend/src/components/earn/Action.spec.tsx
+++ b/packages/demo/frontend/src/components/earn/Action.spec.tsx
@@ -91,6 +91,17 @@ describe('Action', () => {
     expect(screen.getByRole('button', { name: 'Get USDC' })).toBeInTheDocument()
   })
 
+  it('disables the amount input while the Get button shows for a zero balance', () => {
+    render(<Action {...defaultProps} />)
+    expect(screen.getByRole('button', { name: 'Get USDC' })).toBeInTheDocument()
+    expect(screen.getByRole('textbox')).toBeDisabled()
+  })
+
+  it('enables the amount input once a balance is available to lend', () => {
+    render(<Action {...defaultProps} assetBalance="100.00" />)
+    expect(screen.getByRole('textbox')).toBeEnabled()
+  })
+
   it('shows a success toast after the mint resolves', async () => {
     const onMintAsset = vi.fn().mockResolvedValue(undefined)
     render(<Action {...defaultProps} onMintAsset={onMintAsset} />)

--- a/packages/demo/frontend/src/components/earn/Action.tsx
+++ b/packages/demo/frontend/src/components/earn/Action.tsx
@@ -315,7 +315,7 @@ export function Action({
           <AmountInput
             value={effectiveAmount}
             onChange={handleAmountChange}
-            disabled={isLockedWithdrawAmount}
+            disabled={isLockedWithdrawAmount || needsMint}
             displaySymbol={displaySymbol}
           />
 

--- a/packages/demo/frontend/src/hooks/__tests__/useSwap.spec.tsx
+++ b/packages/demo/frontend/src/hooks/__tests__/useSwap.spec.tsx
@@ -1,0 +1,101 @@
+import { createElement, type ReactNode } from 'react'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { TokenBalance } from '@eth-optimism/actions-sdk/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { OP_DEMO, USDC_DEMO } from '@/constants/markets'
+import { useSwap } from '@/hooks/useSwap'
+import { useTokenBalances } from '@/queries/useTokenBalances'
+import { ActivityLogProvider } from '@/providers/ActivityLogProvider'
+import type { EarnOperations } from '@/hooks/useLendProvider'
+
+const CHAIN_ID = 84532
+const tokenBalances: TokenBalance[] = [
+  {
+    asset: USDC_DEMO,
+    totalBalance: 10,
+    totalBalanceRaw: 10_000_000n,
+    chains: {
+      [CHAIN_ID]: { balance: 10, balanceRaw: 10_000_000n },
+    },
+  },
+  {
+    asset: OP_DEMO,
+    totalBalance: 20,
+    totalBalanceRaw: 20_000_000_000_000_000_000n,
+    chains: {
+      [CHAIN_ID]: {
+        balance: 20,
+        balanceRaw: 20_000_000_000_000_000_000n,
+      },
+    },
+  },
+]
+
+function createOperations(
+  getTokenBalances: EarnOperations['getTokenBalances'],
+): EarnOperations {
+  return {
+    getTokenBalances,
+    getMarkets: async () => [],
+    getPosition: async () => {
+      throw new Error('Not used by this test')
+    },
+    getPositions: async () => [],
+    mintAsset: async () => undefined,
+    openPosition: async () => {
+      throw new Error('Not used by this test')
+    },
+    closePosition: async () => {
+      throw new Error('Not used by this test')
+    },
+    executeSwap: async () => ({}),
+    getConfiguredAssets: async () => [USDC_DEMO, OP_DEMO],
+    getSwapMarkets: async () => [],
+    getSwapQuote: async () => null,
+  }
+}
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      createElement(ActivityLogProvider, null, children),
+    )
+  }
+}
+
+describe('useSwap', () => {
+  it('preserves shared balances when they are invalidated', async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    const getTokenBalances = vi.fn(async () => tokenBalances)
+    const operations = createOperations(getTokenBalances)
+
+    const { result } = renderHook(
+      () => {
+        const balanceQuery = useTokenBalances({
+          getTokenBalances,
+          isReady: () => true,
+        })
+        const swap = useSwap({ operations, activeTab: 'swap' })
+        return { balanceQuery, swap }
+      },
+      { wrapper: createWrapper(queryClient) },
+    )
+
+    await waitFor(() => expect(result.current.swap.swapAssets).toHaveLength(2))
+    getTokenBalances.mockClear()
+
+    await act(async () => {
+      await queryClient.invalidateQueries({ queryKey: ['tokenBalances'] })
+    })
+
+    expect(getTokenBalances).toHaveBeenCalledOnce()
+    expect(queryClient.getQueryData(['tokenBalances'])).toEqual(tokenBalances)
+    expect(result.current.swap.swapAssets).toHaveLength(2)
+  })
+})

--- a/packages/demo/frontend/src/hooks/useSwap.ts
+++ b/packages/demo/frontend/src/hooks/useSwap.ts
@@ -25,12 +25,11 @@ export function useSwap({ operations, activeTab }: UseSwapParams) {
   const queryClient = useQueryClient()
   const { logActivity } = useActivityLogger()
 
-  // Read-only subscriber to tokenBalances cache (managed by lend path's useTokenBalances).
-  // enabled:false means this never triggers fetches — it only receives cache updates.
-  // queryFn provided to suppress React Query warning (never called when disabled).
+  // This disabled observer only reads the shared cache during normal rendering.
+  // Invalidations can still select its queryFn, so it must use the real fetcher.
   const { data: walletTokenBalances } = useQuery<TokenBalance[]>({
     queryKey: ['tokenBalances'],
-    queryFn: () => Promise.resolve([]),
+    queryFn: operations.getTokenBalances,
     enabled: false,
   })
   const isLoadingBalances = !walletTokenBalances


### PR DESCRIPTION
| Problem | Solution |
| --- | --- |
| After borrowing or repaying, a user's token balances briefly drop to zero across the whole app and the Swap screen becomes unusable. A background balance refresh can run an empty placeholder data fetcher, overwriting the real balances with nothing. | Point that placeholder at the real balance fetcher so a refresh always returns real data, and keep the Swap screen a passive reader of the shared balances. Adds a regression test that invalidates balances and confirms they survive. |
| On the Lend screen, when a user has a zero balance the amount field stays editable even though the only available action is "Get ETH" / "Get USDC" to acquire funds first. | Grey out and disable the amount field whenever the "Get" button is showing, so it only becomes editable once the user has a balance to lend. |
