### PR TITLE
Bind demo auth credentials and parse Bearer case-insensitively

### DIFF
--- a/docs/brainstorms/demo-auth-credential-binding-requirements.md
+++ b/docs/brainstorms/demo-auth-credential-binding-requirements.md
@@ -1,0 +1,71 @@
+---
+date: 2026-07-29
+topic: demo-auth-credential-binding
+---
+
+# Demo Backend Auth: Credential Binding and Scheme Parsing
+
+## Summary
+
+Two hardening changes at the demo backend's auth boundary: accept the `Bearer` scheme case-insensitively, and reject any request whose identity token resolves to a different user than the access token was issued for. Both are enforced in one place so every authenticated route is covered.
+
+## Problem Frame
+
+An audit of `ecosystem-private` PR 530 (an unauthenticated cross-tenant auth bypass in the Superchain Dev Console API) checked whether the Actions demo shares the same defects. It does not: the demo has no session cache to poison, no session cookie to ride, matches CORS origins exactly rather than by substring, and never sends credentialed CORS. The two real defects from that PR do not reach this codebase.
+
+The audit did surface two smaller issues in `packages/demo/backend/src/middleware/auth.ts`.
+
+The first is the same conformance nit PR 530 fixed. The middleware matches the auth scheme with a case-sensitive prefix check, so a client sending a lowercase scheme is rejected even though RFC 9110 defines the scheme as case-insensitive. It fails closed, so it is a correctness and interoperability problem rather than a security one.
+
+The second is structural. Every authenticated request carries two separate credentials: an access token, and an identity token that determines which wallet the request operates on. Both are cryptographically verified, the access token at the boundary and the identity token during wallet resolution, so neither is forgeable. But nothing checks that they describe the same user. Anyone holding their own valid access token plus some other user's identity token would operate on that other user's wallet. Both are bearer secrets held in the victim's browser, so obtaining the identity token is roughly as hard as obtaining the access token, which is why this is defense in depth rather than a live bypass. The cost of the gap is that the demo's authorization story depends on an unstated coupling between two credentials that the code never enforces.
+
+## Requirements
+
+**Auth scheme parsing**
+- R1. The `Authorization` header's scheme is matched case-insensitively, so a lowercase scheme is accepted exactly like a capitalized one.
+- R2. Token extraction strips only the leading scheme and its separating whitespace, not an occurrence of the scheme's characters elsewhere in the header value.
+- R3. A request with a missing `Authorization` header, a different scheme, or an empty token is still rejected as unauthenticated.
+
+**Credential binding**
+- R4. The identity token is verified at the auth boundary, and the user it resolves to is compared against the user the access token was issued to.
+- R5. When the two identities differ, the request is rejected as unauthenticated before any route handler runs.
+- R6. When the identity token cannot be verified at all, the request is rejected as unauthenticated at the same boundary rather than surfacing later during wallet resolution.
+- R7. The rejection response discloses neither the expected nor the observed identity.
+
+**Coverage and blast radius**
+- R8. Every route already behind the auth boundary inherits the binding check with no per-route change. The wallet service and all controller call sites keep their current signatures.
+
+**Tests**
+- R9. Each defect ships a regression test that fails against the current code and passes after the fix.
+
+## Acceptance Examples
+
+- AE1. **Covers R1, R2.** Given a valid access token and identity token for the same user, sent with a lowercase scheme, when the request hits an authenticated route, it is authenticated normally instead of rejected.
+- AE2. **Covers R4, R5, R7.** Given a valid access token issued to user A paired with a valid identity token for user B, when the request hits an authenticated route, it is rejected as unauthenticated, no wallet is resolved, and the response names neither user.
+- AE3. **Covers R6.** Given a valid access token and an identity token that fails verification, when the request hits an authenticated route, it is rejected as unauthenticated at the boundary.
+- AE4. **Covers R4, R8.** Given a valid access token and identity token for the same user, when the request hits an authenticated route, it proceeds exactly as it does today.
+
+## Success Criteria
+
+- A caller holding a valid access token of their own cannot operate on another user's wallet by supplying that user's identity token.
+- Clients sending a lowercase auth scheme stop receiving a spurious rejection.
+- Both regression tests fail on the current code and pass after the change, the existing route specs still pass, and `pnpm typecheck && pnpm lint && pnpm test` is clean.
+
+## Scope Boundaries
+
+- No CORS work. The demo matches origins exactly and sends no credentialed CORS, so PR 530's second defect and its origin length cap have nothing to fix here.
+- The dual-token protocol stays. Collapsing the two credentials into one was considered and rejected: it would add a Privy API call per request and require a frontend change.
+- No change to the wallet service or controller signatures. Threading a verified user object through the auth context was considered and rejected as too wide for the finding.
+- The unauthenticated faucet route's proxy-blind rate-limit key and the unused Privy cookie-key export are both real, both noted in the audit, and both out of scope here.
+
+## Key Decisions
+
+- Enforce at the auth middleware rather than inside wallet resolution: `AGENTS.md` calls for validating at boundaries rather than at every internal hop, and one boundary check covers every authenticated route without touching a single call site.
+- Accept verifying the identity token twice per request, once at the boundary and once during wallet resolution: both are local verifications against a cached JWKS with no network call, which is a smaller cost than changing the wallet service signature and its eleven call sites.
+- Leave the identity token in the auth context as-is, so no controller and no service changes.
+
+## Dependencies / Assumptions
+
+- Access-token verification returns the authoritative user id for that token, and identity-token resolution verifies the token against the app JWKS before yielding a user with a stable id. Both confirmed against the installed Privy Node SDK (`@privy-io/node` 0.3.0), where the users-by-identity-token call is a thin wrapper over identity-token verification rather than a REST fetch.
+- Identity-token verification reuses a cached JWKS, so the added boundary check issues no network request. Worth confirming during planning if request latency is a concern.
+- The existing route specs mock only access-token verification, so they will need identity resolution mocked once the boundary starts using it.

--- a/docs/plans/2026-07-29-001-fix-demo-auth-credential-binding-plan.md
+++ b/docs/plans/2026-07-29-001-fix-demo-auth-credential-binding-plan.md
@@ -1,7 +1,7 @@
 ---
 date: 2026-07-29
 type: fix
-status: active
+status: completed
 origin: docs/brainstorms/demo-auth-credential-binding-requirements.md
 ---
 
@@ -21,6 +21,8 @@ Verified against the installed `@privy-io/node` 0.3.0 rather than assumed:
 
 - Access-token verification derives its user id as `throwIfNotString(verifiedToken.payload.sub)`. Identity-token parsing derives its user id as `payload.sub`. **Both are the `sub` claim of their respective Privy JWT, so they are the same Privy DID and a direct string comparison is the correct binding check.** This was the main correctness risk in the change and it is resolved.
 - The users-by-identity-token call is a thin wrapper over identity-token verification (signature checked against the app JWKS), not a REST fetch. The app JWKS is a `jose` remote JWKS, which caches. **The boundary check therefore adds no network request per call**, resolving the latency question the origin doc deferred to planning.
+
+  Corrected during code review: the caching half of that claim was wrong. `getPrivyClient()` returns a new `PrivyClient` on every call, so the JWKS cache is per-instance and does not survive a request, and every authenticated request already paid a JWKS fetch before this change. The incremental claim still holds, because both verifications share one resolved client and `jose` dedupes concurrent key lookups into a single fetch. Tracked as a follow-up.
 - Access-token verification's response type declares `user_id` as always present, so a missing one indicates something is wrong rather than a supported state.
 
 Blast radius on tests, which is the only non-obvious part of this change:

--- a/docs/plans/2026-07-29-001-fix-demo-auth-credential-binding-plan.md
+++ b/docs/plans/2026-07-29-001-fix-demo-auth-credential-binding-plan.md
@@ -1,0 +1,151 @@
+---
+date: 2026-07-29
+type: fix
+status: active
+origin: docs/brainstorms/demo-auth-credential-binding-requirements.md
+---
+
+# fix: Bind demo auth credentials and parse Bearer case-insensitively
+
+## Summary
+
+Harden the demo backend's auth boundary in `packages/demo/backend/src/middleware/auth.ts`: match the `Authorization` scheme case-insensitively, and reject any request whose identity token resolves to a different Privy user than the access token was issued to. No production file outside the middleware changes.
+
+## Problem Frame
+
+An audit of `ecosystem-private` PR 530 confirmed the demo does not share that PR's two real defects (no session cache to poison, no session cookie, exact-match CORS, no credentialed CORS). It did surface two smaller issues in the auth middleware: a case-sensitive scheme check that rejects RFC 9110-conformant lowercase schemes, and two separately-verified credentials whose subjects are never compared against each other. See origin: `docs/brainstorms/demo-auth-credential-binding-requirements.md`.
+
+## Research Findings
+
+Verified against the installed `@privy-io/node` 0.3.0 rather than assumed:
+
+- Access-token verification derives its user id as `throwIfNotString(verifiedToken.payload.sub)`. Identity-token parsing derives its user id as `payload.sub`. **Both are the `sub` claim of their respective Privy JWT, so they are the same Privy DID and a direct string comparison is the correct binding check.** This was the main correctness risk in the change and it is resolved.
+- The users-by-identity-token call is a thin wrapper over identity-token verification (signature checked against the app JWKS), not a REST fetch. The app JWKS is a `jose` remote JWKS, which caches. **The boundary check therefore adds no network request per call**, resolving the latency question the origin doc deferred to planning.
+- Access-token verification's response type declares `user_id` as always present, so a missing one indicates something is wrong rather than a supported state.
+
+Blast radius on tests, which is the only non-obvious part of this change:
+
+- Four route specs send auth headers: `swap.routes.spec.ts`, `lend.routes.spec.ts`, `wallet.routes.spec.ts`, `borrow.routes.spec.ts`.
+- `wallet` and `borrow` use the shared `mockVerifiedUser` helper in `packages/demo/backend/src/controllers/routeTestUtils.ts`. `swap` and `lend` each carry their own inline Privy client mock that resolves access-token verification to `undefined`.
+- **No existing mock stubs the users resource.** The moment the middleware resolves the identity token, every one of these specs would fail on a missing method. Test infrastructure has to be extended before the production check lands, which drives the unit ordering below.
+
+## Requirements Traceability
+
+| Unit | Requirements | Acceptance Examples |
+|---|---|---|
+| U1 | R1, R2, R3 | AE1 |
+| U2 | R8, R9 (enabling) | AE4 |
+| U3 | R4, R5, R6, R7, R9 | AE2, AE3, AE4 |
+
+## Implementation Units
+
+### U1. Case-insensitive scheme parsing
+
+**Goal:** Accept a lowercase auth scheme, and strip only the leading scheme rather than an occurrence of the scheme's characters anywhere in the header value.
+
+**Requirements:** R1, R2, R3. Covers AE1.
+
+**Dependencies:** none.
+
+**Files:**
+- `packages/demo/backend/src/middleware/auth.ts`
+- `packages/demo/backend/src/middleware/auth.spec.ts` (new)
+
+**Approach:** Replace the case-sensitive prefix check plus substring removal with a single case-insensitive anchored match that captures the token. Reject when the header is absent, uses a different scheme, or yields an empty token. This collapses the two current steps (the prefix guard and the separate parse helper) into one decision, so the guard and the extraction can no longer disagree about what counts as a valid header.
+
+**Patterns to follow:** existing guard-clause style in the middleware, early `return` of a JSON error rather than throwing.
+
+**Test scenarios:**
+- Covers AE1. A lowercase scheme with an otherwise valid token authenticates instead of returning 401.
+- A capitalized scheme continues to authenticate, proving no regression.
+- Mixed-case scheme authenticates.
+- A missing `Authorization` header returns 401.
+- A non-Bearer scheme returns 401.
+- A scheme with no token, and a scheme with only whitespace after it, both return 401.
+- A token whose own characters contain the scheme name is extracted intact, proving only the leading scheme is stripped.
+
+**Verification:** the new spec passes, and every existing route spec that sends a capitalized scheme still passes.
+
+### U2. Extend test helper to stub identity resolution
+
+**Goal:** Make the shared auth test helper cover identity-token resolution, and move the two specs carrying inline Privy mocks onto it, so U3's production change does not break existing coverage.
+
+**Requirements:** R8, and enables R9. Covers AE4.
+
+**Dependencies:** none. Must land before U3.
+
+**Files:**
+- `packages/demo/backend/src/controllers/routeTestUtils.ts`
+- `packages/demo/backend/src/controllers/swap.routes.spec.ts`
+- `packages/demo/backend/src/controllers/lend.routes.spec.ts`
+
+**Approach:** Extend the shared helper so a mocked verified user also stubs the users resource, returning a user whose id matches the access token's user id by default. Give the helper a way to express a deliberate mismatch, since U3 needs to drive that case. Then delete the inline Privy client mocks in the swap and lend specs in favor of the shared helper, which is what the wallet and borrow specs already do.
+
+This unit is pure test infrastructure: it changes no production file and every spec passes before and after, which keeps the commit independently green.
+
+**Patterns to follow:** `mockVerifiedUser` in `packages/demo/backend/src/controllers/routeTestUtils.ts`, and its existing call sites in the wallet and borrow route specs. Per AGENTS.md "reuse before invention", extend the shared helper rather than adding a parallel one.
+
+**Test scenarios:** `Test expectation: none -- test infrastructure only.` The existing route specs are the coverage: all four auth-sending specs must stay green with no assertion changes.
+
+**Verification:** the full backend suite passes with no production file modified in this unit.
+
+### U3. Bind identity token to access token at the boundary
+
+**Goal:** Reject any request where the identity token's subject differs from the access token's subject, or where the identity token cannot be verified at all.
+
+**Requirements:** R4, R5, R6, R7, R9. Covers AE2, AE3, AE4.
+
+**Dependencies:** U2.
+
+**Files:**
+- `packages/demo/backend/src/middleware/auth.ts`
+- `packages/demo/backend/src/middleware/auth.spec.ts`
+
+**Approach:** After verifying the access token, resolve the identity token through the same Privy client and compare the resolved user's id against the access token's user id. On mismatch, reject as unauthenticated before calling the next handler. Resolve the identity token inside the existing failure-handling path so an unverifiable identity token produces the same unauthenticated response as an invalid access token, satisfying R6 without a second error branch.
+
+Fail closed when the access token verification yields no user id. The SDK types it as always present, so absence is a fault rather than a supported state, and treating it as authenticated would leave exactly the hole this unit closes.
+
+Keep the auth context shape unchanged so the wallet service and all controller call sites are untouched (R8). The identity token is consequently verified twice per request, once here and once during wallet resolution; both are local JWKS checks with no network call, which is the accepted cost recorded in the origin's key decisions.
+
+The response body must not name either identity (R7). Server-side logging of the mismatch is fine and useful, but must not include either token, per AGENTS.md "never log or persist secrets".
+
+**Test scenarios:**
+- Covers AE2. A valid access token for user A with a valid identity token for user B returns 401, the next handler never runs, and the response body names neither user.
+- Covers AE4. A valid access token and identity token for the same user passes through and the next handler runs.
+- Covers AE3. An identity token that fails verification returns 401.
+- An access token that fails verification still returns 401, proving no regression.
+- A verified access token carrying no user id returns 401 rather than passing through.
+- A missing identity-token header returns 401, preserving current behavior.
+- The response body for a mismatch is byte-identical to the one for an invalid token, so the failure mode is not distinguishable by an attacker.
+- The rate-limit key derived for a successful request is unchanged from current behavior.
+
+**Verification:** the mismatch and scheme tests both fail when the production change is reverted; the full backend suite passes with it applied.
+
+## Key Technical Decisions
+
+- **Bind at the middleware, not in wallet resolution.** AGENTS.md calls for validating at boundaries rather than at every internal hop, and one check covers every authenticated route without touching a call site (see origin key decisions).
+- **Compare the two `sub` claims directly.** Verified in research that both sides derive their id from the JWT `sub`, so no normalization or prefix handling is needed.
+- **Fail closed on a missing access-token user id.** The SDK guarantees the field; absence is a fault. Failing open would preserve the gap.
+- **Accept double verification of the identity token.** Both are local and cached, so the cost is negligible against changing the wallet service signature and its call sites.
+- **Extend the shared test helper rather than patching four specs inline.** Also removes an existing inconsistency where two specs hand-rolled what a shared helper already provided.
+
+## Scope Boundaries
+
+- No CORS work. The demo matches origins exactly and sends no credentialed CORS, so PR 530's second defect has nothing to fix here.
+- The dual-token protocol stays; no frontend change.
+- No change to `packages/demo/backend/src/services/wallet.ts` or any controller signature.
+
+### Deferred to Follow-Up Work
+
+- The unauthenticated faucet route's rate-limit key uses the socket address, which collapses to one global bucket behind a proxy.
+- The unused Privy cookie-key export in the middleware is dead code.
+
+## Deferred to Implementation
+
+- Exact naming of the new helper parameter and the middleware's comparison helper.
+- Whether the mismatch rejection reads more clearly as an early return or as a thrown error caught by the existing handler. Both satisfy R5 and R7; pick whichever keeps the function within the repo's 20-line logic guidance.
+
+## Risks
+
+- **Every authenticated route now depends on identity-token resolution succeeding at the boundary.** If resolution were to make a network call, this would add latency to every request. Research confirmed it does not, but this is the assumption to re-check if the Privy SDK major version changes.
+- **A binding check that compared mismatched id formats would reject all traffic.** Mitigated by confirming both sides read the JWT `sub`, and by the AE4 pass-through test which would fail loudly if the formats ever diverge.

--- a/packages/demo/backend/README.md
+++ b/packages/demo/backend/README.md
@@ -45,6 +45,25 @@ A backend service for interacting with the Actions SDK.
 
 Both require `BASE_SEPOLIA_RPC_URL` and `DEMO_MARKET_SETUP_PRIVATE_KEY` in `.env`.
 
+## Authentication
+
+Authenticated routes require **two** Privy credentials on every request:
+
+| Header           | Value                         | Purpose                       |
+| ---------------- | ----------------------------- | ----------------------------- |
+| `Authorization`  | `Bearer <privy access token>` | Authenticates the caller      |
+| `privy-id-token` | `<privy identity token>`      | Resolves the wallet to act on |
+
+Both are verified, and both must have been issued to the same Privy user. A pair
+belonging to two different users is rejected with `401`, because the identity
+token is what selects the wallet downstream.
+
+Refresh the two together. They come from one login session, so refreshing only
+the access token after a `401` leaves a stale identity token in place and every
+retry keeps failing. All authentication failures return the same
+`401 {"error": "Invalid or expired token"}` regardless of cause, so the body
+cannot be used to tell an expired token from a mismatched pair.
+
 ## API Endpoints
 
 | Method | Endpoint            | Description         |

--- a/packages/demo/backend/src/controllers/lend.routes.spec.ts
+++ b/packages/demo/backend/src/controllers/lend.routes.spec.ts
@@ -36,6 +36,23 @@ beforeEach(async () => {
   await mockVerifiedUser('user-a')
 })
 
+describe('lend routes credential binding', () => {
+  it('rejects a cross-user credential pair before reaching the service', async () => {
+    // Proves the binding through the real createApp() stack, not just the
+    // middleware in isolation, so the fix cannot be silently unwired.
+    await mockVerifiedUser('user-a', 'user-b')
+
+    const res = await createApp().request('/lend/position/open', {
+      method: 'POST',
+      headers: { ...authHeaders(), 'Content-Type': 'application/json' },
+      body: JSON.stringify({ marketId: MARKET, amount: 1 }),
+    })
+
+    expect(res.status).toBe(401)
+    expect(lendService.openPosition).not.toBeCalled()
+  })
+})
+
 describe('lend routes error mapping via global onError', () => {
   it('maps a thrown SDK error from GET /lend/markets to its status', async () => {
     vi.mocked(lendService.getMarkets).mockRejectedValue(

--- a/packages/demo/backend/src/controllers/lend.routes.spec.ts
+++ b/packages/demo/backend/src/controllers/lend.routes.spec.ts
@@ -5,6 +5,8 @@ import { createApp } from '@/app.js'
 import { WalletNotFoundError } from '@/helpers/errors.js'
 import * as lendService from '@/services/lend.js'
 
+import { authHeaders, mockVerifiedUser } from './routeTestUtils.js'
+
 vi.mock('@/services/lend.js', () => ({
   getMarkets: vi.fn(),
   getMarket: vi.fn(),
@@ -29,21 +31,9 @@ const MARKET = {
   chainId: 130,
 }
 
-function authHeaders() {
-  return {
-    Authorization: 'Bearer fake-access-token',
-    'privy-id-token': 'fake-id-token',
-  }
-}
-
 beforeEach(async () => {
   vi.resetAllMocks()
-  const { getPrivyClient } = await import('@/config/actions.js')
-  vi.mocked(getPrivyClient).mockReturnValue({
-    utils: () => ({
-      auth: () => ({ verifyAuthToken: vi.fn().mockResolvedValue(undefined) }),
-    }),
-  } as never)
+  await mockVerifiedUser('user-a')
 })
 
 describe('lend routes error mapping via global onError', () => {

--- a/packages/demo/backend/src/controllers/routeTestUtils.ts
+++ b/packages/demo/backend/src/controllers/routeTestUtils.ts
@@ -7,12 +7,25 @@ export function authHeaders(): Record<string, string> {
   }
 }
 
-export async function mockVerifiedUser(userId: string): Promise<void> {
+/**
+ * Stubs Privy so both credentials the auth middleware checks resolve.
+ * @description The access token and the identity token resolve to the same
+ * user unless `identityUserId` is passed, which is how a test expresses a
+ * deliberate cross-user pairing.
+ * @param userId - Privy user the access token was issued to.
+ * @param identityUserId - Privy user the identity token resolves to, defaulting to `userId`.
+ * @returns void
+ */
+export async function mockVerifiedUser(
+  userId: string,
+  identityUserId: string = userId,
+): Promise<void> {
   const { getPrivyClient } = await import('@/config/actions.js')
   vi.mocked(getPrivyClient).mockReturnValue({
     utils: () => ({
       auth: () => ({
         verifyAuthToken: vi.fn().mockResolvedValue({ user_id: userId }),
+        verifyIdentityToken: vi.fn().mockResolvedValue({ id: identityUserId }),
       }),
     }),
   } as never)

--- a/packages/demo/backend/src/controllers/routeTestUtils.ts
+++ b/packages/demo/backend/src/controllers/routeTestUtils.ts
@@ -1,5 +1,7 @@
 import { vi } from 'vitest'
 
+import { buildPrivyClientMock } from '@/utils/testUtils.js'
+
 export function authHeaders(): Record<string, string> {
   return {
     Authorization: 'Bearer fake-access-token',
@@ -21,12 +23,9 @@ export async function mockVerifiedUser(
   identityUserId: string = userId,
 ): Promise<void> {
   const { getPrivyClient } = await import('@/config/actions.js')
-  vi.mocked(getPrivyClient).mockReturnValue({
-    utils: () => ({
-      auth: () => ({
-        verifyAuthToken: vi.fn().mockResolvedValue({ user_id: userId }),
-        verifyIdentityToken: vi.fn().mockResolvedValue({ id: identityUserId }),
-      }),
-    }),
-  } as never)
+  const { client } = buildPrivyClientMock({
+    accessSubject: userId,
+    identitySubject: identityUserId,
+  })
+  vi.mocked(getPrivyClient).mockReturnValue(client)
 }

--- a/packages/demo/backend/src/controllers/swap.routes.spec.ts
+++ b/packages/demo/backend/src/controllers/swap.routes.spec.ts
@@ -10,6 +10,8 @@ import { createApp } from '@/app.js'
 import { WalletNotFoundError } from '@/helpers/errors.js'
 import * as swapService from '@/services/swap.js'
 
+import { authHeaders, mockVerifiedUser } from './routeTestUtils.js'
+
 vi.mock('@/services/swap.js', () => ({
   getMarkets: vi.fn(),
   getQuote: vi.fn(),
@@ -32,13 +34,6 @@ const TOKEN_IN = '0x1111111111111111111111111111111111111111'
 const TOKEN_OUT = '0x2222222222222222222222222222222222222222'
 const CHAIN_ID = 84532
 
-function authHeaders() {
-  return {
-    Authorization: 'Bearer fake-access-token',
-    'privy-id-token': 'fake-id-token',
-  }
-}
-
 function executeBody() {
   return JSON.stringify({
     amountIn: 100,
@@ -50,12 +45,7 @@ function executeBody() {
 
 beforeEach(async () => {
   vi.resetAllMocks()
-  const { getPrivyClient } = await import('@/config/actions.js')
-  vi.mocked(getPrivyClient).mockReturnValue({
-    utils: () => ({
-      auth: () => ({ verifyAuthToken: vi.fn().mockResolvedValue(undefined) }),
-    }),
-  } as never)
+  await mockVerifiedUser('user-a')
 })
 
 describe('swap routes error mapping via global onError', () => {

--- a/packages/demo/backend/src/middleware/auth.spec.ts
+++ b/packages/demo/backend/src/middleware/auth.spec.ts
@@ -1,0 +1,155 @@
+import { Hono } from 'hono'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { type AuthContext, authMiddleware } from '@/middleware/auth.js'
+
+vi.mock('@/config/actions.js', () => ({
+  getPrivyClient: vi.fn(),
+}))
+
+const ACCESS_TOKEN = 'access-token'
+const ID_TOKEN = 'id-token'
+const USER = 'did:privy:user-a'
+
+/**
+ * Stubs the Privy client the middleware reaches for.
+ * @description Both tokens resolve to `subject` unless `identitySubject` is
+ * given, which is how a deliberate cross-user pairing is expressed.
+ * @param overrides - Subject returned by each token, or a rejection to force a verification failure.
+ * @returns void
+ */
+async function mockPrivy(overrides: {
+  subject?: unknown
+  identitySubject?: string
+  identityRejects?: boolean
+  accessRejects?: boolean
+}) {
+  const { getPrivyClient } = await import('@/config/actions.js')
+  const verifyAuthToken = overrides.accessRejects
+    ? vi.fn().mockRejectedValue(new Error('invalid access token'))
+    : vi.fn().mockResolvedValue({ user_id: overrides.subject })
+  const verifyIdentityToken = overrides.identityRejects
+    ? vi.fn().mockRejectedValue(new Error('invalid identity token'))
+    : vi.fn().mockResolvedValue({
+        id: overrides.identitySubject ?? overrides.subject,
+      })
+
+  vi.mocked(getPrivyClient).mockReturnValue({
+    utils: () => ({ auth: () => ({ verifyAuthToken, verifyIdentityToken }) }),
+  } as never)
+
+  return { verifyAuthToken, verifyIdentityToken }
+}
+
+/**
+ * Drives the middleware over a minimal app so the assertions cover the
+ * middleware contract rather than a whole route stack.
+ * @param headers - Request headers to send.
+ * @returns The response, plus whether the downstream handler ran.
+ */
+async function request(headers: Record<string, string>) {
+  let handlerRan = false
+  const app = new Hono<{ Variables: { auth: AuthContext } }>()
+  app.use('*', authMiddleware)
+  app.get('/protected', (c) => {
+    handlerRan = true
+    return c.json({ rateLimitKey: c.get('auth').rateLimitKey })
+  })
+
+  const res = await app.request('/protected', { headers })
+  return { res, handlerRan }
+}
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+describe('authMiddleware authorization scheme', () => {
+  let privy: Awaited<ReturnType<typeof mockPrivy>>
+
+  beforeEach(async () => {
+    privy = await mockPrivy({ subject: USER })
+  })
+
+  it('accepts a lowercase scheme', async () => {
+    const { res, handlerRan } = await request({
+      Authorization: `bearer ${ACCESS_TOKEN}`,
+      'privy-id-token': ID_TOKEN,
+    })
+
+    expect(res.status).toBe(200)
+    expect(handlerRan).toBe(true)
+  })
+
+  it('accepts a capitalized scheme', async () => {
+    const { res } = await request({
+      Authorization: `Bearer ${ACCESS_TOKEN}`,
+      'privy-id-token': ID_TOKEN,
+    })
+
+    expect(res.status).toBe(200)
+  })
+
+  it('accepts a mixed-case scheme', async () => {
+    const { res } = await request({
+      Authorization: `BeArEr ${ACCESS_TOKEN}`,
+      'privy-id-token': ID_TOKEN,
+    })
+
+    expect(res.status).toBe(200)
+  })
+
+  it('strips only the leading scheme, not scheme text inside the token', async () => {
+    const { res } = await request({
+      Authorization: 'Bearer bearer-Bearer-token',
+      'privy-id-token': ID_TOKEN,
+    })
+
+    expect(res.status).toBe(200)
+    expect(privy.verifyAuthToken).toBeCalledWith('bearer-Bearer-token')
+  })
+
+  it('rejects a missing Authorization header', async () => {
+    const { res, handlerRan } = await request({ 'privy-id-token': ID_TOKEN })
+
+    expect(res.status).toBe(401)
+    expect(handlerRan).toBe(false)
+  })
+
+  it('rejects a non-Bearer scheme', async () => {
+    const { res } = await request({
+      Authorization: `Basic ${ACCESS_TOKEN}`,
+      'privy-id-token': ID_TOKEN,
+    })
+
+    expect(res.status).toBe(401)
+  })
+
+  it('rejects a scheme with no token', async () => {
+    const { res } = await request({
+      Authorization: 'Bearer',
+      'privy-id-token': ID_TOKEN,
+    })
+
+    expect(res.status).toBe(401)
+  })
+
+  it('rejects a scheme followed only by whitespace', async () => {
+    const { res } = await request({
+      Authorization: 'Bearer    ',
+      'privy-id-token': ID_TOKEN,
+    })
+
+    expect(res.status).toBe(401)
+  })
+
+  it('rejects a missing identity token header', async () => {
+    const { res, handlerRan } = await request({
+      Authorization: `Bearer ${ACCESS_TOKEN}`,
+    })
+
+    expect(res.status).toBe(401)
+    expect(handlerRan).toBe(false)
+  })
+})

--- a/packages/demo/backend/src/middleware/auth.spec.ts
+++ b/packages/demo/backend/src/middleware/auth.spec.ts
@@ -153,3 +153,97 @@ describe('authMiddleware authorization scheme', () => {
     expect(handlerRan).toBe(false)
   })
 })
+
+describe('authMiddleware credential binding', () => {
+  const headers = {
+    Authorization: `Bearer ${ACCESS_TOKEN}`,
+    'privy-id-token': ID_TOKEN,
+  }
+
+  it('rejects an identity token issued to a different user', async () => {
+    await mockPrivy({ subject: USER, identitySubject: 'did:privy:user-b' })
+
+    const { res, handlerRan } = await request(headers)
+
+    expect(res.status).toBe(401)
+    expect(handlerRan).toBe(false)
+    const body = (await res.json()) as { error: string }
+    expect(body.error).not.toContain('user-a')
+    expect(body.error).not.toContain('user-b')
+  })
+
+  it('does not distinguish a mismatch from an invalid access token', async () => {
+    await mockPrivy({ subject: USER, identitySubject: 'did:privy:user-b' })
+    const mismatch = await request(headers)
+
+    await mockPrivy({ subject: USER, accessRejects: true })
+    const invalid = await request(headers)
+
+    expect(mismatch.res.status).toBe(invalid.res.status)
+    expect(await mismatch.res.text()).toBe(await invalid.res.text())
+  })
+
+  it('accepts an identity token issued to the same user', async () => {
+    await mockPrivy({ subject: USER })
+
+    const { res, handlerRan } = await request(headers)
+
+    expect(res.status).toBe(200)
+    expect(handlerRan).toBe(true)
+  })
+
+  it('rejects an identity token that fails verification', async () => {
+    await mockPrivy({ subject: USER, identityRejects: true })
+
+    const { res, handlerRan } = await request(headers)
+
+    expect(res.status).toBe(401)
+    expect(handlerRan).toBe(false)
+  })
+
+  it('rejects an access token that fails verification', async () => {
+    await mockPrivy({ subject: USER, accessRejects: true })
+
+    const { res, handlerRan } = await request(headers)
+
+    expect(res.status).toBe(401)
+    expect(handlerRan).toBe(false)
+  })
+
+  it('rejects a verified access token carrying no user id', async () => {
+    await mockPrivy({ subject: undefined, identitySubject: 'did:privy:user-b' })
+
+    const { res, handlerRan } = await request(headers)
+
+    expect(res.status).toBe(401)
+    expect(handlerRan).toBe(false)
+  })
+
+  it('rejects when neither token carries a subject', async () => {
+    // A bare equality check would treat two absent subjects as a match, so
+    // this is the case that must fail closed on its own.
+    await mockPrivy({ subject: undefined })
+
+    const { res, handlerRan } = await request(headers)
+
+    expect(res.status).toBe(401)
+    expect(handlerRan).toBe(false)
+  })
+
+  it('keys rate limiting on the verified user', async () => {
+    await mockPrivy({ subject: USER })
+
+    const { res } = await request(headers)
+
+    const body = (await res.json()) as { rateLimitKey: string }
+    expect(body.rateLimitKey).toBe(`user:${USER}`)
+  })
+
+  it('verifies the identity token it was given', async () => {
+    const privy = await mockPrivy({ subject: USER })
+
+    await request(headers)
+
+    expect(privy.verifyIdentityToken).toBeCalledWith(ID_TOKEN)
+  })
+})

--- a/packages/demo/backend/src/middleware/auth.spec.ts
+++ b/packages/demo/backend/src/middleware/auth.spec.ts
@@ -2,6 +2,10 @@ import { Hono } from 'hono'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { type AuthContext, authMiddleware } from '@/middleware/auth.js'
+import {
+  buildPrivyClientMock,
+  type PrivyMockOptions,
+} from '@/utils/testUtils.js'
 
 vi.mock('@/config/actions.js', () => ({
   getPrivyClient: vi.fn(),
@@ -12,31 +16,24 @@ const ID_TOKEN = 'id-token'
 const USER = 'did:privy:user-a'
 
 /**
- * Stubs the Privy client the middleware reaches for.
- * @description Both tokens resolve to `subject` unless `identitySubject` is
- * given, which is how a deliberate cross-user pairing is expressed.
- * @param overrides - Subject returned by each token, or a rejection to force a verification failure.
- * @returns void
+ * Points the middleware at a stubbed Privy client.
+ * @description Defaults the identity subject to the access subject, so a test
+ * only names `identitySubject` when it wants a deliberate cross-user pairing.
+ * @param options - Subjects each token resolves to, or a value to reject with.
+ * @returns Both verification spies, for call assertions.
  */
-async function mockPrivy(overrides: {
-  subject?: unknown
-  identitySubject?: string
-  identityRejects?: boolean
-  accessRejects?: boolean
-}) {
+async function mockPrivy(options: PrivyMockOptions) {
   const { getPrivyClient } = await import('@/config/actions.js')
-  const verifyAuthToken = overrides.accessRejects
-    ? vi.fn().mockRejectedValue(new Error('invalid access token'))
-    : vi.fn().mockResolvedValue({ user_id: overrides.subject })
-  const verifyIdentityToken = overrides.identityRejects
-    ? vi.fn().mockRejectedValue(new Error('invalid identity token'))
-    : vi.fn().mockResolvedValue({
-        id: overrides.identitySubject ?? overrides.subject,
-      })
-
-  vi.mocked(getPrivyClient).mockReturnValue({
-    utils: () => ({ auth: () => ({ verifyAuthToken, verifyIdentityToken }) }),
-  } as never)
+  const { client, verifyAuthToken, verifyIdentityToken } = buildPrivyClientMock(
+    {
+      ...options,
+      identitySubject:
+        'identitySubject' in options
+          ? options.identitySubject
+          : options.accessSubject,
+    },
+  )
+  vi.mocked(getPrivyClient).mockReturnValue(client)
 
   return { verifyAuthToken, verifyIdentityToken }
 }
@@ -45,31 +42,33 @@ async function mockPrivy(overrides: {
  * Drives the middleware over a minimal app so the assertions cover the
  * middleware contract rather than a whole route stack.
  * @param headers - Request headers to send.
- * @returns The response, plus whether the downstream handler ran.
+ * @returns The response, whether the downstream handler ran, and the auth context it saw.
  */
 async function request(headers: Record<string, string>) {
-  let handlerRan = false
+  let seenAuth: AuthContext | undefined
   const app = new Hono<{ Variables: { auth: AuthContext } }>()
   app.use('*', authMiddleware)
   app.get('/protected', (c) => {
-    handlerRan = true
+    seenAuth = c.get('auth')
     return c.json({ rateLimitKey: c.get('auth').rateLimitKey })
   })
 
   const res = await app.request('/protected', { headers })
-  return { res, handlerRan }
+  return { res, handlerRan: seenAuth !== undefined, auth: seenAuth }
 }
+
+let errorLog: ReturnType<typeof vi.spyOn>
 
 beforeEach(() => {
   vi.resetAllMocks()
-  vi.spyOn(console, 'error').mockImplementation(() => {})
+  errorLog = vi.spyOn(console, 'error').mockImplementation(() => {})
 })
 
 describe('authMiddleware authorization scheme', () => {
   let privy: Awaited<ReturnType<typeof mockPrivy>>
 
   beforeEach(async () => {
-    privy = await mockPrivy({ subject: USER })
+    privy = await mockPrivy({ accessSubject: USER })
   })
 
   it('accepts a lowercase scheme', async () => {
@@ -110,6 +109,43 @@ describe('authMiddleware authorization scheme', () => {
     expect(privy.verifyAuthToken).toBeCalledWith('bearer-Bearer-token')
   })
 
+  it('accepts a tab between scheme and token', async () => {
+    // The old case-sensitive prefix check required a literal space, so this
+    // shape is one of the two that actually distinguishes the new parser.
+    const { res } = await request({
+      Authorization: `Bearer\t${ACCESS_TOKEN}`,
+      'privy-id-token': ID_TOKEN,
+    })
+
+    expect(res.status).toBe(200)
+    expect(privy.verifyAuthToken).toBeCalledWith(ACCESS_TOKEN)
+  })
+
+  it('rejects trailing content after the token without calling Privy', async () => {
+    // Pins the capture boundary and the end anchor together: widening the
+    // capture or dropping the anchor would forward a malformed header to Privy.
+    const { res, handlerRan } = await request({
+      Authorization: `Bearer ${ACCESS_TOKEN} extra`,
+      'privy-id-token': ID_TOKEN,
+    })
+
+    expect(res.status).toBe(401)
+    expect(handlerRan).toBe(false)
+    expect(privy.verifyAuthToken).not.toBeCalled()
+  })
+
+  it('rejects a non-breaking space as the delimiter', async () => {
+    // RFC 9110 allows only SP and HTAB. A bare whitespace class also matches U+00A0.
+    const { res, handlerRan } = await request({
+      Authorization: `Bearer\u00a0${ACCESS_TOKEN}`,
+      'privy-id-token': ID_TOKEN,
+    })
+
+    expect(res.status).toBe(401)
+    expect(handlerRan).toBe(false)
+    expect(privy.verifyAuthToken).not.toBeCalled()
+  })
+
   it('rejects a missing Authorization header', async () => {
     const { res, handlerRan } = await request({ 'privy-id-token': ID_TOKEN })
 
@@ -144,13 +180,30 @@ describe('authMiddleware authorization scheme', () => {
     expect(res.status).toBe(401)
   })
 
-  it('rejects a missing identity token header', async () => {
+  it('rejects a missing identity token header before calling Privy', async () => {
     const { res, handlerRan } = await request({
       Authorization: `Bearer ${ACCESS_TOKEN}`,
     })
 
     expect(res.status).toBe(401)
     expect(handlerRan).toBe(false)
+    // Pins the guard ahead of verification. Hoisting the Privy calls above it
+    // would turn unauthenticated traffic into JWKS load.
+    expect(privy.verifyAuthToken).not.toBeCalled()
+    expect(privy.verifyIdentityToken).not.toBeCalled()
+  })
+
+  it('rejects the same token presented in both credential slots', async () => {
+    // Both verifiers share one JWKS and issuer/audience config, so a single
+    // stolen token must never be able to stand in for the pair.
+    const { res, handlerRan } = await request({
+      Authorization: `Bearer ${ID_TOKEN}`,
+      'privy-id-token': ID_TOKEN,
+    })
+
+    expect(res.status).toBe(401)
+    expect(handlerRan).toBe(false)
+    expect(privy.verifyAuthToken).not.toBeCalled()
   })
 })
 
@@ -161,7 +214,10 @@ describe('authMiddleware credential binding', () => {
   }
 
   it('rejects an identity token issued to a different user', async () => {
-    await mockPrivy({ subject: USER, identitySubject: 'did:privy:user-b' })
+    await mockPrivy({
+      accessSubject: USER,
+      identitySubject: 'did:privy:user-b',
+    })
 
     const { res, handlerRan } = await request(headers)
 
@@ -173,10 +229,16 @@ describe('authMiddleware credential binding', () => {
   })
 
   it('does not distinguish a mismatch from an invalid access token', async () => {
-    await mockPrivy({ subject: USER, identitySubject: 'did:privy:user-b' })
+    await mockPrivy({
+      accessSubject: USER,
+      identitySubject: 'did:privy:user-b',
+    })
     const mismatch = await request(headers)
 
-    await mockPrivy({ subject: USER, accessRejects: true })
+    await mockPrivy({
+      accessSubject: USER,
+      accessRejects: new Error('invalid access token'),
+    })
     const invalid = await request(headers)
 
     expect(mismatch.res.status).toBe(invalid.res.status)
@@ -184,16 +246,69 @@ describe('authMiddleware credential binding', () => {
   })
 
   it('accepts an identity token issued to the same user', async () => {
-    await mockPrivy({ subject: USER })
+    await mockPrivy({ accessSubject: USER })
 
-    const { res, handlerRan } = await request(headers)
+    const { res, handlerRan, auth } = await request(headers)
 
     expect(res.status).toBe(200)
     expect(handlerRan).toBe(true)
+    expect(auth?.idToken).toBe(ID_TOKEN)
+  })
+
+  it('rejects a non-string identity subject', async () => {
+    // The SDK assigns the identity subject straight from the JWT claim with no
+    // string guard, unlike the access-token path, so a non-string is reachable.
+    await mockPrivy({ accessSubject: USER, identitySubject: { id: USER } })
+
+    const { res, handlerRan } = await request(headers)
+
+    expect(res.status).toBe(401)
+    expect(handlerRan).toBe(false)
+  })
+
+  it('rejects when both credentials fail verification', async () => {
+    await mockPrivy({
+      accessSubject: USER,
+      accessRejects: new Error('invalid access token'),
+      identityRejects: new Error('invalid identity token'),
+    })
+
+    const { res, handlerRan } = await request(headers)
+
+    expect(res.status).toBe(401)
+    expect(handlerRan).toBe(false)
+  })
+
+  it('rejects when Privy rejects with a non-Error value', async () => {
+    await mockPrivy({ accessSubject: USER, accessRejects: 'boom' })
+
+    const { res, handlerRan } = await request(headers)
+
+    expect(res.status).toBe(401)
+    expect(handlerRan).toBe(false)
+  })
+
+  it('logs neither credential when a mismatch is rejected', async () => {
+    await mockPrivy({
+      accessSubject: USER,
+      identitySubject: 'did:privy:user-b',
+    })
+
+    await request(headers)
+
+    const logged = errorLog.mock.calls
+      .flat()
+      .map((arg) => (arg instanceof Error ? arg.message : String(arg)))
+      .join(' ')
+    expect(logged).not.toContain(ACCESS_TOKEN)
+    expect(logged).not.toContain(ID_TOKEN)
   })
 
   it('rejects an identity token that fails verification', async () => {
-    await mockPrivy({ subject: USER, identityRejects: true })
+    await mockPrivy({
+      accessSubject: USER,
+      identityRejects: new Error('invalid identity token'),
+    })
 
     const { res, handlerRan } = await request(headers)
 
@@ -202,7 +317,10 @@ describe('authMiddleware credential binding', () => {
   })
 
   it('rejects an access token that fails verification', async () => {
-    await mockPrivy({ subject: USER, accessRejects: true })
+    await mockPrivy({
+      accessSubject: USER,
+      accessRejects: new Error('invalid access token'),
+    })
 
     const { res, handlerRan } = await request(headers)
 
@@ -211,7 +329,10 @@ describe('authMiddleware credential binding', () => {
   })
 
   it('rejects a verified access token carrying no user id', async () => {
-    await mockPrivy({ subject: undefined, identitySubject: 'did:privy:user-b' })
+    await mockPrivy({
+      accessSubject: undefined,
+      identitySubject: 'did:privy:user-b',
+    })
 
     const { res, handlerRan } = await request(headers)
 
@@ -222,7 +343,7 @@ describe('authMiddleware credential binding', () => {
   it('rejects when neither token carries a subject', async () => {
     // A bare equality check would treat two absent subjects as a match, so
     // this is the case that must fail closed on its own.
-    await mockPrivy({ subject: undefined })
+    await mockPrivy({ accessSubject: undefined })
 
     const { res, handlerRan } = await request(headers)
 
@@ -231,7 +352,7 @@ describe('authMiddleware credential binding', () => {
   })
 
   it('keys rate limiting on the verified user', async () => {
-    await mockPrivy({ subject: USER })
+    await mockPrivy({ accessSubject: USER })
 
     const { res } = await request(headers)
 
@@ -240,7 +361,7 @@ describe('authMiddleware credential binding', () => {
   })
 
   it('verifies the identity token it was given', async () => {
-    const privy = await mockPrivy({ subject: USER })
+    const privy = await mockPrivy({ accessSubject: USER })
 
     await request(headers)
 

--- a/packages/demo/backend/src/middleware/auth.ts
+++ b/packages/demo/backend/src/middleware/auth.ts
@@ -12,8 +12,10 @@ export interface AuthContext {
  * @description Case-insensitive because RFC 9110 defines the auth scheme as
  * case-insensitive. Capturing in the same pattern that guards the header keeps
  * the guard and the extraction from disagreeing on what a valid header is.
+ * The delimiter is SP and HTAB rather than `\s`, which would also admit vertical
+ * tab, form feed, and non-breaking space that RFC 9110 does not allow.
  */
-const BEARER_SCHEME = /^Bearer\s+(\S+)\s*$/i
+const BEARER_SCHEME = /^Bearer[ \t]+(\S+)[ \t]*$/i
 
 /**
  * Thrown when the identity token resolves to a different user than the access
@@ -29,6 +31,32 @@ class CredentialSubjectMismatchError extends Error {
   }
 }
 
+/**
+ * Reports whether both verified credentials describe the same Privy user.
+ * @description Both arguments are the `sub` claim of their respective Privy JWT,
+ * so a direct comparison is correct. The explicit access-subject check is load
+ * bearing: comparison alone would treat two absent subjects as equal, and the
+ * SDK assigns the identity subject without a string guard, so a non-string can
+ * reach here.
+ * @param accessSubject - Subject of the verified access token.
+ * @param identitySubject - Subject of the verified identity token.
+ * @returns True when both are present and identical.
+ */
+function subjectsMatch(accessSubject: string, identitySubject: string) {
+  return Boolean(accessSubject) && accessSubject === identitySubject
+}
+
+/**
+ * Authenticates a request from its Privy access token and identity token.
+ * @description Requires an `Authorization: Bearer` access token and a
+ * `privy-id-token` identity token, verifies both, and requires that they were
+ * issued to the same Privy user. Binding them matters because the identity token
+ * is what resolves the acting wallet downstream, so an unbound pair would let a
+ * caller act on another user's wallet. Populates the `auth` context on success.
+ * @param c - Hono request context.
+ * @param next - Downstream handler, invoked only when both credentials agree.
+ * @returns A 401 JSON response, or nothing when authentication succeeds.
+ */
 export async function authMiddleware(c: Context, next: Next) {
   const authHeader = c.req.header('Authorization')
   const idToken = c.req.header('privy-id-token')
@@ -42,6 +70,14 @@ export async function authMiddleware(c: Context, next: Next) {
     return c.json({ error: 'Unauthorized' }, 401)
   }
 
+  // One token cannot satisfy both slots. Access-token verification demands a
+  // `sid` claim that identity tokens are not documented to carry, so a replay
+  // would most likely fail anyway, but rejecting it outright keeps a single
+  // stolen credential from ever standing in for the pair.
+  if (idToken === accessToken) {
+    return c.json({ error: 'Unauthorized' }, 401)
+  }
+
   try {
     const privyAuth = getPrivyClient().utils().auth()
     // Both credentials are verified here so the identity that resolves the
@@ -51,10 +87,7 @@ export async function authMiddleware(c: Context, next: Next) {
       privyAuth.verifyIdentityToken(idToken),
     ])
 
-    if (
-      !verifiedAuthToken.user_id ||
-      identityUser.id !== verifiedAuthToken.user_id
-    ) {
+    if (!subjectsMatch(verifiedAuthToken.user_id, identityUser.id)) {
       throw new CredentialSubjectMismatchError()
     }
 

--- a/packages/demo/backend/src/middleware/auth.ts
+++ b/packages/demo/backend/src/middleware/auth.ts
@@ -9,19 +9,26 @@ export interface AuthContext {
   rateLimitKey: string
 }
 
+/**
+ * Matches the `Bearer` scheme and captures the token after it.
+ * @description Case-insensitive because RFC 9110 defines the auth scheme as
+ * case-insensitive. Capturing in the same pattern that guards the header keeps
+ * the guard and the extraction from disagreeing on what a valid header is.
+ */
+const BEARER_SCHEME = /^Bearer\s+(\S+)\s*$/i
+
 export async function authMiddleware(c: Context, next: Next) {
   const authHeader = c.req.header('Authorization')
   const idToken = c.req.header('privy-id-token')
+  const accessToken = authHeader?.match(BEARER_SCHEME)?.[1]
 
-  if (!authHeader?.startsWith('Bearer ')) {
+  if (!accessToken) {
     return c.json({ error: 'Unauthorized' }, 401)
   }
 
   if (!idToken) {
     return c.json({ error: 'Unauthorized' }, 401)
   }
-
-  const accessToken = parseAuthorizationHeader(authHeader)
 
   try {
     const privy = getPrivyClient()
@@ -40,10 +47,6 @@ export async function authMiddleware(c: Context, next: Next) {
   }
 
   await next()
-}
-
-const parseAuthorizationHeader = (value: string) => {
-  return value.replace('Bearer', '').trim()
 }
 
 function verifiedUserRateLimitKey(

--- a/packages/demo/backend/src/middleware/auth.ts
+++ b/packages/demo/backend/src/middleware/auth.ts
@@ -1,5 +1,3 @@
-import { createHash } from 'node:crypto'
-
 import type { Context, Next } from 'hono'
 
 import { getPrivyClient } from '@/config/actions.js'
@@ -17,6 +15,20 @@ export interface AuthContext {
  */
 const BEARER_SCHEME = /^Bearer\s+(\S+)\s*$/i
 
+/**
+ * Thrown when the identity token resolves to a different user than the access
+ * token was issued to.
+ * @description Module-local because it is thrown and handled inside
+ * `authMiddleware`, which routes it through the same rejection an invalid
+ * token gets so a mismatch is not distinguishable to the caller.
+ */
+class CredentialSubjectMismatchError extends Error {
+  override name = 'CredentialSubjectMismatchError' as const
+  constructor() {
+    super('identity token subject does not match access token subject')
+  }
+}
+
 export async function authMiddleware(c: Context, next: Next) {
   const authHeader = c.req.header('Authorization')
   const idToken = c.req.header('privy-id-token')
@@ -31,46 +43,33 @@ export async function authMiddleware(c: Context, next: Next) {
   }
 
   try {
-    const privy = getPrivyClient()
-    const verifiedAuthToken = await privy
-      .utils()
-      .auth()
-      .verifyAuthToken(accessToken)
+    const privyAuth = getPrivyClient().utils().auth()
+    // Both credentials are verified here so the identity that resolves the
+    // wallet downstream is the one this access token was issued to.
+    const [verifiedAuthToken, identityUser] = await Promise.all([
+      privyAuth.verifyAuthToken(accessToken),
+      privyAuth.verifyIdentityToken(idToken),
+    ])
+
+    if (
+      !verifiedAuthToken.user_id ||
+      identityUser.id !== verifiedAuthToken.user_id
+    ) {
+      throw new CredentialSubjectMismatchError()
+    }
+
     const authContext: AuthContext = {
       idToken,
-      rateLimitKey: verifiedUserRateLimitKey(verifiedAuthToken, accessToken),
+      rateLimitKey: `user:${verifiedAuthToken.user_id}`,
     }
     c.set('auth', authContext)
   } catch (err) {
-    console.error('❌ Auth middleware: Token verification failed:', err)
+    // Logged without either token, since both are credentials.
+    console.error('❌ Auth middleware: authentication failed:', err)
     return c.json({ error: 'Invalid or expired token' }, 401)
   }
 
   await next()
-}
-
-function verifiedUserRateLimitKey(
-  verifiedAuthToken: unknown,
-  accessToken: string,
-): string {
-  if (hasVerifiedUserId(verifiedAuthToken)) {
-    return `user:${verifiedAuthToken.user_id}`
-  }
-
-  return `user-token:${hashToken(accessToken)}`
-}
-
-function hasVerifiedUserId(value: unknown): value is { user_id: string } {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    'user_id' in value &&
-    typeof value.user_id === 'string'
-  )
-}
-
-function hashToken(value: string): string {
-  return createHash('sha256').update(value).digest('hex')
 }
 
 export const PRIVY_TOKEN_COOKIE_KEY = 'privy-token'

--- a/packages/demo/backend/src/utils/testUtils.ts
+++ b/packages/demo/backend/src/utils/testUtils.ts
@@ -1,5 +1,44 @@
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts'
+import { vi } from 'vitest'
 
 export const getRandomAddress = () => {
   return privateKeyToAccount(generatePrivateKey()).address
+}
+
+/**
+ * Verification stubs for the two credentials the auth middleware checks.
+ * @description Subjects are `unknown` so tests can express the SDK's own
+ * looseness: the access-token path runs its subject through a string guard, but
+ * identity-token parsing assigns `id: payload.sub` unchecked, so a non-string
+ * identity subject is reachable in production and must be expressible here.
+ */
+export interface PrivyMockOptions {
+  accessSubject?: unknown
+  identitySubject?: unknown
+  accessRejects?: unknown
+  identityRejects?: unknown
+}
+
+/**
+ * Builds a Privy client mock exposing only the auth surface the middleware uses.
+ * @description Shared so the middleware spec and the route specs stub the same
+ * nested `utils().auth()` shape in one place. The `as never` cast is unavoidable:
+ * `PrivyClient` is a class with private fields, so no object literal can
+ * structurally satisfy it.
+ * @param options - Subjects each token resolves to, or a value to reject with.
+ * @returns The mock client plus both verification spies for assertions.
+ */
+export function buildPrivyClientMock(options: PrivyMockOptions = {}) {
+  const verifyAuthToken = options.accessRejects
+    ? vi.fn().mockRejectedValue(options.accessRejects)
+    : vi.fn().mockResolvedValue({ user_id: options.accessSubject })
+  const verifyIdentityToken = options.identityRejects
+    ? vi.fn().mockRejectedValue(options.identityRejects)
+    : vi.fn().mockResolvedValue({ id: options.identitySubject })
+
+  const client = {
+    utils: () => ({ auth: () => ({ verifyAuthToken, verifyIdentityToken }) }),
+  } as never
+
+  return { client, verifyAuthToken, verifyIdentityToken }
 }


### PR DESCRIPTION
## Summary

Hardens the demo backend's auth boundary in `packages/demo/backend/src/middleware/auth.ts`. Two changes, no production file outside the middleware touched.

**1. `Bearer` scheme is now matched case-insensitively.** The header was guarded with `startsWith('Bearer ')` and then parsed with `value.replace('Bearer', '')`, so `bearer <jwt>` produced a spurious 401 even though RFC 9110 defines the auth scheme as case-insensitive. Guard and extraction are now a single anchored pattern, which also means they can no longer disagree about what a valid header is.

**2. The access token and identity token are now bound to the same user.** Every authenticated request carries two credentials: an `Authorization` bearer access token, and a `privy-id-token` identity token that determines which wallet the request operates on. Both were verified, but nothing checked that they described the same user, so a caller holding their own valid access token plus another user's identity token would have operated on that user's wallet. The middleware now verifies both and rejects when the subjects differ.

Both credentials are secrets held in the user's browser, so obtaining the identity token is about as hard as obtaining the access token. This was defense in depth, not a live bypass.

## Why

Came out of auditing a confirmed unauthenticated cross-tenant auth bypass in a sibling repo (truncatable bcrypt session-cache fingerprint chained with unanchored credentialed CORS). This codebase does **not** share those defects:

- No session cache to poison. Every authenticated request verifies the access token; there is no cache-hit branch that skips verification.
- No session cookie to ride. Auth is header-based, so there is no ambient credential for a cross-origin page to replay.
- CORS matches origins by exact equality plus one fully-anchored regex, and never sets `credentials: true`, so the lookalike-suffix origin attack has nothing to work with.

The two items above are what the audit *did* find.

## Implementation notes

- Both subjects are compared directly because both derive from the `sub` claim of their respective Privy JWT (`verifyAuthToken` returns `throwIfNotString(payload.sub)`; identity-token parsing sets `id: payload.sub`). No normalization needed.
- Identity-token verification is a JWKS signature check rather than a REST lookup of the user. It does not add a network round trip to this request path: both verifications run against a single `getPrivyClient().utils().auth()` instance, so they share one JWKS key set, and `jose` dedupes concurrent key lookups into one in-flight fetch. Calling `getPrivyClient()` twice would have doubled the fetch, which is why the client is resolved once.
- Worth flagging separately, since it surprised me: `getPrivyClient()` returns a `new PrivyClient(...)` on every call, so the `jose` JWKS cache is per-instance and is defeated across requests. Every authenticated request already paid a JWKS fetch before this change. That is pre-existing and untouched here, but a module-level client singleton would make the cache actually work. Filed as follow-up below.
- A mismatch and an invalid token return a byte-identical response, so the failure mode is not a probe signal. A test asserts this rather than leaving it to convention.
- The verified `user_id` is now guaranteed present, which made the old `user-token:<sha256>` rate-limit fallback unreachable. It and its helpers were removed rather than left as dead code.

## Hardening added during review

- **A single token can no longer stand in for the pair.** Both verifiers share one JWKS and the same issuer/audience config, and the only thing separating the token types is that access-token verification additionally requires a `sid` claim. Whether Privy identity tokens carry `sid` could not be confirmed from the SDK, so if they do, presenting a victim's identity token in both slots would have authenticated, cutting the required credentials from two to one. Rejecting `idToken === accessToken` closes that outright.
- **The scheme delimiter is now SP and HTAB, not `\s`.** RFC 9110 permits only those two; a bare `\s` class also matches vertical tab, form feed, and non-breaking space.
- **Guard ordering is now pinned by tests.** The missing-identity-token check runs before either Privy call, so unauthenticated traffic cannot be turned into JWKS load.

## Testing

`packages/demo/backend/src/middleware/auth.spec.ts` is new: 26 tests over scheme parsing and credential binding, driven through a minimal Hono app. `lend.routes.spec.ts` adds one cross-user case through the real `createApp()` stack so the fix cannot be silently unwired.

These four mutations were each confirmed to fail the suite:

| Mutation | Caught by |
| --- | --- |
| Widen the capture group to `(.*)` | trailing-content test |
| Drop the end anchor | trailing-content test |
| Remove the `idToken === accessToken` guard | token-reuse test |
| Reduce the subject check to bare equality | both-subjects-absent test |

Removing `authMiddleware` from `/lend/position/open` also fails the route-level test.

Other notable cases: cross-user pairing rejected with no identity in the body; mismatch response byte-identical to the invalid-token response; a non-string identity subject rejected (the SDK assigns that claim without a string guard, unlike the access-token path); the error log asserted to contain neither credential.

Two tests pin behavior that is defense-in-depth rather than a reachable path: an access token resolving with no subject cannot happen through the real SDK, since `throwIfNotString` rejects it first. They document the guard's intent rather than covering a live vector.

`mockVerifiedUser` gained identity-token stubbing, and both it and the middleware spec now share a `buildPrivyClientMock` helper in `utils/testUtils.ts` rather than hand-building the same nested mock shape twice. `swap.routes.spec.ts` and `lend.routes.spec.ts` moved off their hand-rolled Privy mocks, dropping a duplicated `authHeaders` helper.

`pnpm typecheck && pnpm lint && pnpm test` clean. 218 backend tests, 1462 across the workspace, no new lint warnings.

## Follow-ups, not fixed here

- **`getPrivyClient()` returns a new `PrivyClient` per call** (`config/actions.ts`), so jose's JWKS cache is per-instance and never survives a request. Every authenticated request already pays a JWKS fetch, and an unauthenticated one can force it too. A module-level singleton fixes it; route specs mock the exported function, so memoizing is test-safe. Flagged independently by three reviewers.
- **The identity token is verified twice per request**, once at the boundary and once in `services/wallet.ts`, against separately-fetched JWKS instances. Harmless today, but during a key rotation the two could disagree and turn an authenticated request into an unmapped 500. Putting the verified user on `AuthContext` would fix it, at the cost of touching the wallet service and its call sites.
- **`AuthContext.rateLimitKey` has no consumers.** The per-user limiter that read it was removed with `middleware/rateLimit.ts`; the only limiter left is the faucet's, keyed on connection address. So no authenticated route is throttled at all. Left in place as pre-existing.
- **`POST /wallet/eth`** is unauthenticated by design, but keys its limit on the socket address, which collapses to one global bucket behind a proxy.
- **`PRIVY_TOKEN_COOKIE_KEY`** is a dead export.
- **Worth one real staging login before merge.** Every test mocks Privy, so nothing here proves the two live tokens use the same subject namespace. They do per the SDK source (both read the JWT `sub`), but if that were ever wrong this would 401 all authenticated traffic on deploy.
